### PR TITLE
Add disallowTransferToParent check to parent agent transfer condition

### DIFF
--- a/core/src/main/java/com/google/adk/flows/llmflows/AgentTransfer.java
+++ b/core/src/main/java/com/google/adk/flows/llmflows/AgentTransfer.java
@@ -87,7 +87,7 @@ public final class AgentTransfer implements RequestProcessor {
         "If another agent is better for answering the question according to its description, call"
             + " `transferToAgent` function to transfer the question to that agent. When"
             + " transferring, do not generate any text other than the function call.\n");
-    if (agent.parentAgent() != null) {
+    if (agent.parentAgent() != null && !agent.disallowTransferToParent()) {
       sb.append("Your parent agent is ");
       sb.append(agent.parentAgent().name());
       sb.append(


### PR DESCRIPTION
Only allow transfer to parent agent when both conditions are met:
- Parent agent exists (agent.parentAgent() != null)
- Transfer to parent is allowed (!agent.disallowTransferToParent())

This prevents unwanted transfers to parent agents when explicitly disabled. Aligns Java implementation with Python version for consistency.