### PR TITLE
feat(spring-boot-starter-adk): Add Spring Boot Starter support

### DIFF
--- a/contrib/spring-boot-starter-adk/pom.xml
+++ b/contrib/spring-boot-starter-adk/pom.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.google.adk</groupId>
+        <artifactId>google-adk-parent</artifactId>
+        <version>0.2.1-SNAPSHOT</version><!-- {x-version-update:google-adk:current} -->
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>spring-boot-starter-adk</artifactId>
+    <name>Agent Development Kit - Spring Boot Starter</name>
+    <description>Spring Boot Starter for the Agent Development Kit.</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.google.adk</groupId>
+            <artifactId>google-adk</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.google.adk</groupId>
+            <artifactId>google-adk-dev</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <!-- Test dependencies -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/contrib/spring-boot-starter-adk/src/main/java/com/google/adk/starters/springboot/AdkSpringbootAutoConfiguration.java
+++ b/contrib/spring-boot-starter-adk/src/main/java/com/google/adk/starters/springboot/AdkSpringbootAutoConfiguration.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.adk.starters.springboot;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ComponentScan("com.google.adk")
+public class AdkSpringbootAutoConfiguration {
+
+  private static final Logger logger =
+      LoggerFactory.getLogger(AdkSpringbootAutoConfiguration.class);
+
+  public AdkSpringbootAutoConfiguration() {
+    logger.info("AdkSpringbootAutoConfiguration initialized.");
+  }
+}

--- a/contrib/spring-boot-starter-adk/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/contrib/spring-boot-starter-adk/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+com.google.adk.starters.springboot.AdkSpringbootAutoConfiguration

--- a/contrib/spring-boot-starter-adk/src/test/java/com/google/adk/starters/springboot/AdkSpringbootStarterTest.java
+++ b/contrib/spring-boot-starter-adk/src/test/java/com/google/adk/starters/springboot/AdkSpringbootStarterTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.adk.starters.springboot;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.google.adk.agents.BaseAgent;
+import com.google.adk.agents.LlmAgent;
+import com.google.adk.web.AgentStaticLoader;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.web.servlet.MockMvc;
+
+/**
+ * Integration tests for the ADK Spring Boot Starter.
+ *
+ * <p>These tests use MockMvc to simulate HTTP requests and verify the expected responses from the
+ * ADK API server, ensuring that the Spring Boot autoconfiguration works correctly.
+ */
+@SpringBootTest(properties = "adk.agents.loader=static")
+@AutoConfigureMockMvc
+public class AdkSpringbootStarterTest {
+
+  @Autowired private AgentStaticLoader agentStaticLoader;
+
+  @Autowired private MockMvc mockMvc;
+
+  @Test
+  void testAgentStaticLoaderIsLoaded() throws Exception {
+    assertNotNull(agentStaticLoader);
+    mockMvc
+        .perform(get("/list-apps"))
+        .andExpect(status().isOk())
+        .andExpect(content().json("[\"test_agent\"]"));
+  }
+
+  @SpringBootApplication
+  public static class TestApplication {
+    public static void main(String[] args) {
+      SpringApplication.run(TestApplication.class, args);
+    }
+  }
+
+  @Configuration
+  public static class AppConfig {
+    @Bean("agentLoader")
+    public AgentStaticLoader agentStaticLoader() {
+      BaseAgent testAgent =
+          LlmAgent.builder()
+              .name("test_agent")
+              .model("gemini-2.0-flash-lite")
+              .description("Test agent for demonstrating AgentStaticLoader")
+              .instruction("You are a test agent.")
+              .build();
+      return new AgentStaticLoader(testAgent);
+    }
+  }
+}

--- a/dev/src/main/java/com/google/adk/web/AgentStaticLoader.java
+++ b/dev/src/main/java/com/google/adk/web/AgentStaticLoader.java
@@ -37,7 +37,7 @@ import javax.annotation.Nonnull;
  * <p>This class is not a Spring component by itself - instances are created programmatically and
  * then registered as beans via factory methods.
  */
-class AgentStaticLoader implements AgentLoader {
+public class AgentStaticLoader implements AgentLoader {
 
   private final ImmutableMap<String, BaseAgent> agents;
 

--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,7 @@
     <module>dev</module>
     <module>maven_plugin</module>
     <module>contrib/langchain4j</module>
+    <module>contrib/spring-boot-starter-adk</module>
     <module>tutorials/city-time-weather</module>
   </modules>
 


### PR DESCRIPTION
This commit introduces a new Spring Boot Starter module for the Agent Development Kit (ADK),
making it easier for developers to integrate ADK into Spring Boot applications.

Changes include:
- Created new spring-boot-starter-adk module under contrib/
- Added AdkSpringbootAutoConfiguration for automatic configuration
- Implemented auto-configuration imports file for Spring Boot
- Added dependencies on core ADK modules (google-adk, google-adk-dev)
- Included test dependencies (spring-boot-starter-test, mockito-core)
- Added integration tests for the starter
- Made AgentStaticLoader public to enable external instantiation
- Registered the new module in the parent pom.xml

The purpose of this starter is to activate the entire component functionality, enabling developers to use it out of the box.
But I'm not sure which functionalities should be placed in the starter. For example, whether it's necessary to provide annotation scanning or a class like AgentFactory, allowing developers to register their Agents as Beans. Whether such a design is needed requires further discussion.

