### PR TITLE
Add support for optional parameters in @Annotations.Schema

### DIFF
--- a/core/src/main/java/com/google/adk/tools/Annotations.java
+++ b/core/src/main/java/com/google/adk/tools/Annotations.java
@@ -33,6 +33,8 @@ public final class Annotations {
     String name() default "";
 
     String description() default "";
+
+    boolean optional() default false;
   }
 
   private Annotations() {}

--- a/core/src/main/java/com/google/adk/tools/FunctionCallingUtils.java
+++ b/core/src/main/java/com/google/adk/tools/FunctionCallingUtils.java
@@ -104,7 +104,10 @@ public final class FunctionCallingUtils {
       if (ignoreParams.contains(paramName)) {
         continue;
       }
-      required.add(paramName);
+      Annotations.Schema schema = param.getAnnotation(Annotations.Schema.class);
+      if (schema == null || !schema.optional()) {
+        required.add(paramName);
+      }
       properties.put(paramName, buildSchemaFromParameter(param));
     }
     builder.parameters(

--- a/core/src/main/java/com/google/adk/tools/FunctionTool.java
+++ b/core/src/main/java/com/google/adk/tools/FunctionTool.java
@@ -197,11 +197,17 @@ public class FunctionTool extends BaseTool {
         arguments[i] = null;
         continue;
       }
+      Annotations.Schema schema = parameters[i].getAnnotation(Annotations.Schema.class);
       if (!args.containsKey(paramName)) {
-        throw new IllegalArgumentException(
-            String.format(
-                "The parameter '%s' was not found in the arguments provided by the model.",
-                paramName));
+        if (schema != null && schema.optional()) {
+          arguments[i] = null;
+          continue;
+        } else {
+          throw new IllegalArgumentException(
+              String.format(
+                  "The parameter '%s' was not found in the arguments provided by the model.",
+                  paramName));
+        }
       }
       Class<?> paramType = parameters[i].getType();
       Object argValue = args.get(paramName);
@@ -274,11 +280,17 @@ public class FunctionTool extends BaseTool {
         }
         continue;
       }
+      Annotations.Schema schema = parameters[i].getAnnotation(Annotations.Schema.class);
       if (!args.containsKey(paramName)) {
-        throw new IllegalArgumentException(
-            String.format(
-                "The parameter '%s' was not found in the arguments provided by the model.",
-                paramName));
+        if (schema != null && schema.optional()) {
+          arguments[i] = null;
+          continue;
+        } else {
+          throw new IllegalArgumentException(
+              String.format(
+                  "The parameter '%s' was not found in the arguments provided by the model.",
+                  paramName));
+        }
       }
       Class<?> paramType = parameters[i].getType();
       Object argValue = args.get(paramName);


### PR DESCRIPTION
Add optional parameter to @Annotations.Schema to mark function parameters as optional, excluding them from the "required" array in generated function schemas.

```
// Example func
public Map<String, Object> executeExample(
    @Annotations.Schema(name = "requiredParam", description = "A required parameter") 
    String requiredParam,
    
    @Annotations.Schema(name = "optionalParam", description = "An optional parameter", optional = true)
    Integer optionalParam
) {
    // implementation
}

// Generated schema
{
  "required": ["requiredParam"]
}
```

Fix https://github.com/google/adk-java/issues/493