### PR TITLE
feat: Add inputAudioTranscription support to Java ADK

### DIFF
--- a/core/src/main/java/com/google/adk/agents/RunConfig.java
+++ b/core/src/main/java/com/google/adk/agents/RunConfig.java
@@ -48,7 +48,11 @@ public abstract class RunConfig {
 
   public abstract @Nullable AudioTranscriptionConfig outputAudioTranscription();
 
+  public abstract @Nullable AudioTranscriptionConfig inputAudioTranscription();
+
   public abstract int maxLlmCalls();
+
+  public abstract Builder toBuilder();
 
   public static Builder builder() {
     return new AutoValue_RunConfig.Builder()
@@ -65,7 +69,8 @@ public abstract class RunConfig {
         .setMaxLlmCalls(runConfig.maxLlmCalls())
         .setResponseModalities(runConfig.responseModalities())
         .setSpeechConfig(runConfig.speechConfig())
-        .setOutputAudioTranscription(runConfig.outputAudioTranscription());
+        .setOutputAudioTranscription(runConfig.outputAudioTranscription())
+        .setInputAudioTranscription(runConfig.inputAudioTranscription());
   }
 
   /** Builder for {@link RunConfig}. */
@@ -87,6 +92,10 @@ public abstract class RunConfig {
     @CanIgnoreReturnValue
     public abstract Builder setOutputAudioTranscription(
         AudioTranscriptionConfig outputAudioTranscription);
+
+    @CanIgnoreReturnValue
+    public abstract Builder setInputAudioTranscription(
+        AudioTranscriptionConfig inputAudioTranscription);
 
     @CanIgnoreReturnValue
     public abstract Builder setMaxLlmCalls(int maxLlmCalls);

--- a/core/src/main/java/com/google/adk/flows/llmflows/Basic.java
+++ b/core/src/main/java/com/google/adk/flows/llmflows/Basic.java
@@ -48,6 +48,8 @@ public final class Basic implements RequestProcessor {
         .ifPresent(liveConnectConfigBuilder::speechConfig);
     Optional.ofNullable(context.runConfig().outputAudioTranscription())
         .ifPresent(liveConnectConfigBuilder::outputAudioTranscription);
+    Optional.ofNullable(context.runConfig().inputAudioTranscription())
+        .ifPresent(liveConnectConfigBuilder::inputAudioTranscription);
 
     LlmRequest.Builder builder =
         request.toBuilder()

--- a/core/src/main/java/com/google/adk/runner/Runner.java
+++ b/core/src/main/java/com/google/adk/runner/Runner.java
@@ -319,9 +319,15 @@ public class Runner {
         if (runConfig.outputAudioTranscription() == null) {
           runConfigBuilder.setOutputAudioTranscription(AudioTranscriptionConfig.builder().build());
         }
+        if (runConfig.inputAudioTranscription() == null) {
+          runConfigBuilder.setInputAudioTranscription(AudioTranscriptionConfig.builder().build());
+        }
       } else if (!runConfig.responseModalities().contains(new Modality(Modality.Known.TEXT))) {
         if (runConfig.outputAudioTranscription() == null) {
           runConfigBuilder.setOutputAudioTranscription(AudioTranscriptionConfig.builder().build());
+        }
+        if (runConfig.inputAudioTranscription() == null) {
+          runConfigBuilder.setInputAudioTranscription(AudioTranscriptionConfig.builder().build());
         }
       }
     }

--- a/core/src/test/java/com/google/adk/agents/RunConfigTest.java
+++ b/core/src/test/java/com/google/adk/agents/RunConfigTest.java
@@ -25,6 +25,7 @@ public final class RunConfigTest {
             .setSaveInputBlobsAsArtifacts(true)
             .setStreamingMode(RunConfig.StreamingMode.SSE)
             .setOutputAudioTranscription(audioTranscriptionConfig)
+            .setInputAudioTranscription(audioTranscriptionConfig)
             .setMaxLlmCalls(10)
             .build();
 
@@ -33,6 +34,7 @@ public final class RunConfigTest {
     assertThat(runConfig.saveInputBlobsAsArtifacts()).isTrue();
     assertThat(runConfig.streamingMode()).isEqualTo(RunConfig.StreamingMode.SSE);
     assertThat(runConfig.outputAudioTranscription()).isEqualTo(audioTranscriptionConfig);
+    assertThat(runConfig.inputAudioTranscription()).isEqualTo(audioTranscriptionConfig);
     assertThat(runConfig.maxLlmCalls()).isEqualTo(10);
   }
 
@@ -45,6 +47,7 @@ public final class RunConfigTest {
     assertThat(runConfig.saveInputBlobsAsArtifacts()).isFalse();
     assertThat(runConfig.streamingMode()).isEqualTo(RunConfig.StreamingMode.NONE);
     assertThat(runConfig.outputAudioTranscription()).isNull();
+    assertThat(runConfig.inputAudioTranscription()).isNull();
     assertThat(runConfig.maxLlmCalls()).isEqualTo(500);
   }
 
@@ -66,6 +69,7 @@ public final class RunConfigTest {
             .setSaveInputBlobsAsArtifacts(true)
             .setStreamingMode(RunConfig.StreamingMode.BIDI)
             .setOutputAudioTranscription(audioTranscriptionConfig)
+            .setInputAudioTranscription(audioTranscriptionConfig)
             .setMaxLlmCalls(20)
             .build();
 
@@ -74,6 +78,24 @@ public final class RunConfigTest {
     assertThat(runConfig.saveInputBlobsAsArtifacts()).isTrue();
     assertThat(runConfig.streamingMode()).isEqualTo(RunConfig.StreamingMode.BIDI);
     assertThat(runConfig.outputAudioTranscription()).isEqualTo(audioTranscriptionConfig);
+    assertThat(runConfig.inputAudioTranscription()).isEqualTo(audioTranscriptionConfig);
     assertThat(runConfig.maxLlmCalls()).isEqualTo(20);
+  }
+
+  @Test
+  public void testInputAudioTranscriptionOnly() {
+    AudioTranscriptionConfig inputTranscriptionConfig = AudioTranscriptionConfig.builder().build();
+
+    RunConfig runConfig =
+        RunConfig.builder()
+            .setStreamingMode(RunConfig.StreamingMode.BIDI)
+            .setResponseModalities(ImmutableList.of(new Modality(Modality.Known.AUDIO)))
+            .setInputAudioTranscription(inputTranscriptionConfig)
+            .build();
+
+    assertThat(runConfig.inputAudioTranscription()).isEqualTo(inputTranscriptionConfig);
+    assertThat(runConfig.outputAudioTranscription()).isNull();
+    assertThat(runConfig.streamingMode()).isEqualTo(RunConfig.StreamingMode.BIDI);
+    assertThat(runConfig.responseModalities()).containsExactly(new Modality(Modality.Known.AUDIO));
   }
 }

--- a/core/src/test/java/com/google/adk/flows/llmflows/BasicTest.java
+++ b/core/src/test/java/com/google/adk/flows/llmflows/BasicTest.java
@@ -221,12 +221,32 @@ public final class BasicTest {
   }
 
   @Test
+  public void processRequest_buildsLiveConnectConfigFromRunConfig_inputAudioTranscription() {
+    RunConfig runConfig =
+        RunConfig.builder().setInputAudioTranscription(TEST_AUDIO_TRANSCRIPTION_CONFIG).build();
+    LlmAgent agentWithConfig = LlmAgent.builder().name("agentWithConfig").model(testLlm).build();
+    InvocationContext contextWithRunConfig = createInvocationContext(agentWithConfig, runConfig);
+
+    RequestProcessingResult result =
+        basicProcessor.processRequest(contextWithRunConfig, initialRequest).blockingGet();
+
+    LlmRequest updatedRequest = result.updatedRequest();
+    assertThat(updatedRequest.liveConnectConfig()).isNotNull();
+    assertThat(updatedRequest.liveConnectConfig().responseModalities().get()).isEmpty();
+    assertThat(updatedRequest.liveConnectConfig().speechConfig()).isEmpty();
+    assertThat(updatedRequest.liveConnectConfig().inputAudioTranscription())
+        .hasValue(TEST_AUDIO_TRANSCRIPTION_CONFIG);
+    assertThat(result.events()).isEmpty();
+  }
+
+  @Test
   public void processRequest_buildsLiveConnectConfigFromRunConfig_allFields() {
     RunConfig runConfig =
         RunConfig.builder()
             .setResponseModalities(ImmutableList.of(new Modality(Modality.Known.AUDIO)))
             .setSpeechConfig(TEST_SPEECH_CONFIG)
             .setOutputAudioTranscription(TEST_AUDIO_TRANSCRIPTION_CONFIG)
+            .setInputAudioTranscription(TEST_AUDIO_TRANSCRIPTION_CONFIG)
             .build();
     LlmAgent agentWithConfig = LlmAgent.builder().name("agentWithConfig").model(testLlm).build();
     InvocationContext contextWithRunConfig = createInvocationContext(agentWithConfig, runConfig);
@@ -240,6 +260,8 @@ public final class BasicTest {
         .containsExactly(new Modality(Modality.Known.AUDIO));
     assertThat(updatedRequest.liveConnectConfig().speechConfig()).hasValue(TEST_SPEECH_CONFIG);
     assertThat(updatedRequest.liveConnectConfig().outputAudioTranscription())
+        .hasValue(TEST_AUDIO_TRANSCRIPTION_CONFIG);
+    assertThat(updatedRequest.liveConnectConfig().inputAudioTranscription())
         .hasValue(TEST_AUDIO_TRANSCRIPTION_CONFIG);
     assertThat(result.events()).isEmpty();
   }


### PR DESCRIPTION
# Summary
Adds `inputAudioTranscription` support to the Java ADK to achieve feature parity with Python.
When enabled, the live connect config requests model-side transcription of input audio into text, allowing real-time conversation processing and downstream analysis.
# Changes
## RunConfig
- Introduce `inputAudioTranscription` field with builder support.
- Preserve existing defaults and semantics.
## Runner
- In live runs with audio modalities, default `inputAudioTranscription` (and `outputAudioTranscription`) when not explicitly set and TEXT is not included, mirroring the Python logic.
## LLM Request Building (Basic)
- Populate `LiveConnectConfig.inputAudioTranscription` from RunConfig.
## Tests
- RunConfigTest: validates setting and default behavior of `inputAudioTranscription`.
- BasicTest: verifies `LiveConnectConfig` is built with `inputAudioTranscription` (and combined with other configs).