### PR TITLE
fix: listSessions returns sessions with empty state

### DIFF
--- a/core/src/main/java/com/google/adk/sessions/VertexAiSessionService.java
+++ b/core/src/main/java/com/google/adk/sessions/VertexAiSessionService.java
@@ -122,7 +122,6 @@ public final class VertexAiSessionService implements BaseSessionService {
         .defaultIfEmpty(ListSessionsResponse.builder().build());
   }
 
-  @SuppressWarnings("unchecked")
   private ListSessionsResponse parseListSessionsResponse(
       JsonNode listSessionsResponseMap, String appName, String userId) {
     List<Map<String, Object>> apiSessions =


### PR DESCRIPTION
May look like optimization but [python version ](https://github.com/google/adk-python/blob/fe1fc75c15a7983829bbe0b023f4b612b1e5c018/src/google/adk/sessions/vertex_ai_session_service.py#L240)returns non-empty session states.