### PR TITLE
Make AgentStaticLoader public

### DIFF
--- a/dev/src/main/java/com/google/adk/web/AgentStaticLoader.java
+++ b/dev/src/main/java/com/google/adk/web/AgentStaticLoader.java
@@ -37,7 +37,7 @@ import javax.annotation.Nonnull;
  * <p>This class is not a Spring component by itself - instances are created programmatically and
  * then registered as beans via factory methods.
  */
-class AgentStaticLoader implements AgentLoader {
+public class AgentStaticLoader implements AgentLoader {
 
   private final ImmutableMap<String, BaseAgent> agents;
 


### PR DESCRIPTION
This is needed to start an application with custom Spring configuration. AgentStaticLoader will be instantiated as a bean.