### PR TITLE
chore: Bump Protobuf version from 4.31.0-RC1 to 4.32.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,12 +42,10 @@
     <auto-value.version>1.11.0</auto-value.version>
     <spring-boot.version>3.4.1</spring-boot.version>
     <otel.version>1.49.0</otel.version>
-    
-    <!-- Dependency versions consolidated from child modules -->
     <mcp.version>0.11.3</mcp.version>
     <errorprone.version>2.38.0</errorprone.version>
     <google.genai.version>1.8.0</google.genai.version>
-    <protobuf.version>4.31.0-RC1</protobuf.version>
+    <protobuf.version>4.32.0</protobuf.version>
     <junit.version>5.11.4</junit.version>
     <mockito.version>5.17.0</mockito.version>
     <java-websocket.version>1.6.0</java-websocket.version>


### PR DESCRIPTION
This is the latest version.

I'm proposed this not entirely just "for fun" only, but also because I'm hoping that this might help to solve a problem that I'm running into in https://github.com/enola-dev/enola/issues/1635 for https://github.com/enola-dev/enola/pull/1689.