### PR TITLE
chore: Remove .mvn/ from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,6 @@
 
 # Maven target directory
 target/
-.mvn/
 
 # IntelliJ IDEA files
 .idea/


### PR DESCRIPTION
It's wrong to .gitignore the .mvn/ directory, because that is, contrary to target/, NOT a "Maven target directory" at all actually.

It contains the maven-wrapper.properties, which is an important SOURCE build configuration file. 

This file is ALREADY in Git (as it should be); having files that ARE committed on .gitignore can be very confusing.