### PR TITLE
chore: Remove paths from GitHub Workflow

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -5,10 +5,6 @@ on:
   pull_request:
     branches:
       - main
-    paths:
-      - "core/**"
-      - "dev/**"
-      # Add other module paths here
 
 jobs:
   build-modules:


### PR DESCRIPTION
I think we want any PR / changes to be validation tested on CI, not only core/** and dev/** don't we? For example, changes to (new) root pom.xml or to (future) contrib/** changes should also trigger a build (IMHO).

@glaforge FYI