### PR TITLE
docs: Clarify Compatibility Guarantees in contrib's README

### DIFF
--- a/contrib/README.md
+++ b/contrib/README.md
@@ -17,6 +17,12 @@ fixes.
 *   **Error Handling:** Handle errors gracefully with informative messages.
 *   **Documentation:** Document your code and its usage.
 
+**Compatibility Guarantees:**
+
+* All code in `contrib/` is explictly not covered by any sort of backwards API Compatibility Guarantees, even across minor (patch) releases.
+* The maintainers (committers) of this project are going to merge any changes in both implementations and interfaces without API stability concerns.
+* Contributors are welcome to raise their PRs based on this policy, and incrementally improve code without worrying about API breakage.
+
 **Contrib Graduation:**
 
 We'll consider graduating community contributions into officially maintained


### PR DESCRIPTION
@glaforge SGTY - LGTM? Re. #102.

@cornellgit @poggecci any objections to this? Makes `contrib/` (much) simpler - IMHO.

OK to merge? Or do we need to have a UN security council vote (just joking) to further discuss this?