### PR TITLE
Fix missing "model" role in Gemini LLM responses

### DIFF
--- a/core/src/main/java/com/google/adk/models/Gemini.java
+++ b/core/src/main/java/com/google/adk/models/Gemini.java
@@ -334,6 +334,7 @@ public class Gemini extends BaseLlm {
                               LlmResponse.builder()
                                   .content(
                                       Content.builder()
+                                          .role("model")
                                           .parts(
                                               ImmutableList.of(
                                                   Part.builder()
@@ -374,6 +375,7 @@ public class Gemini extends BaseLlm {
                                   LlmResponse.builder()
                                       .content(
                                           Content.builder()
+                                              .role("model")
                                               .parts(
                                                   ImmutableList.of(
                                                       Part.builder()


### PR DESCRIPTION
### Problem

Chat history that was sent on subsequent requests was only storing user messages, missing bot responses due to Gemini class creating Content objects without the required "model" role.

### Solution

Applied fix to all `LlmResponse.create()` calls in Gemini class

### Result

- Bot responses now properly stored in chat history alongside user messages
- Maintains backward compatibility
- All tests pass