### PR TITLE
chore: Rename mcp-schema.version property in POM to mcp.version

### DIFF
--- a/contrib/langchain4j/pom.xml
+++ b/contrib/langchain4j/pom.xml
@@ -30,7 +30,7 @@
     <description>LangChain4j integration for the Agent Development Kit.</description>
 
     <properties>
-        <mcp-schema.version>0.10.0</mcp-schema.version>
+        <mcp.version>0.10.0</mcp.version>
         <google.genai.version>1.8.0</google.genai.version>
         <junit.version>5.11.4</junit.version>
         <mockito.version>5.17.0</mockito.version>
@@ -78,7 +78,7 @@
         <dependency>
             <groupId>io.modelcontextprotocol.sdk</groupId>
             <artifactId>mcp</artifactId>
-            <version>${mcp-schema.version}</version>
+            <version>${mcp.version}</version>
         </dependency>
 
         <!-- Test dependencies -->

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -30,7 +30,7 @@
   <description>Agent Development Kit: an open-source, code-first toolkit designed to simplify building, evaluating, and deploying advanced AI agents anywhere.</description>
 
   <properties>
-    <mcp-schema.version>0.10.0</mcp-schema.version>
+    <mcp.version>0.10.0</mcp.version>
     <errorprone.version>2.38.0</errorprone.version>
     <google.auth.version>1.33.1</google.auth.version>
     <google.cloud.storage.version>2.28.0</google.cloud.storage.version>
@@ -76,7 +76,7 @@
     <dependency>
       <groupId> io.modelcontextprotocol.sdk</groupId>
       <artifactId>mcp</artifactId>
-      <version>${mcp-schema.version}</version>
+      <version>${mcp.version}</version>
     </dependency>
     <dependency>
       <groupId>com.google.auth</groupId>


### PR DESCRIPTION
I was confused what was _"schema"_ related... but then figured out that this is literally just the (Maven) version of the https://github.com/modelcontextprotocol/java-sdk, so how about dropping the `-schema` to make this a bit more clear?