### PR TITLE
Add google-java-format as Maven plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -192,6 +192,25 @@
     </pluginManagement>
     <plugins>
       <plugin>
+        <groupId>com.spotify.fmt</groupId>
+        <artifactId>fmt-maven-plugin</artifactId>
+        <version>2.27</version>
+        <dependencies>
+          <dependency>
+            <groupId>com.google.googlejavaformat</groupId>
+            <artifactId>google-java-format</artifactId>
+            <version>1.27.0</version>
+          </dependency>
+        </dependencies>
+        <executions>
+          <execution>
+            <goals>
+              <goal>format</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
         <version>0.8.12</version>


### PR DESCRIPTION
Re. #168.

We intentionally fix the google-java-format version in the Maven plugin, as this will make upgrading it in the future easier, as we won't be blocked by the version which the fmt-maven-plugin uses. See also https://github.com/spotify/fmt-maven-plugin/pull/202.

Still only DRAFT, because TODO:

- [x] merge #208
- [x] clarify #209
- [x] merge (or close to reject) #189, just to avoid merge conflicts