### PR TITLE
feat(SseServerParameters): Add configuration option for connection endpoint

### DIFF
--- a/core/src/main/java/com/google/adk/tools/mcp/DefaultMcpTransportBuilder.java
+++ b/core/src/main/java/com/google/adk/tools/mcp/DefaultMcpTransportBuilder.java
@@ -21,7 +21,8 @@ public class DefaultMcpTransportBuilder implements McpTransportBuilder {
       return new StdioClientTransport(serverParameters);
     } else if (connectionParams instanceof SseServerParameters sseServerParams) {
       return HttpClientSseClientTransport.builder(sseServerParams.url())
-          .sseEndpoint("sse")
+          .sseEndpoint(
+              sseServerParams.sseEndpoint() == null ? "sse" : sseServerParams.sseEndpoint())
           .customizeRequest(
               builder ->
                   Optional.ofNullable(sseServerParams.headers())

--- a/core/src/main/java/com/google/adk/tools/mcp/SseServerParameters.java
+++ b/core/src/main/java/com/google/adk/tools/mcp/SseServerParameters.java
@@ -29,6 +29,10 @@ public abstract class SseServerParameters {
   /** The URL of the SSE server. */
   public abstract String url();
 
+  /** The endpoint to connect to on the SSE server. */
+  @Nullable
+  public abstract String sseEndpoint();
+
   /** Optional headers to include in the SSE connection request. */
   @Nullable
   public abstract ImmutableMap<String, Object> headers();
@@ -51,6 +55,9 @@ public abstract class SseServerParameters {
   public abstract static class Builder {
     /** Sets the URL of the SSE server. */
     public abstract Builder url(String url);
+
+    /** Sets the endpoint to connect to on the SSE server. */
+    public abstract Builder sseEndpoint(String sseEndpoint);
 
     /** Sets the headers for the SSE connection request. */
     public abstract Builder headers(@Nullable Map<String, Object> headers);


### PR DESCRIPTION
This commit adds a new configuration option sseEndpoint to the SseServerParameters class, which is used to specify the exact endpoint for connecting to the SSE server. It also updates the related processing logic in DefaultMcpTransportBuilder to ensure the configuration is applied correctly.

In the Java DefaultMcpTransportBuilder implementation, when constructing the HttpClientSseClientTransport, the sseEndpoint parameter is hardcoded to "sse" by default. However, in the official MCP implementation, the following line:

<img width="1526" height="1054" alt="image" src="https://github.com/user-attachments/assets/58972115-5a49-4b22-9b9e-0f305f061980" />

```java
URI clientUri = Utils.resolveUri(this.baseUri, this.sseEndpoint);
```

will normalize a URL like "http://testurl/sse?param=xxx" into "http://testurl/sse", leading to the loss of query parameters.