### PR TITLE
chore: Fix wrong Maven version numbers

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -20,7 +20,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.google.adk</groupId>
   <artifactId>google-adk</artifactId>
-  <version>0.1.0</version><!-- {x-version-update:google-adk:current} -->
+  <version>0.1.1-SNAPSHOT</version><!-- {x-version-update:google-adk:current} -->
   <packaging>jar</packaging>
   <name>Agent Development Kit</name>
   <url>https://github.com/google/adk-java</url>

--- a/dev/pom.xml
+++ b/dev/pom.xml
@@ -19,7 +19,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.google.adk</groupId>
     <artifactId>google-adk-dev</artifactId>
-    <version>0.1.0</version>
+    <version>0.1.1-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>Agent Development Kit - Dev Tools</name>
     <url>https://github.com/google/adk-java</url>


### PR DESCRIPTION
To make the #155 review easier, I'm "forking out" a change that I implicitly made there into a tiny separate PR here, which @shukladivyansh raised a question about ([here](https://github.com/google/adk-java/pull/155#discussion_r2132669691)), so that we can discuss and settle that matter here in isolation, first.

So the `<version>0.1.0` which the existing x2 POMs on the current `main` branch (as of cec9ef3cf25e58bd7460fb99ceef2dabe0a64932) use is wrong.

This isn't an "opinion" or a "preference", but simply due to how Maven works. The reason is the following, if I may try to explain: 

This project has already release a 0.1.0 version. That's awesome - great!! That is now, of course, is a stabled fixed version, agreed? (BTW see the #169 issue, but that's kind of separate from what this is about.)

OK, so now I'm (someone is) using the ADK. For example, say with https://github.com/enola-dev/LearningADK/tree/main/quickstart. Or wherever. That uses ADK v0.1.0. Cool. So now you have `~/.m2/repository/com/google/adk/google-adk/0.1.0/google-adk-0.1.0.jar`, right? Great.

The you `git clone https://github.com/google/adk-java.git && cd adk-java && ./mvnw clean install` it. Or perhaps e.g. use https://jitpack.io. And now... things get REALLY confusing! Do you see why?

Because https://github.com/google/adk-java/tree/cec9ef3cf25e58bd7460fb99ceef2dabe0a64932 (the state of the `main` branch today) is NOT v0.1.0 (anymore) - of course!

The way about a million Maven projects out there do this is simply be incrementing the version in the POM as soon as (right after) a version is actually released. The Maven Deploy Plugin even does this automatically!

That's why the version in a Maven POM on a `main` branch should always be a `SNAPSHOT` of some upcoming planned future release. Ergo, since `0.1.0` has already been released, what's now on the `main` branch is what's (eventually) going to be (thus today a _"SNAPSHOT"_  of) what will later be a `0.1.0`. (Or a `0.2.0`, or a `1.0.0`, or whatever number. What that number is is much less important, and a sort of separate conversion. The real point is simply that it should never be the version of something that was ALREADY released.)

I hope that this help to clarify. Please let me know if this explanation is not clear enough, and I'm happy to help.

@glaforge FYI