### PR TITLE
chore: Fail CI build if there are wrongly formatted files (re. #168)

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -39,3 +39,6 @@ jobs:
 
       - name: Compile and test (all) modules with Java ${{ matrix.java-version }}
         run: ./mvnw clean test
+
+      - name: Detected wrongly formatted files
+        run: git status && git diff --exit-code


### PR DESCRIPTION
See https://github.com/google/adk-java/issues/168 :

If there are "dirty files" at the end of the build (modified by the formatter, ran by Maven), then the user committed files to a PR which they didn't format - and this makes the build fail.

Doing this will avoid end-users running into ill formatted files after a git clone, and having to manually propose PRs such as @kaikreuzer https://github.com/google/adk-java/pull/279.

PS: Inspired e.g. by https://github.com/enola-dev/enola/blob/46e6e203d9f8b17406c5b0f5a156ba37c880ab45/tools/git/test.bash#L20.

@poggecci do you think this would make sense and be useful?