### PR TITLE
feat: provide more detailed logs when mcp tool declaration failed.

### DIFF
--- a/core/src/main/java/com/google/adk/tools/mcp/AbstractMcpTool.java
+++ b/core/src/main/java/com/google/adk/tools/mcp/AbstractMcpTool.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.adk.tools.BaseTool;
+import com.google.adk.tools.mcp.McpToolException.McpToolDeclarationException;
 import com.google.common.collect.ImmutableMap;
 import com.google.genai.types.FunctionDeclaration;
 import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
@@ -77,14 +78,20 @@ public abstract class AbstractMcpTool<T> extends BaseTool {
   @Override
   public Optional<FunctionDeclaration> declaration() {
     JsonSchema schema = this.mcpTool.inputSchema();
-    return Optional.ofNullable(schema)
-        .map(
-            value ->
-                FunctionDeclaration.builder()
-                    .name(this.name())
-                    .description(this.description())
-                    .parametersJsonSchema(value)
-                    .build());
+    try {
+      return Optional.ofNullable(schema)
+          .map(
+              value ->
+                  FunctionDeclaration.builder()
+                      .name(this.name())
+                      .description(this.description())
+                      .parametersJsonSchema(value)
+                      .build());
+    } catch (Exception e) {
+      throw new McpToolDeclarationException(
+          String.format("MCP tool:%s failed to get declaration, schema:%s.", this.name(), schema),
+          e);
+    }
   }
 
   @SuppressWarnings("PreferredInterfaceType") // BaseTool.runAsync() returns Map<String, Object>

--- a/core/src/main/java/com/google/adk/tools/mcp/McpToolException.java
+++ b/core/src/main/java/com/google/adk/tools/mcp/McpToolException.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.adk.tools.mcp;
+
+/** Base exception for all errors originating from {@code AbstractMcpTool} and its subclasses. */
+public class McpToolException extends RuntimeException {
+
+  public McpToolException(String message, Throwable cause) {
+    super(message, cause);
+  }
+
+  /** Exception thrown when there's an error during MCP tool declaration generated. */
+  public static class McpToolDeclarationException extends McpToolException {
+    public McpToolDeclarationException(String message, Throwable cause) {
+      super(message, cause);
+    }
+  }
+}


### PR DESCRIPTION
When using GenAI's `Schema.fromJson(jsonString) `to convert tool schemas provided by some third-party MCP servers, a `GenAiIOException` is thrown. For example:

```json
{
    "type": "object",
    "properties": {
        "address": {
            "title": "Address",
            "type": "string"
        },
        "city": {
            "anyOf": [
                {
                    "type": "string"
                },
                {
                    "type": "null"
                }
            ],
            "default": null,
            "title": "City"
        }
    },
    "required": [
        "address"
    ]
}
```

It will trigger a runtime exception.

```
Caused by: com.google.genai.errors.GenAiIOException: Failed to deserialize the JSON string.
	at com.google.genai.JsonSerializable.fromJsonString(JsonSerializable.java:128)
	at com.google.genai.types.Schema.fromJson(Schema.java:437)
	at com.google.adk.tools.mcp.McpTool.toGeminiSchema(McpTool.java:110)
	... 184 common frames omitted
Caused by: com.fasterxml.jackson.databind.JsonMappingException: N/A
 at [Source: REDACTED (`StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION` disabled); line: 1, column: 140] (through reference chain: com.google.genai.types.AutoValue_Schema$Builder["properties"]->java.util.LinkedHashMap["city"]->com.google.genai.types.AutoValue_Schema$Builder["default"])
	at com.fasterxml.jackson.databind.JsonMappingException.from(JsonMappingException.java:276)
	at com.fasterxml.jackson.databind.deser.SettableBeanProperty._throwAsIOE(SettableBeanProperty.java:628)
	at com.fasterxml.jackson.databind.deser.SettableBeanProperty._throwAsIOE(SettableBeanProperty.java:616)
	at com.fasterxml.jackson.databind.deser.impl.MethodProperty.deserializeSetAndReturn(MethodProperty.java:173)
	at com.fasterxml.jackson.databind.deser.BuilderBasedDeserializer.vanillaDeserialize(BuilderBasedDeserializer.java:294)
	at com.fasterxml.jackson.databind.deser.BuilderBasedDeserializer.deserialize(BuilderBasedDeserializer.java:218)
	at com.fasterxml.jackson.databind.deser.std.MapDeserializer._readAndBindStringKeyMap(MapDeserializer.java:623)
	at com.fasterxml.jackson.databind.deser.std.MapDeserializer.deserialize(MapDeserializer.java:449)
	at com.fasterxml.jackson.databind.deser.std.MapDeserializer.deserialize(MapDeserializer.java:32)
	at com.fasterxml.jackson.databind.deser.impl.MethodProperty.deserializeSetAndReturn(MethodProperty.java:158)
	at com.fasterxml.jackson.databind.deser.BuilderBasedDeserializer.vanillaDeserialize(BuilderBasedDeserializer.java:294)
	at com.fasterxml.jackson.databind.deser.BuilderBasedDeserializer.deserialize(BuilderBasedDeserializer.java:218)
	at com.fasterxml.jackson.databind.deser.DefaultDeserializationContext.readRootValue(DefaultDeserializationContext.java:342)
	at com.fasterxml.jackson.databind.ObjectMapper._readMapAndClose(ObjectMapper.java:4917)
	at com.fasterxml.jackson.databind.ObjectMapper.readValue(ObjectMapper.java:3860)
	at com.fasterxml.jackson.databind.ObjectMapper.readValue(ObjectMapper.java:3828)
	at com.google.genai.JsonSerializable.fromJsonString(JsonSerializable.java:126)
	... 186 common frames omitted
Caused by: java.lang.NullPointerException: null
	at java.base/java.util.Objects.requireNonNull(Objects.java:208)
	at java.base/java.util.Optional.of(Optional.java:113)
	at com.google.genai.types.AutoValue_Schema$Builder.default_(AutoValue_Schema.java:407)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:568)
	at com.fasterxml.jackson.databind.deser.impl.MethodProperty.deserializeSetAndReturn(MethodProperty.java:170)
	... 199 common frames omitted
```

This PR will help developers quickly identify the problematic tool.

