### PR TITLE
fix: Broken Dev UI (fixes #302)

### DIFF
--- a/dev/pom.xml
+++ b/dev/pom.xml
@@ -107,10 +107,18 @@
   <build>
     <resources>
       <resource>
-        <directory>browser</directory>
-        <!-- This will place the contents of the 'browser' folder into 'BOOT-INF/classes/browser/'
-        in the JAR -->
-        <targetPath>browser</targetPath>
+        <!-- This will correctly place the contents of the 'browser' folder into 'browser/' at the
+             root of the normal JAR, and in 'BOOT-INF/classes/browser/' in the Spring Boot repackaged
+             executable JAR.
+
+             We use <directory>. and <include>browser/** instead of <directory>browser with <targetPath>browser
+             because that does not work and used to cause https://github.com/google/adk-java/issues/302.
+
+             An alternative would be to simply use src/main/resources/browser instead of doing this. -->
+        <directory>.</directory>
+        <includes>
+          <include>browser/**</include>
+        </includes>
       </resource>
     </resources>
     <pluginManagement>


### PR DESCRIPTION
This will fix https://github.com/google/adk-java/issues/302.

The currently broken Dev UI problem can be reproduced without this fix by running https://github.com/enola-dev/LearningADK#jitpack (which at `b80aceb` [still used](https://github.com/enola-dev/LearningADK/blob/b80aceb1631c2f214905f025aa2c6bd7eb941e3e/jitpack/pom.xml#L33) the current ADK Java [417a8bc](https://github.com/google/adk-java/commit/417a8bcf12bb2c21cf869554335f9649f9ff7a56) without this fix).

Unfortunately it's more difficult than I thought to add non-regression integration test coverage for this; I was hoping to build upon #342 and #343 (which IMHO still add value as-is) with something like https://github.com/google/adk-java/compare/main...vorburger:adk-java:AdkWebServerTest-UI-packaging, but due to the way Maven works, that actually didn't reproduce the issue (so it's pointless).

But I've manually verified that this does the trick using https://github.com/enola-dev/LearningADK#snapshot.

@Poggecci @shukladivyansh merge?