### PR TITLE
ci: add license validation step for core and dev modules

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -15,6 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
+        module: [core, dev]
         java-version: ['17', '21']
 
     steps:
@@ -35,6 +36,10 @@ jobs:
           restore-keys: | # Fallback keys if exact match is not found
             ${{ runner.os }}-maven-${{ matrix.java-version }}-
             ${{ runner.os }}-maven-
+
+      - name: License validation for ${{ matrix.module }}
+        working-directory: ./${{ matrix.module }}
+        run: mvn checkstyle:check -Dcheckstyle.config.location=../license-checks.xml -Dcheckstyle.header.file=../java.header
 
       - name: Compile and install core module with Java ${{ matrix.java-version }}
         working-directory: ./core

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: License validation for ${{ matrix.module }}
         working-directory: ./${{ matrix.module }}
-        run: mvn checkstyle:check -Dcheckstyle.config.location=../license-checks.xml -Dcheckstyle.header.file=../java.header
+        run: mvn checkstyle:check -Dcheckstyle.config.location=../license-checks.xml
 
       - name: Compile and install core module with Java ${{ matrix.java-version }}
         working-directory: ./core

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -416,6 +416,7 @@
         <artifactId>maven-checkstyle-plugin</artifactId>
         <version>${checkstyle-maven-plugin.version}</version>
         <configuration>
+          <propertyExpansion>checkstyle.header.file=../java.header</propertyExpansion>
           <includeTestSourceDirectory>false</includeTestSourceDirectory>
           <failOnViolation>true</failOnViolation>
           <violationSeverity>warning</violationSeverity>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -63,6 +63,7 @@
     <java-websocket.version>1.6.0</java-websocket.version>
     <jackson.version>2.19.0</jackson.version>
     <okhttp.version>4.12.0</okhttp.version>
+    <checkstyle-maven-plugin.version>3.6.0</checkstyle-maven-plugin.version>
   </properties>
   <distributionManagement>
     <repository>
@@ -409,6 +410,16 @@
             </configuration>
           </execution>
         </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-checkstyle-plugin</artifactId>
+        <version>${checkstyle-maven-plugin.version}</version>
+        <configuration>
+          <includeTestSourceDirectory>false</includeTestSourceDirectory>
+          <failOnViolation>true</failOnViolation>
+          <violationSeverity>warning</violationSeverity>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/dev/pom.xml
+++ b/dev/pom.xml
@@ -259,6 +259,7 @@
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <version>${checkstyle-maven-plugin.version}</version>
                 <configuration>
+                    <propertyExpansion>checkstyle.header.file=../java.header</propertyExpansion>
                     <includeTestSourceDirectory>false</includeTestSourceDirectory>
                     <failOnViolation>true</failOnViolation>
                     <violationSeverity>warning</violationSeverity>

--- a/dev/pom.xml
+++ b/dev/pom.xml
@@ -53,6 +53,7 @@
       <graphviz.version>0.18.1</graphviz.version>
       <ecj.version>3.41.0</ecj.version>
       <otel.version>1.49.0</otel.version>
+      <checkstyle-maven-plugin.version>3.6.0</checkstyle-maven-plugin.version>
     </properties>
     <distributionManagement>
         <repository>
@@ -251,6 +252,16 @@
                 <version>3.1.1</version>
                 <configuration>
                     <skip>false</skip>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+                <version>${checkstyle-maven-plugin.version}</version>
+                <configuration>
+                    <includeTestSourceDirectory>false</includeTestSourceDirectory>
+                    <failOnViolation>true</failOnViolation>
+                    <violationSeverity>warning</violationSeverity>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
### Description

adds automated license validation steps in CI 

( Hello, If the java.header and license-checks files are automatically used elsewhere or have other uses and it shouldn't be validated in ci, please close this PR. Thanks )