### PR TITLE
fix: Same GenAI version in langchain4j as in core

### DIFF
--- a/contrib/langchain4j/pom.xml
+++ b/contrib/langchain4j/pom.xml
@@ -31,7 +31,7 @@
 
     <properties>
         <mcp-schema.version>0.10.0</mcp-schema.version>
-        <google.genai.version>1.0.0</google.genai.version>
+        <google.genai.version>1.8.0</google.genai.version>
         <junit.version>5.11.4</junit.version>
         <mockito.version>5.17.0</mockito.version>
         <langchain4j.version>1.1.0</langchain4j.version>

--- a/contrib/langchain4j/src/main/java/com/google/adk/models/langchain4j/LangChain4j.java
+++ b/contrib/langchain4j/src/main/java/com/google/adk/models/langchain4j/LangChain4j.java
@@ -490,7 +490,7 @@ public class LangChain4j extends BaseLlm {
                 .items(toJsonSchemaElement(schema.items().orElseThrow()))
                 .build();
         case OBJECT -> toParameters(schema);
-        case TYPE_UNSPECIFIED ->
+        default ->
             throw new UnsupportedFeatureException(
                 "LangChain4jLlm does not support schema of type: " + type);
       };


### PR DESCRIPTION
The real fix will be to pull much more of these version up from the child in the parent POM.

But let's already fix this, because this "version skew" is pretty bad as-is.