### PR TITLE
feat: Implementation of a session service for the ADK (Agent Development Kit) that uses Google Firestore as the backend for storing session data

### DIFF
--- a/a2a/webservice/pom.xml
+++ b/a2a/webservice/pom.xml
@@ -1,13 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
     <groupId>com.google.adk</groupId>
     <artifactId>google-adk-parent</artifactId>
     <version>0.4.0-SNAPSHOT</version><!-- {x-version-update:google-adk:current} -->
+    <relativePath>../../pom.xml</relativePath>
   </parent>
 
   <artifactId>google-adk-a2a-webservice</artifactId>

--- a/contrib/firestore-session-service/.gitignore
+++ b/contrib/firestore-session-service/.gitignore
@@ -1,0 +1,10 @@
+/target
+*.prefs
+*.iml
+.idea/
+.vscode/
+.DS_Store
+logs/
+*.log
+*.project
+

--- a/contrib/firestore-session-service/README.md
+++ b/contrib/firestore-session-service/README.md
@@ -1,0 +1,90 @@
+## Firestore Session Service for ADK
+
+This sub-module contains an implementation of a session service for the ADK (Agent Development Kit) that uses Google Firestore as the backend for storing session data. This allows developers to manage user sessions in a scalable and reliable manner using Firestore's NoSQL database capabilities.
+
+## Getting Started
+
+To integrate this Firestore session service into your ADK project, add the following dependencies to your project's build configuration: pom.xml for Maven or build.gradle for Gradle.
+
+## Basic Setup
+
+```xml
+<dependencies>
+    <!-- ADK Core -->
+    <dependency>
+        <groupId>com.google.adk</groupId>
+        <artifactId>google-adk</artifactId>
+        <version>0.4.0-SNAPSHOT</version>
+    </dependency>
+    <!-- Firestore Session Service -->
+    <dependency>
+        <groupId>com.google.adk.contrib</groupId>
+        <artifactId>firestore-session-service</artifactId>
+        <version>0.4.0-SNAPSHOT</version>
+    </dependency>
+</dependencies>
+```
+
+```gradle
+dependencies {
+    // ADK Core
+    implementation 'com.google.adk:google-adk:0.4.0-SNAPSHOT'
+    // Firestore Session Service
+    implementation 'com.google.adk.contrib:firestore-session-service:0.4.0-SNAPSHOT'
+}
+```
+
+## Running the Service
+
+You can customize your ADK application to use the Firestore session service by providing your own Firestore property settings, otherwise library will use the default settings.
+
+Sample Property Settings:
+
+```properties
+# Firestore collection name for storing session data
+adk.firestore.collection.name=adk-session
+# Google Cloud Storage bucket name for artifact storage
+adk.gcs.bucket.name=your-gcs-bucket-name
+#stop words for keyword extraction
+adk.stop.words=a,about,above,after,again,against,all,am,an,and,any,are,aren't,as,at,be,because,been,before,being,below,between,both,but,by,can't,cannot,could,couldn't,did,didn't,do,does,doesn't,doing,don't,down,during,each,few,for,from,further,had,hadn't,has,hasn't,have,haven't,having,he,he'd,he'll,he's,her,here,here's,hers,herself,him,himself,his,how,i,i'd,i'll,i'm,i've,if,in,into,is
+```
+
+Then, you can use the `FirestoreDatabaseRunner` to start your ADK application with Firestore session management:
+
+```java
+import com.google.adk.agents.YourAgent; // Replace with your actual agent class
+import com.google.adk.plugins.BasePlugin;
+import com.google.adk.runner.FirestoreDatabaseRunner;
+import com.google.cloud.firestore.Firestore;
+import com.google.cloud.firestore.FirestoreOptions;
+import java.util.ArrayList;
+import java.util.List;
+import com.google.adk.sessions.GetSessionConfig;
+import java.util.Optional;
+
+
+
+
+public class YourApp {
+    public static void main(String[] args) {
+        Firestore firestore = FirestoreOptions.getDefaultInstance().getService();
+        List<BasePlugin> plugins = new ArrayList<>();
+        // Add any plugins you want to use
+
+
+        FirestoreDatabaseRunner firestoreRunner = new FirestoreDatabaseRunner(
+            new YourAgent(), // Replace with your actual agent instance
+            "YourAppName",
+            plugins,
+            firestore
+        );
+
+        GetSessionConfig config = GetSessionConfig.builder().build();
+        // Example usage of session service
+        firestoreRunner.sessionService().getSession("APP_NAME","USER_ID","SESSION_ID", Optional.of(config));
+
+    }
+}
+```
+
+Make sure to replace `YourAgent` and `"YourAppName"` with your actual agent class and application name.

--- a/contrib/firestore-session-service/pom.xml
+++ b/contrib/firestore-session-service/pom.xml
@@ -1,0 +1,104 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright 2025 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.google.adk</groupId>
+        <artifactId>google-adk-parent</artifactId>
+        <version>0.4.0-SNAPSHOT</version><!-- {x-version-update:google-adk:current} -->
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>google-adk-firestore-session-service</artifactId>
+    <name>Agent Development Kit - Firestore Session Management</name>
+    <description>Firestore integration with Agent Development Kit for User Session Management</description>
+
+
+    <dependencies>
+
+        <dependency>
+            <groupId>com.google.adk</groupId>
+            <artifactId>google-adk</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.google.adk</groupId>
+            <artifactId>google-adk-dev</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.google.genai</groupId>
+            <artifactId>google-genai</artifactId>
+            <version>${google.genai.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.google.cloud</groupId>
+            <artifactId>google-cloud-firestore</artifactId>
+            <version>3.30.3</version>
+        </dependency>
+        <dependency>
+            <groupId>com.google.truth</groupId>
+            <artifactId>truth</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <argLine>
+                        ${jacoco.agent.argLine}
+                        --add-opens java.base/java.util=ALL-UNNAMED
+                        --add-opens java.base/java.lang=ALL-UNNAMED
+                    </argLine>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/contrib/firestore-session-service/src/main/java/com/google/adk/memory/FirestoreMemoryService.java
+++ b/contrib/firestore-session-service/src/main/java/com/google/adk/memory/FirestoreMemoryService.java
@@ -1,0 +1,182 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.adk.memory;
+
+import com.google.adk.sessions.Session;
+import com.google.adk.utils.Constants;
+import com.google.api.core.ApiFuture;
+import com.google.api.core.ApiFutures;
+import com.google.cloud.firestore.Firestore;
+import com.google.cloud.firestore.Query;
+import com.google.cloud.firestore.QueryDocumentSnapshot;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
+import com.google.common.util.concurrent.MoreExecutors;
+import com.google.genai.types.Content;
+import com.google.genai.types.Part;
+import io.reactivex.rxjava3.core.Completable;
+import io.reactivex.rxjava3.core.Single;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * FirestoreMemoryService is an implementation of BaseMemoryService that uses Firestore to store and
+ * retrieve session memory entries.
+ */
+public class FirestoreMemoryService implements BaseMemoryService {
+
+  private static final Logger logger = LoggerFactory.getLogger(FirestoreMemoryService.class);
+  private static final Pattern WORD_PATTERN = Constants.WORD_PATTERN;
+
+  private final Firestore firestore;
+
+  /** Constructor for FirestoreMemoryService */
+  public FirestoreMemoryService(Firestore firestore) {
+    this.firestore = firestore;
+  }
+
+  /**
+   * Adds a session to memory. This is a no-op for FirestoreMemoryService since keywords are indexed
+   * when events are appended in FirestoreSessionService.
+   */
+  @Override
+  public Completable addSessionToMemory(Session session) {
+    // No-op. Keywords are indexed when events are appended in
+    // FirestoreSessionService.
+    return Completable.complete();
+  }
+
+  /** Searches memory entries for the given appName and userId that match the query keywords. */
+  @Override
+  public Single<SearchMemoryResponse> searchMemory(String appName, String userId, String query) {
+    return Single.fromCallable(
+        () -> {
+          Objects.requireNonNull(appName, "appName cannot be null");
+          Objects.requireNonNull(userId, "userId cannot be null");
+          Objects.requireNonNull(query, "query cannot be null");
+
+          Set<String> queryKeywords = extractKeywords(query);
+
+          if (queryKeywords.isEmpty()) {
+            return SearchMemoryResponse.builder().build();
+          }
+
+          List<String> queryKeywordsList = new ArrayList<>(queryKeywords);
+          List<List<String>> chunks = Lists.partition(queryKeywordsList, 10);
+
+          List<ApiFuture<List<QueryDocumentSnapshot>>> futures = new ArrayList<>();
+          for (List<String> chunk : chunks) {
+            Query eventsQuery =
+                firestore
+                    .collectionGroup(Constants.EVENTS_SUBCOLLECTION_NAME)
+                    .whereEqualTo("appName", appName)
+                    .whereEqualTo("userId", userId)
+                    .whereArrayContainsAny("keywords", chunk);
+            futures.add(
+                ApiFutures.transform(
+                    eventsQuery.get(),
+                    com.google.cloud.firestore.QuerySnapshot::getDocuments,
+                    MoreExecutors.directExecutor()));
+          }
+
+          Set<String> seenEventIds = new HashSet<>();
+          List<MemoryEntry> matchingMemories = new ArrayList<>();
+
+          for (QueryDocumentSnapshot eventDoc :
+              ApiFutures.allAsList(futures).get().stream()
+                  .flatMap(List::stream)
+                  .collect(Collectors.toList())) {
+            if (seenEventIds.add(eventDoc.getId())) {
+              MemoryEntry entry = memoryEntryFromDoc(eventDoc);
+              if (entry != null) {
+                matchingMemories.add(entry);
+              }
+            }
+          }
+
+          return SearchMemoryResponse.builder()
+              .setMemories(ImmutableList.copyOf(matchingMemories))
+              .build();
+        });
+  }
+
+  /**
+   * Extracts keywords from the given text by splitting on non-word characters, converting to lower
+   */
+  private Set<String> extractKeywords(String text) {
+    Set<String> keywords = new HashSet<>();
+    if (text != null && !text.isEmpty()) {
+      Matcher matcher = WORD_PATTERN.matcher(text.toLowerCase(Locale.ROOT));
+      while (matcher.find()) {
+        String word = matcher.group();
+        if (!Constants.STOP_WORDS.contains(word)) {
+          keywords.add(word);
+        }
+      }
+    }
+    return keywords;
+  }
+
+  /** Creates a MemoryEntry from a Firestore document. */
+  @SuppressWarnings("unchecked")
+  private MemoryEntry memoryEntryFromDoc(QueryDocumentSnapshot doc) {
+    Map<String, Object> data = doc.getData();
+    if (data == null) {
+      return null;
+    }
+
+    try {
+      String author = (String) data.get("author");
+      String timestampStr = (String) data.get("timestamp");
+      Map<String, Object> contentMap = (Map<String, Object>) data.get("content");
+
+      if (author == null || timestampStr == null || contentMap == null) {
+        logger.warn("Skipping malformed event data: {}", data);
+        return null;
+      }
+
+      List<Map<String, Object>> partsList = (List<Map<String, Object>>) contentMap.get("parts");
+      List<Part> parts = new ArrayList<>();
+      if (partsList != null) {
+        for (Map<String, Object> partMap : partsList) {
+          if (partMap.containsKey("text")) {
+            parts.add(Part.fromText((String) partMap.get("text")));
+          }
+        }
+      }
+
+      return MemoryEntry.builder()
+          .author(author)
+          .content(Content.fromParts(parts.toArray(new Part[0])))
+          .timestamp(timestampStr)
+          .build();
+    } catch (Exception e) {
+      logger.error("Failed to parse memory entry from Firestore data: " + data, e);
+      return null;
+    }
+  }
+}

--- a/contrib/firestore-session-service/src/main/java/com/google/adk/runner/FirestoreDatabaseRunner.java
+++ b/contrib/firestore-session-service/src/main/java/com/google/adk/runner/FirestoreDatabaseRunner.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.adk.runner;
+
+import com.google.adk.agents.BaseAgent;
+import com.google.adk.memory.FirestoreMemoryService;
+import com.google.adk.plugins.BasePlugin;
+import com.google.adk.sessions.FirestoreSessionService;
+import com.google.adk.utils.FirestoreProperties;
+import com.google.cloud.firestore.Firestore;
+import com.google.cloud.storage.StorageOptions;
+
+/** FirestoreDatabaseRunner */
+public class FirestoreDatabaseRunner extends Runner {
+
+  /** Constructor for FirestoreDatabaseRunner */
+  public FirestoreDatabaseRunner(BaseAgent baseAgent, Firestore firestore) {
+    this(baseAgent, baseAgent.name(), new java.util.ArrayList<>(), firestore);
+  }
+
+  /** Constructor for FirestoreDatabaseRunner with appName */
+  public FirestoreDatabaseRunner(BaseAgent baseAgent, String appName, Firestore firestore) {
+    this(baseAgent, appName, new java.util.ArrayList<>(), firestore);
+  }
+
+  /** Constructor for FirestoreDatabaseRunner with parent runners */
+  public FirestoreDatabaseRunner(
+      BaseAgent baseAgent,
+      String appName,
+      java.util.List<BasePlugin> plugins,
+      Firestore firestore) {
+    super(
+        baseAgent,
+        appName,
+        new com.google.adk.artifacts.GcsArtifactService(
+            getBucketNameFromEnv(), StorageOptions.getDefaultInstance().getService()),
+        new FirestoreSessionService(firestore),
+        new FirestoreMemoryService(firestore),
+        plugins);
+  }
+
+  /** Gets the GCS bucket name from the environment variable ADK_GCS_BUCKET_NAME. */
+  private static String getBucketNameFromEnv() {
+    String bucketName = FirestoreProperties.getInstance().getGcsAdkBucketName();
+    if (bucketName == null || bucketName.trim().isEmpty()) {
+      throw new RuntimeException(
+          "Required property 'gcs.adk.bucket.name' is not set. This"
+              + " is needed for the GcsArtifactService.");
+    }
+    return bucketName;
+  }
+}

--- a/contrib/firestore-session-service/src/main/java/com/google/adk/sessions/FirestoreSessionService.java
+++ b/contrib/firestore-session-service/src/main/java/com/google/adk/sessions/FirestoreSessionService.java
@@ -1,0 +1,709 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.adk.sessions;
+
+import com.google.adk.events.Event;
+import com.google.adk.events.EventActions;
+import com.google.adk.utils.ApiFutureUtils;
+import com.google.adk.utils.Constants;
+import com.google.api.core.ApiFuture;
+import com.google.api.core.ApiFutures;
+import com.google.cloud.firestore.CollectionReference;
+import com.google.cloud.firestore.DocumentSnapshot;
+import com.google.cloud.firestore.Firestore;
+import com.google.cloud.firestore.Query;
+import com.google.cloud.firestore.QueryDocumentSnapshot;
+import com.google.cloud.firestore.WriteBatch;
+import com.google.cloud.firestore.WriteResult;
+import com.google.common.util.concurrent.MoreExecutors;
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
+import com.google.genai.types.Content;
+import com.google.genai.types.Part;
+import io.reactivex.rxjava3.core.Completable;
+import io.reactivex.rxjava3.core.Maybe;
+import io.reactivex.rxjava3.core.Single;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.regex.Matcher;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * FirestoreSessionService implements session management using Google Firestore as the backend
+ * storage.
+ */
+public class FirestoreSessionService implements BaseSessionService {
+  private static final Logger logger = LoggerFactory.getLogger(FirestoreSessionService.class);
+  private final Firestore firestore;
+  private static final String ROOT_COLLECTION_NAME = Constants.ROOT_COLLECTION_NAME;
+  private static final String EVENTS_SUBCOLLECTION_NAME = Constants.EVENTS_SUBCOLLECTION_NAME;
+  private static final String APP_STATE_COLLECTION = Constants.APP_STATE_COLLECTION;
+  private static final String USER_STATE_COLLECTION = Constants.USER_STATE_COLLECTION;
+  private static final String SESSION_COLLECTION_NAME = Constants.SESSION_COLLECTION_NAME;
+  private static final String USER_ID_KEY = Constants.KEY_USER_ID;
+  private static final String APP_NAME_KEY = Constants.KEY_APP_NAME;
+  private static final String STATE_KEY = Constants.KEY_STATE;
+  private static final String ID_KEY = Constants.KEY_ID;
+  private static final String UPDATE_TIME_KEY = Constants.KEY_UPDATE_TIME;
+  private static final String TIMESTAMP_KEY = Constants.KEY_TIMESTAMP;
+
+  /** Constructor for FirestoreSessionService. */
+  public FirestoreSessionService(Firestore firestore) {
+    this.firestore = firestore;
+  }
+
+  /** Gets the sessions collection reference for a given userId. */
+  private CollectionReference getSessionsCollection(String userId) {
+    return firestore
+        .collection(ROOT_COLLECTION_NAME)
+        .document(userId)
+        .collection(SESSION_COLLECTION_NAME);
+  }
+
+  /** Creates a new session in Firestore. */
+  @Override
+  public Single<Session> createSession(
+      String appName, String userId, ConcurrentMap<String, Object> state, String sessionId) {
+    return Single.fromCallable(
+        () -> {
+          Objects.requireNonNull(appName, "appName cannot be null");
+          Objects.requireNonNull(userId, "userId cannot be null");
+
+          String resolvedSessionId =
+              Optional.ofNullable(sessionId)
+                  .map(String::trim)
+                  .filter(s -> !s.isEmpty())
+                  .orElseGet(() -> UUID.randomUUID().toString());
+
+          ConcurrentMap<String, Object> initialState =
+              (state == null) ? new ConcurrentHashMap<>() : new ConcurrentHashMap<>(state);
+          logger.info(
+              "Creating session for userId: {} with sessionId: {} and initial state: {}",
+              userId,
+              resolvedSessionId,
+              initialState);
+          List<Event> initialEvents = new ArrayList<>();
+          Instant now = Instant.now();
+          Session newSession =
+              Session.builder(resolvedSessionId)
+                  .appName(appName)
+                  .userId(userId)
+                  .state(initialState)
+                  .events(initialEvents)
+                  .lastUpdateTime(now)
+                  .build();
+
+          // Convert Session to a Map for Firestore
+          Map<String, Object> sessionData = new HashMap<>();
+          sessionData.put(ID_KEY, newSession.id());
+          sessionData.put(APP_NAME_KEY, newSession.appName());
+          sessionData.put(USER_ID_KEY, newSession.userId());
+          sessionData.put(UPDATE_TIME_KEY, newSession.lastUpdateTime().toString());
+          sessionData.put(STATE_KEY, newSession.state());
+
+          // Asynchronously write to Firestore and wait for the result
+          ApiFuture<WriteResult> future =
+              getSessionsCollection(userId).document(resolvedSessionId).set(sessionData);
+          future.get(); // Block until the write is complete
+
+          return newSession;
+        });
+  }
+
+  /***
+   * Retrieves a session by appName, userId, and sessionId from Firestore.
+   */
+  @Override
+  public Maybe<Session> getSession(
+      String appName, String userId, String sessionId, Optional<GetSessionConfig> configOpt) {
+    Objects.requireNonNull(appName, "appName cannot be null");
+    Objects.requireNonNull(userId, "userId cannot be null");
+    Objects.requireNonNull(sessionId, "sessionId cannot be null");
+    Objects.requireNonNull(configOpt, "configOpt cannot be null");
+
+    logger.info("Getting session for userId: {} with sessionId: {}", userId, sessionId);
+    ApiFuture<DocumentSnapshot> future = getSessionsCollection(userId).document(sessionId).get();
+
+    return ApiFutureUtils.toMaybe(future)
+        .flatMap(
+            document -> {
+              if (!document.exists()) {
+                logger.warn("Session not found for sessionId: {}", sessionId);
+                return Maybe.error(new SessionNotFoundException("Session not found: " + sessionId));
+              }
+
+              Map<String, Object> data = document.getData();
+              if (data == null) {
+                logger.warn("Session data is null for sessionId: {}", sessionId);
+                return Maybe.empty();
+              }
+
+              // Fetch events based on config
+              GetSessionConfig config = configOpt.orElse(GetSessionConfig.builder().build());
+              CollectionReference eventsCollection =
+                  document.getReference().collection(EVENTS_SUBCOLLECTION_NAME);
+              Query eventsQuery = eventsCollection.orderBy(TIMESTAMP_KEY);
+
+              if (config.afterTimestamp().isPresent()) {
+                eventsQuery =
+                    eventsQuery.whereGreaterThan(
+                        TIMESTAMP_KEY, config.afterTimestamp().get().toString());
+              }
+
+              if (config.numRecentEvents().isPresent()) {
+                eventsQuery = eventsQuery.limitToLast(config.numRecentEvents().get());
+              }
+
+              ApiFuture<List<QueryDocumentSnapshot>> eventsFuture =
+                  ApiFutures.transform(
+                      eventsQuery.get(),
+                      com.google.cloud.firestore.QuerySnapshot::getDocuments,
+                      MoreExecutors.directExecutor());
+
+              return ApiFutureUtils.toSingle(eventsFuture)
+                  .map(
+                      eventDocs -> {
+                        List<Event> events = new ArrayList<>();
+                        for (DocumentSnapshot eventDoc : eventDocs) {
+                          Event event = eventFromMap(eventDoc.getData(), userId);
+                          if (event != null) {
+                            events.add(event);
+                          }
+                        }
+                        return events;
+                      })
+                  .map(
+                      events -> {
+                        ConcurrentMap<String, Object> state =
+                            new ConcurrentHashMap<>((Map<String, Object>) data.get(STATE_KEY));
+                        return Session.builder((String) data.get(ID_KEY))
+                            .appName((String) data.get(APP_NAME_KEY))
+                            .userId((String) data.get(USER_ID_KEY))
+                            .lastUpdateTime(Instant.parse((String) data.get(UPDATE_TIME_KEY)))
+                            .state(state)
+                            .events(events)
+                            .build();
+                      })
+                  .toMaybe();
+            });
+  }
+
+  /**
+   * Reconstructs an Event object from a Map retrieved from Firestore.
+   *
+   * @param data The map representation of the event.
+   * @return An Event object, or null if the data is malformed.
+   */
+  private Event eventFromMap(Map<String, Object> data, String sessionUserId) {
+    if (data == null) {
+      return null;
+    }
+    try {
+      String author = safeCast(data.get("author"), String.class, "author");
+      String timestampStr = safeCast(data.get(TIMESTAMP_KEY), String.class, "timestamp");
+      Map<String, Object> contentMap = safeCast(data.get("content"), Map.class, "content");
+
+      if (author == null || timestampStr == null || contentMap == null) {
+        logger.warn(
+            "Skipping malformed event data due to missing author, timestamp, or content: {}", data);
+        return null;
+      }
+
+      Instant timestamp = Instant.parse(timestampStr);
+
+      // Reconstruct Content object
+      List<Map> partsList = safeCast(contentMap.get("parts"), List.class, "parts.list");
+      List<Part> parts = new ArrayList<>();
+      if (partsList != null) {
+        for (Map<String, Object> partMap : partsList) {
+          Part part = null;
+          if (partMap.containsKey("text")) {
+            part = Part.fromText((String) partMap.get("text"));
+          } else if (partMap.containsKey("functionCall")) {
+            part =
+                functionCallPartFromMap(
+                    safeCast(partMap.get("functionCall"), Map.class, "functionCall"));
+          } else if (partMap.containsKey("functionResponse")) {
+            part =
+                functionResponsePartFromMap(
+                    safeCast(partMap.get("functionResponse"), Map.class, "functionResponse"));
+          } else if (partMap.containsKey("fileData")) {
+            part = fileDataPartFromMap(safeCast(partMap.get("fileData"), Map.class, "fileData"));
+          }
+          if (part != null) {
+            parts.add(part);
+          }
+        }
+      }
+
+      // The role of the content should be 'user' or 'model'.
+      // An agent's turn is 'model'. A user's turn is 'user'.
+      // A special case is a function response, which is authored by the 'user'
+      // but represents a response to a model's function call.
+      String role;
+      boolean hasFunctionResponse = parts.stream().anyMatch(p -> p.functionResponse().isPresent());
+
+      if (hasFunctionResponse) {
+        role = "user"; // Function responses are sent with the 'user' role.
+      } else {
+        // If the author is the user, the role is 'user'. Otherwise, it's 'model'.
+        role = author.equalsIgnoreCase(sessionUserId) ? "user" : "model";
+      }
+      logger.debug("Reconstructed event role: {}", role);
+      Content content = Content.builder().role(role).parts(parts).build();
+
+      return Event.builder()
+          .author(author)
+          .content(content)
+          .timestamp(timestamp.toEpochMilli())
+          .build();
+    } catch (Exception e) {
+      logger.error("Failed to parse event from Firestore data: " + data, e);
+      return null;
+    }
+  }
+
+  /**
+   * Constructs a FunctionCall Part from a map representation.
+   *
+   * @param fcMap The map containing the function call 'name' and 'args'.
+   * @return A Part containing the FunctionCall.
+   */
+  private Part functionCallPartFromMap(Map<String, Object> fcMap) {
+    if (fcMap == null) {
+      return null;
+    }
+    String name = (String) fcMap.get("name");
+    Map<String, Object> args = safeCast(fcMap.get("args"), Map.class, "functionCall.args");
+    return Part.fromFunctionCall(name, args);
+  }
+
+  /**
+   * Constructs a FunctionResponse Part from a map representation.
+   *
+   * @param frMap The map containing the function response 'name' and 'response'.
+   * @return A Part containing the FunctionResponse.
+   */
+  private Part functionResponsePartFromMap(Map<String, Object> frMap) {
+    if (frMap == null) {
+      return null;
+    }
+    String name = (String) frMap.get("name");
+    Map<String, Object> response =
+        safeCast(frMap.get("response"), Map.class, "functionResponse.response");
+    return Part.fromFunctionResponse(name, response);
+  }
+
+  /**
+   * Constructs a fileData Part from a map representation.
+   *
+   * @param fdMap The map containing the file data 'fileUri' and 'mimeType'.
+   * @return A Part containing the file data.
+   */
+  private Part fileDataPartFromMap(Map<String, Object> fdMap) {
+    if (fdMap == null) return null;
+    String fileUri = (String) fdMap.get("fileUri");
+    String mimeType = (String) fdMap.get("mimeType");
+    return Part.fromUri(fileUri, mimeType);
+  }
+
+  /** Converts an Event object to a Map representation suitable for Firestore storage. */
+  private Map<String, Object> eventToMap(Session session, Event event) {
+    Map<String, Object> data = new HashMap<>();
+    // For user-generated events, the author should be the user's ID.
+    // The ADK runner sets the author to "user" for the user's turn.
+    if ("user".equalsIgnoreCase(event.author())) {
+      data.put("author", session.userId());
+    } else {
+      data.put("author", event.author());
+    }
+    data.put(TIMESTAMP_KEY, Instant.ofEpochMilli(event.timestamp()).toString());
+    data.put(APP_NAME_KEY, session.appName()); // Persist appName with the event
+
+    Map<String, Object> contentData = new HashMap<>();
+    List<Map<String, Object>> partsData = new ArrayList<>();
+    Set<String> keywords = new HashSet<>();
+
+    event
+        .content()
+        .flatMap(Content::parts)
+        .ifPresent(
+            parts -> {
+              for (Part part : parts) {
+                Map<String, Object> partData = new HashMap<>();
+                part.text()
+                    .ifPresent(
+                        text -> {
+                          partData.put("text", text);
+                          // Extract keywords only if there is text
+                          if (!text.isEmpty()) {
+
+                            Matcher matcher = Constants.WORD_PATTERN.matcher(text);
+                            while (matcher.find()) {
+                              String word = matcher.group().toLowerCase(Locale.ROOT);
+                              if (!Constants.STOP_WORDS.contains(word)) {
+                                keywords.add(word);
+                              }
+                            }
+                          }
+                        });
+                part.functionCall()
+                    .ifPresent(
+                        fc -> {
+                          Map<String, Object> fcMap = new HashMap<>();
+                          fc.name().ifPresent(name -> fcMap.put("name", name));
+                          fc.args().ifPresent(args -> fcMap.put("args", args));
+                          if (!fcMap.isEmpty()) {
+                            partData.put("functionCall", fcMap);
+                          }
+                        });
+                part.functionResponse()
+                    .ifPresent(
+                        fr -> {
+                          Map<String, Object> frMap = new HashMap<>();
+                          fr.name().ifPresent(name -> frMap.put("name", name));
+                          fr.response().ifPresent(response -> frMap.put("response", response));
+                          if (!frMap.isEmpty()) {
+                            partData.put("functionResponse", frMap);
+                          }
+                        });
+                part.fileData()
+                    .ifPresent(
+                        fd -> {
+                          Map<String, Object> fdMap = new HashMap<>();
+                          // When serializing, we assume the artifact service has already converted
+                          // the
+                          // bytes to a GCS URI.
+                          fd.fileUri().ifPresent(uri -> fdMap.put("fileUri", uri));
+                          fd.mimeType().ifPresent(mime -> fdMap.put("mimeType", mime));
+                          if (!fdMap.isEmpty()) {
+                            partData.put("fileData", fdMap);
+                          }
+                        });
+
+                // Add other part types if necessary
+                partsData.add(partData);
+              }
+            });
+
+    logger.info("Serialized parts data before saving: {}", partsData);
+    contentData.put("parts", partsData);
+    data.put("content", contentData);
+    if (!keywords.isEmpty()) {
+      data.put("keywords", new ArrayList<>(keywords)); // Firestore works well with Lists
+    }
+
+    return data;
+  }
+
+  /** Lists all sessions for a given appName and userId. */
+  @Override
+  public Single<ListSessionsResponse> listSessions(String appName, String userId) {
+    return Single.fromCallable(
+        () -> {
+          Objects.requireNonNull(appName, "appName cannot be null");
+          Objects.requireNonNull(userId, "userId cannot be null");
+
+          logger.info("Listing sessions for userId: {}", userId);
+
+          Query query = getSessionsCollection(userId).whereEqualTo(APP_NAME_KEY, appName);
+
+          ApiFuture<List<QueryDocumentSnapshot>> querySnapshot =
+              ApiFutures.transform(
+                  query.get(), // Query is already scoped to the user
+                  snapshot -> snapshot.getDocuments(),
+                  MoreExecutors.directExecutor());
+
+          List<Session> sessions = new ArrayList<>();
+          for (DocumentSnapshot document : querySnapshot.get()) {
+            Map<String, Object> data = document.getData();
+            if (data != null) {
+              // Create a session object with empty events and state, as per
+              // InMemorySessionService
+              Session session =
+                  Session.builder((String) data.get(ID_KEY))
+                      .appName((String) data.get(APP_NAME_KEY))
+                      .userId((String) data.get(USER_ID_KEY))
+                      .lastUpdateTime(Instant.parse((String) data.get(UPDATE_TIME_KEY)))
+                      .state(new ConcurrentHashMap<>()) // Empty state
+                      .events(new ArrayList<>()) // Empty events
+                      .build();
+              sessions.add(session);
+            }
+          }
+
+          return ListSessionsResponse.builder().sessions(sessions).build();
+        });
+  }
+
+  /** Deletes a session and all its associated events from Firestore. */
+  @Override
+  public Completable deleteSession(String appName, String userId, String sessionId) {
+    return Completable.fromAction(
+        () -> {
+          Objects.requireNonNull(appName, "appName cannot be null");
+          Objects.requireNonNull(userId, "userId cannot be null");
+          Objects.requireNonNull(sessionId, "sessionId cannot be null");
+
+          logger.info("Deleting session for userId: {} with sessionId: {}", userId, sessionId);
+
+          // Reference to the session document
+          com.google.cloud.firestore.DocumentReference sessionRef =
+              getSessionsCollection(userId).document(sessionId);
+
+          // 1. Fetch all events in the subcollection to delete them in batches.
+          CollectionReference eventsRef = sessionRef.collection(EVENTS_SUBCOLLECTION_NAME);
+          com.google.api.core.ApiFuture<com.google.cloud.firestore.QuerySnapshot> eventsQuery =
+              eventsRef.get();
+          List<QueryDocumentSnapshot> eventDocuments = eventsQuery.get().getDocuments();
+
+          if (!eventDocuments.isEmpty()) {
+            List<ApiFuture<List<WriteResult>>> batchCommitFutures = new ArrayList<>();
+            // Firestore batches can have up to 500 operations.
+            for (int i = 0; i < eventDocuments.size(); i += 500) {
+              WriteBatch batch = firestore.batch();
+              List<QueryDocumentSnapshot> chunk =
+                  eventDocuments.subList(i, Math.min(i + 500, eventDocuments.size()));
+              for (QueryDocumentSnapshot doc : chunk) {
+                batch.delete(doc.getReference());
+              }
+              batchCommitFutures.add(batch.commit());
+            }
+            // Wait for all batch deletions to complete.
+            ApiFutures.allAsList(batchCommitFutures).get();
+          }
+
+          // 2. Delete the session document itself
+          sessionRef.delete().get(); // Block until deletion is complete
+
+          logger.info("Successfully deleted session: {}", sessionId);
+        });
+  }
+
+  /** Lists all events for a given appName, userId, and sessionId. */
+  @Override
+  public Single<ListEventsResponse> listEvents(String appName, String userId, String sessionId) {
+    return Single.fromCallable(
+        () -> {
+          Objects.requireNonNull(appName, "appName cannot be null");
+          Objects.requireNonNull(userId, "userId cannot be null");
+          Objects.requireNonNull(sessionId, "sessionId cannot be null");
+
+          logger.info("Listing events for userId: {} with sessionId: {}", userId, sessionId);
+
+          // First, check if the session document exists.
+          ApiFuture<DocumentSnapshot> sessionFuture =
+              getSessionsCollection(userId).document(sessionId).get();
+          DocumentSnapshot sessionDocument = sessionFuture.get(); // Block for the result
+
+          if (!sessionDocument.exists()) {
+            logger.warn(
+                "Session not found for sessionId: {}. Returning empty list of events.", sessionId);
+            throw new SessionNotFoundException(appName + "," + userId + "," + sessionId);
+          }
+
+          // Session exists, now fetch the events.
+          CollectionReference eventsCollection =
+              sessionDocument.getReference().collection(EVENTS_SUBCOLLECTION_NAME);
+          Query eventsQuery = eventsCollection.orderBy(TIMESTAMP_KEY);
+
+          ApiFuture<List<QueryDocumentSnapshot>> eventsFuture =
+              ApiFutures.transform(
+                  eventsQuery.get(),
+                  querySnapshot -> querySnapshot.getDocuments(),
+                  MoreExecutors.directExecutor());
+
+          List<Event> events = new ArrayList<>();
+          for (DocumentSnapshot eventDoc : eventsFuture.get()) {
+            Event event = eventFromMap(eventDoc.getData(), userId);
+            if (event != null) {
+              events.add(event);
+            }
+          }
+          logger.info("Returning {} events for sessionId: {}", events.size(), sessionId);
+          return ListEventsResponse.builder().events(events).build();
+        });
+  }
+
+  /** Appends an event to a session, updating the session state and persisting to Firestore. */
+  @CanIgnoreReturnValue
+  @Override
+  public Single<Event> appendEvent(Session session, Event event) {
+    return Single.fromCallable(
+        () -> {
+          Objects.requireNonNull(session, "session cannot be null");
+          Objects.requireNonNull(session.appName(), "session.appName cannot be null");
+          Objects.requireNonNull(session.userId(), "session.userId cannot be null");
+          Objects.requireNonNull(session.id(), "session.id cannot be null");
+          logger.info("appendEvent(S,E) - appending event to sessionId: {}", session.id());
+          String appName = session.appName();
+          String userId = session.userId();
+          String sessionId = session.id();
+
+          List<ApiFuture<WriteResult>> futures = new ArrayList<>();
+
+          // --- Update User/App State ---
+          EventActions actions = event.actions();
+          if (actions != null) {
+            Map<String, Object> stateDelta = actions.stateDelta();
+            if (stateDelta != null && !stateDelta.isEmpty()) {
+              AtomicBoolean sessionStateChanged = new AtomicBoolean(false);
+              Map<String, Object> appStateUpdates = new HashMap<>();
+              Map<String, Object> userStateUpdates = new HashMap<>();
+
+              stateDelta.forEach(
+                  (key, value) -> {
+                    if (key.startsWith("_app_")) {
+                      appStateUpdates.put(key.substring("_app_".length()), value);
+                    } else if (key.startsWith("_user_")) {
+                      userStateUpdates.put(key.substring("_user_".length()), value);
+                    } else {
+                      // Regular session state
+                      sessionStateChanged.set(true);
+                      if (value == null) {
+                        session.state().remove(key);
+                      } else {
+                        session.state().put(key, value);
+                      }
+                    }
+                  });
+
+              if (!appStateUpdates.isEmpty()) {
+                futures.add(
+                    firestore
+                        .collection(APP_STATE_COLLECTION)
+                        .document(appName)
+                        .set(appStateUpdates, com.google.cloud.firestore.SetOptions.merge()));
+              }
+              if (!userStateUpdates.isEmpty()) {
+                futures.add(
+                    firestore
+                        .collection(USER_STATE_COLLECTION)
+                        .document(appName)
+                        .collection("users")
+                        .document(userId)
+                        .set(userStateUpdates, com.google.cloud.firestore.SetOptions.merge()));
+              }
+
+              // Only update the session state if it actually changed.
+              if (sessionStateChanged.get()) {
+                futures.add(
+                    getSessionsCollection(userId)
+                        .document(sessionId)
+                        .update(STATE_KEY, session.state()));
+              }
+            }
+          }
+
+          // Manually add the event to the session's internal list.
+          session.events().add(event);
+          session.lastUpdateTime(getInstantFromEvent(event));
+
+          // --- Persist event to Firestore ---
+          Map<String, Object> eventData = eventToMap(session, event);
+          eventData.put(USER_ID_KEY, userId);
+          eventData.put(APP_NAME_KEY, appName);
+          // Generate a new ID for the event document
+          String eventId =
+              getSessionsCollection(userId)
+                  .document(sessionId)
+                  .collection(EVENTS_SUBCOLLECTION_NAME)
+                  .document()
+                  .getId();
+          futures.add(
+              getSessionsCollection(userId)
+                  .document(sessionId)
+                  .collection(EVENTS_SUBCOLLECTION_NAME)
+                  .document(eventId)
+                  .set(eventData));
+
+          // --- Update the session document in Firestore ---
+          Map<String, Object> sessionUpdates = new HashMap<>();
+          sessionUpdates.put(
+              UPDATE_TIME_KEY, session.lastUpdateTime().toString()); // Always update the timestamp
+          futures.add(getSessionsCollection(userId).document(sessionId).update(sessionUpdates));
+
+          // Block and wait for all async Firestore operations to complete.
+          // This makes the method effectively synchronous within the reactive chain,
+          // ensuring the database is consistent before the runner proceeds.
+          ApiFutures.allAsList(futures).get();
+
+          logger.info("Event appended successfully to sessionId: {}", sessionId);
+          logger.info("Returning appended event: {}", event.stringifyContent());
+
+          return event;
+        });
+  }
+
+  /** Converts an event's timestamp to an Instant. Adapt based on actual Event structure. */
+  private Instant getInstantFromEvent(Event event) {
+    // The event timestamp is in milliseconds since the epoch.
+    return Instant.ofEpochMilli(event.timestamp());
+  }
+
+  /**
+   * Safely casts an object to a specific type, logging a warning and returning null if the cast
+   * fails.
+   *
+   * @param obj The object to cast.
+   * @param clazz The target class to cast to.
+   * @param fieldName The name of the field being cast, for logging purposes.
+   * @return The casted object, or null if the object is not an instance of the target class.
+   * @param <T> The target type.
+   */
+  private <T> T safeCast(Object obj, Class<T> clazz, String fieldName) {
+    return safeCast(obj, clazz, fieldName, null);
+  }
+
+  /**
+   * Safely casts an object to a specific type, logging a warning and returning a default value if
+   * the cast fails.
+   *
+   * @param obj The object to cast.
+   * @param clazz The target class to cast to.
+   * @param fieldName The name of the field being cast, for logging purposes.
+   * @param defaultValue The value to return if the cast fails.
+   * @return The casted object, or the default value if the object is not an instance of the target
+   *     class.
+   * @param <T> The target type.
+   */
+  private <T> T safeCast(Object obj, Class<T> clazz, String fieldName, T defaultValue) {
+    if (obj == null) {
+      return defaultValue;
+    }
+    if (clazz.isInstance(obj)) {
+      return clazz.cast(obj);
+    }
+    logger.warn(
+        "Type mismatch for field '{}'. Expected {} but got {}. Returning default value.",
+        fieldName,
+        clazz.getName(),
+        obj.getClass().getName());
+    return defaultValue;
+  }
+}

--- a/contrib/firestore-session-service/src/main/java/com/google/adk/utils/ApiFutureUtils.java
+++ b/contrib/firestore-session-service/src/main/java/com/google/adk/utils/ApiFutureUtils.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.adk.utils;
+
+import com.google.api.core.ApiFuture;
+import com.google.api.core.ApiFutureCallback;
+import com.google.api.core.ApiFutures;
+import com.google.common.util.concurrent.MoreExecutors;
+import io.reactivex.rxjava3.core.Maybe;
+import io.reactivex.rxjava3.core.Single;
+import java.util.concurrent.Executor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** Utility class for converting ApiFuture to RxJava Single and Maybe types. */
+public class ApiFutureUtils {
+
+  /** Logger for this class. */
+  private static final Logger logger = LoggerFactory.getLogger(ApiFutureUtils.class);
+
+  // Executor for async operations. Package-private for testing.
+  static Executor executor = MoreExecutors.directExecutor();
+
+  private ApiFutureUtils() {}
+
+  /**
+   * Converts an ApiFuture to an RxJava Single.
+   *
+   * @param future the ApiFuture to convert
+   * @param <T> the type of the result
+   * @return a Single that emits the result of the ApiFuture
+   */
+  public static <T> Single<T> toSingle(ApiFuture<T> future) {
+    return Single.create(
+        emitter -> {
+          ApiFutures.addCallback(
+              future,
+              new ApiFutureCallback<T>() {
+                @Override
+                public void onSuccess(T result) {
+                  emitter.onSuccess(result);
+                }
+
+                @Override
+                public void onFailure(Throwable t) {
+                  // Log the failure of the future before passing it down the reactive chain.
+                  logger.error("ApiFuture failed with an exception.", t);
+                  emitter.onError(t);
+                }
+              },
+              executor);
+        });
+  }
+
+  /**
+   * Converts an ApiFuture to an RxJava Maybe.
+   *
+   * @param future the ApiFuture to convert
+   * @param <T> the type of the result
+   * @return a Maybe that emits the result of the ApiFuture or completes if the future fails
+   */
+  public static <T> Maybe<T> toMaybe(ApiFuture<T> future) {
+    return toSingle(future).toMaybe();
+  }
+}

--- a/contrib/firestore-session-service/src/main/java/com/google/adk/utils/Constants.java
+++ b/contrib/firestore-session-service/src/main/java/com/google/adk/utils/Constants.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.adk.utils;
+
+import java.util.Set;
+import java.util.regex.Pattern;
+
+/** Constants used across Firestore session service tests. */
+public class Constants {
+
+  /** user events collections */
+  public static final String EVENTS_SUBCOLLECTION_NAME = "user-event";
+
+  /** agent app state collection */
+  public static final String APP_STATE_COLLECTION = "app-state";
+
+  /** user state colection */
+  public static final String USER_STATE_COLLECTION = "user-state";
+
+  /** session collection name */
+  public static final String SESSION_COLLECTION_NAME = "sessions";
+
+  /** userId */
+  public static final String KEY_USER_ID = "userId";
+
+  /** appName */
+  public static final String KEY_APP_NAME = "appName";
+
+  /** timestamp */
+  public static final String KEY_TIMESTAMP = "timestamp";
+
+  /** state */
+  public static final String KEY_STATE = "state";
+
+  /** id */
+  public static final String KEY_ID = "id";
+
+  /** updateTime */
+  public static final String KEY_UPDATE_TIME = "updateTime";
+
+  /** user */
+  public static final String KEY_USER = "user";
+
+  /** model */
+  public static final String KEY_MODEL = "model";
+
+  /** author */
+  public static final String KEY_AUTHOR = "author";
+
+  /** Stop words for keyword extraction, loaded from properties. */
+  public static final Set<String> STOP_WORDS = FirestoreProperties.getInstance().getStopWords();
+
+  /** Pattern to match words for keyword extraction. */
+  public static final Pattern WORD_PATTERN = Pattern.compile("[A-Za-z]+");
+
+  /** root collection name fof firestore */
+  public static final String ROOT_COLLECTION_NAME =
+      FirestoreProperties.getInstance().getFirebaseRootCollectionName();
+
+  /** private constrctor */
+  private Constants() {
+    // Prevent instantiation.
+  }
+}

--- a/contrib/firestore-session-service/src/main/java/com/google/adk/utils/FirestoreProperties.java
+++ b/contrib/firestore-session-service/src/main/java/com/google/adk/utils/FirestoreProperties.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.adk.utils;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Properties;
+import java.util.Set;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Placeholder class to test that the FirestoreProperties file is correctly included in the test
+ * resources.
+ */
+public class FirestoreProperties {
+
+  /** Logger for this class. */
+  private static final Logger logger = LoggerFactory.getLogger(FirestoreProperties.class);
+
+  /** The default property file name. */
+  private static final String DEFAULT_PROPERTY_FILE_NAME = "adk-firestore.properties";
+
+  /** The template for the environment-specific property file name. */
+  private static final String ENV_PROPERTY_FILE_TEMPLATE = "adk-firestore-%s.properties";
+
+  private static volatile FirestoreProperties INSTANCE = new FirestoreProperties();
+
+  private final Properties properties;
+
+  private final String firebaseRootCollectionNameKey = "firebase.root.collection.name";
+  private final String firebaseRootCollectionDefaultValue = "adk-session";
+
+  private final String gcsAdkBucketNameKey = "gcs.adk.bucket.name";
+
+  private final String keywordExtractionStopWordsKey = "keyword.extraction.stopwords";
+
+  /** Default stop words for keyword extraction, used as a fallback. */
+  private final Set<String> DEFAULT_STOP_WORDS =
+      new HashSet<>(
+          Arrays.asList(
+              "a", "an", "and", "are", "as", "at", "be", "but", "by", "for", "if", "in", "into",
+              "is", "it", "i", "no", "not", "of", "on", "or", "such", "that", "the", "their",
+              "then", "there", "these", "they", "this", "to", "was", "will", "with", "what",
+              "where", "when", "why", "how", "help", "need", "like", "make", "got", "would",
+              "could", "should"));
+
+  /**
+   * Private constructor to initialize the properties by attempting to load the environment-specific
+   * file first, then falling back to the default.
+   */
+  private FirestoreProperties() {
+    this.properties = new Properties();
+    InputStream inputStream = null;
+
+    // 1. Check for the "env" environment variable
+    String env = System.getenv("env");
+    if (env != null && !env.trim().isEmpty()) {
+      String environmentSpecificFileName = String.format(ENV_PROPERTY_FILE_TEMPLATE, env);
+      inputStream = loadResourceAsStream(environmentSpecificFileName);
+    }
+
+    // 2. If the environment-specific file was not found, try the default
+    if (inputStream == null) {
+      inputStream = loadResourceAsStream(DEFAULT_PROPERTY_FILE_NAME);
+    }
+
+    // 3. Load the properties from the found input stream
+    if (inputStream != null) {
+      try {
+        this.properties.load(inputStream);
+      } catch (IOException e) {
+        logger.error("Failed to load properties file.", e);
+        throw new RuntimeException("Failed to load properties file.", e);
+      } finally {
+        try {
+          inputStream.close();
+        } catch (IOException e) {
+          // Log and ignore
+          logger.warn("Failed to close properties file input stream.", e);
+        }
+      }
+    }
+  }
+
+  /**
+   * Helper method to load a resource as a stream.
+   *
+   * @param resourceName the name of the resource to load
+   * @return an InputStream for the resource, or null if not found
+   */
+  private InputStream loadResourceAsStream(String resourceName) {
+    return FirestoreProperties.class.getClassLoader().getResourceAsStream(resourceName);
+  }
+
+  /**
+   * Functionality to read a property from the loaded properties file.
+   *
+   * @param key the property key
+   * @return the property value, or null if not found
+   */
+  public String getProperty(String key) {
+    return this.properties.getProperty(key);
+  }
+
+  /**
+   * Get the root collection name from the properties file, or return the default value if not
+   * found.
+   *
+   * @return the root collection name
+   */
+  public String getFirebaseRootCollectionName() {
+    return this.properties.getProperty(
+        firebaseRootCollectionNameKey, firebaseRootCollectionDefaultValue);
+  }
+
+  /**
+   * Get the stop words for keyword extraction from the properties file, or return the default set
+   * if not found.
+   *
+   * @return the set of stop words
+   */
+  public Set<String> getStopWords() {
+    String stopwordsProp = this.getProperty(keywordExtractionStopWordsKey);
+    if (stopwordsProp != null && !stopwordsProp.trim().isEmpty()) {
+      return new HashSet<>(Arrays.asList(stopwordsProp.split("\\s*,\\s*")));
+    }
+    // Fallback to the default hardcoded list if the property is not set
+    return DEFAULT_STOP_WORDS;
+  }
+
+  /**
+   * Get the GCS ADK bucket name from the properties file.
+   *
+   * @return the GCS ADK bucket name
+   */
+  public String getGcsAdkBucketName() {
+    return this.properties.getProperty(gcsAdkBucketNameKey);
+  }
+
+  /**
+   * Returns a singleton instance of FirestoreProperties.
+   *
+   * @return the FirestoreProperties instance
+   */
+  public static FirestoreProperties getInstance() {
+    if (INSTANCE == null) {
+
+      INSTANCE = new FirestoreProperties();
+    }
+    return INSTANCE;
+  }
+
+  /** Resets the singleton instance. For testing purposes only. */
+  public static void resetForTest() {
+    INSTANCE = null;
+  }
+}

--- a/contrib/firestore-session-service/src/test/java/com/google/adk/memory/FirestoreMemoryServiceTest.java
+++ b/contrib/firestore-session-service/src/test/java/com/google/adk/memory/FirestoreMemoryServiceTest.java
@@ -1,0 +1,217 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.adk.memory;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.when;
+
+import com.google.api.core.ApiFutures;
+import com.google.cloud.firestore.CollectionGroup;
+import com.google.cloud.firestore.Firestore;
+import com.google.cloud.firestore.Query;
+import com.google.cloud.firestore.QueryDocumentSnapshot;
+import com.google.cloud.firestore.QuerySnapshot;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.reactivex.rxjava3.observers.TestObserver;
+import java.time.Instant;
+import java.util.Collections;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/** Test for {@link FirestoreMemoryService}. */
+@ExtendWith(MockitoExtension.class)
+public class FirestoreMemoryServiceTest {
+
+  @Mock private Firestore mockDb;
+  @Mock private CollectionGroup mockCollectionGroup;
+  @Mock private Query mockQuery;
+  @Mock private QuerySnapshot mockQuerySnapshot;
+  @Mock private QueryDocumentSnapshot mockDoc1;
+
+  private FirestoreMemoryService memoryService;
+
+  /** Sets up the FirestoreMemoryService and common mock behaviors before each test. */
+  @BeforeEach
+  public void setup() {
+    memoryService = new FirestoreMemoryService(mockDb);
+
+    lenient().when(mockDb.collectionGroup(anyString())).thenReturn(mockCollectionGroup);
+    lenient().when(mockCollectionGroup.whereEqualTo(anyString(), any())).thenReturn(mockQuery);
+    lenient().when(mockQuery.whereEqualTo(anyString(), any())).thenReturn(mockQuery);
+    lenient().when(mockQuery.whereArrayContainsAny(anyString(), anyList())).thenReturn(mockQuery);
+    lenient().when(mockQuery.get()).thenReturn(ApiFutures.immediateFuture(mockQuerySnapshot));
+  }
+
+  /** Tests that searchMemory returns memory entries matching the search keywords. */
+  @Test
+  void searchMemory_withMatchingKeywords_returnsMemoryEntries() {
+    // Arrange
+    when(mockQuerySnapshot.getDocuments()).thenReturn(ImmutableList.of(mockDoc1));
+    when(mockDoc1.getId()).thenReturn("doc1");
+    when(mockDoc1.getData())
+        .thenReturn(
+            ImmutableMap.of(
+                "author", "test-user",
+                "timestamp", Instant.now().toString(),
+                "content",
+                    ImmutableMap.of(
+                        "parts",
+                        ImmutableList.of(ImmutableMap.of("text", "this is a test memory")))));
+
+    // Act
+    TestObserver<SearchMemoryResponse> testObserver =
+        memoryService.searchMemory("test-app", "test-user", "search for memory").test();
+
+    // Assert
+    testObserver.awaitCount(1);
+    testObserver.assertComplete();
+    testObserver.assertValue(
+        response -> {
+          assertThat(response.memories()).hasSize(1);
+          assertThat(response.memories().get(0).author()).isEqualTo("test-user");
+          return true;
+        });
+  }
+
+  /** Tests that searchMemory returns an empty response when no matching keywords are found. */
+  @Test
+  void searchMemory_withNoMatchingKeywords_returnsEmptyResponse() {
+    // Arrange
+    when(mockQuerySnapshot.getDocuments()).thenReturn(Collections.emptyList());
+
+    // Act
+    TestObserver<SearchMemoryResponse> testObserver =
+        memoryService.searchMemory("test-app", "test-user", "search for nothing").test();
+
+    // Assert
+    testObserver.awaitCount(1);
+    testObserver.assertComplete();
+    testObserver.assertValue(response -> response.memories().isEmpty());
+  }
+
+  /** Tests that searchMemory returns an empty response when the query is empty. */
+  @Test
+  void searchMemory_withEmptyQuery_returnsEmptyResponse() {
+    // Act
+    TestObserver<SearchMemoryResponse> testObserver =
+        memoryService.searchMemory("test-app", "test-user", "").test();
+
+    // Assert
+    testObserver.awaitCount(1);
+    testObserver.assertComplete();
+    testObserver.assertValue(response -> response.memories().isEmpty());
+  }
+
+  /** Tests that searchMemory handles malformed document data gracefully. */
+  @Test
+  void searchMemory_withMalformedDoc_returnsEmptyMemories() {
+    // Arrange
+    when(mockQuerySnapshot.getDocuments()).thenReturn(ImmutableList.of(mockDoc1));
+    when(mockDoc1.getId()).thenReturn("doc1");
+    when(mockDoc1.getData()).thenReturn(ImmutableMap.of("author", "test-user")); // Missing fields
+
+    // Act
+    TestObserver<SearchMemoryResponse> testObserver =
+        memoryService.searchMemory("test-app", "test-user", "search for memory").test();
+
+    // Assert
+    testObserver.awaitCount(1);
+    testObserver.assertComplete();
+    testObserver.assertValue(response -> response.memories().isEmpty());
+  }
+
+  /** Tests that searchMemory handles documents with no data gracefully. */
+  @Test
+  void searchMemory_withDocWithNoData_returnsEmptyMemories() {
+    // Arrange
+    when(mockQuerySnapshot.getDocuments()).thenReturn(ImmutableList.of(mockDoc1));
+    when(mockDoc1.getId()).thenReturn("doc1");
+    when(mockDoc1.getData()).thenReturn(null);
+
+    // Act
+    TestObserver<SearchMemoryResponse> testObserver =
+        memoryService.searchMemory("test-app", "test-user", "search for memory").test();
+
+    // Assert
+    testObserver.awaitCount(1);
+    testObserver.assertComplete();
+    testObserver.assertValue(response -> response.memories().isEmpty());
+  }
+
+  /** Tests that searchMemory handles documents with no content parts gracefully. */
+  @Test
+  void searchMemory_withDocWithNoParts_returnsMemoryWithEmptyContent() {
+    // Arrange
+    when(mockQuerySnapshot.getDocuments()).thenReturn(ImmutableList.of(mockDoc1));
+    when(mockDoc1.getId()).thenReturn("doc1");
+
+    Map<String, Object> contentMap = new java.util.HashMap<>();
+    contentMap.put("parts", null); // Explicitly set parts to null
+    Map<String, Object> docData = new java.util.HashMap<>();
+    docData.put("author", "test-user");
+    docData.put("timestamp", Instant.now().toString());
+    docData.put("content", contentMap);
+    when(mockDoc1.getData()).thenReturn(docData);
+
+    // Act
+    TestObserver<SearchMemoryResponse> testObserver =
+        memoryService.searchMemory("test-app", "test-user", "search for memory").test();
+
+    // Assert
+    testObserver.awaitCount(1);
+    testObserver.assertComplete();
+    testObserver.assertValue(
+        response -> {
+          assertThat(response.memories()).hasSize(1);
+          assertThat(response.memories().get(0).content().parts().get().isEmpty());
+          return true;
+        });
+  }
+
+  /** Tests that searchMemory handles documents with non-text content parts gracefully. */
+  @Test
+  void searchMemory_withDocWithNonTextPart_returnsMemoryWithEmptyContent() {
+    // Arrange
+    when(mockQuerySnapshot.getDocuments()).thenReturn(ImmutableList.of(mockDoc1));
+    when(mockDoc1.getId()).thenReturn("doc1");
+    when(mockDoc1.getData())
+        .thenReturn(
+            ImmutableMap.of(
+                "author", "test-user",
+                "timestamp", Instant.now().toString(),
+                "content", ImmutableMap.of("parts", ImmutableList.of(ImmutableMap.of()))));
+
+    // Act
+    TestObserver<SearchMemoryResponse> testObserver =
+        memoryService.searchMemory("test-app", "test-user", "search for memory").test();
+
+    // Assert
+    testObserver.awaitCount(1);
+    testObserver.assertComplete();
+    testObserver.assertValue(
+        response -> response.memories().get(0).content().parts().get().isEmpty());
+  }
+}

--- a/contrib/firestore-session-service/src/test/java/com/google/adk/runner/FirestoreDatabaseRunnerTest.java
+++ b/contrib/firestore-session-service/src/test/java/com/google/adk/runner/FirestoreDatabaseRunnerTest.java
@@ -1,0 +1,250 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.adk.runner;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.adk.agents.BaseAgent;
+import com.google.adk.agents.InvocationContext;
+import com.google.adk.agents.RunConfig;
+import com.google.adk.events.Event;
+import com.google.adk.plugins.BasePlugin;
+import com.google.adk.sessions.Session;
+import com.google.adk.utils.FirestoreProperties;
+import com.google.api.core.ApiFutures;
+import com.google.cloud.firestore.CollectionReference;
+import com.google.cloud.firestore.DocumentReference;
+import com.google.cloud.firestore.DocumentSnapshot;
+import com.google.cloud.firestore.Firestore;
+import com.google.cloud.firestore.Query;
+import com.google.cloud.firestore.QuerySnapshot;
+import com.google.cloud.firestore.WriteResult;
+import com.google.genai.types.Content;
+import com.google.genai.types.Part;
+import io.reactivex.rxjava3.core.Flowable;
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Map;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/** Test class for {@link FirestoreDatabaseRunner} tests. */
+@ExtendWith(MockitoExtension.class)
+public class FirestoreDatabaseRunnerTest {
+
+  private static final String ENV_PROPERTY_NAME = "env"; // Renamed for clarity
+
+  @BeforeEach
+  public void setup() throws Exception {
+    // Reset properties before each test to ensure isolation
+    FirestoreProperties.resetForTest();
+  }
+
+  @Mock private BaseAgent mockAgent;
+  @Mock private Firestore mockFirestore;
+  // Mocks for the FirestoreSessionService that will be created internally
+  @Mock private CollectionReference mockRootCollection;
+  @Mock private DocumentReference mockUserDocRef;
+  @Mock private CollectionReference mockSessionsCollection;
+  @Mock private DocumentReference mockSessionDocRef;
+  @Mock private DocumentSnapshot mockSessionSnapshot;
+  // Mocks for state updates
+  @Mock private CollectionReference mockAppStateCollection;
+  @Mock private DocumentReference mockAppStateDocRef;
+  @Mock private CollectionReference mockUserStateRootCollection;
+  @Mock private DocumentReference mockUserStateAppDocRef;
+  @Mock private CollectionReference mockUserStateUsersCollection;
+  @Mock private DocumentReference mockUserStateUserDocRef;
+  @Mock private CollectionReference mockEventsCollection;
+  @Mock private DocumentReference mockEventDocRef;
+  @Mock private Query mockQuery;
+  @Mock private QuerySnapshot mockQuerySnapshot;
+  @Mock private WriteResult mockWriteResult;
+
+  /**
+   * Tests that the constructor succeeds when the required properties are set.
+   *
+   * @throws Exception
+   */
+  @Test
+  void constructor_succeeds() throws Exception {
+    // Ensure the required property is set for the success case
+    System.setProperty(ENV_PROPERTY_NAME, "default"); // Loads adk-firestore.properties
+    Mockito.when(mockAgent.name()).thenReturn("test-agent");
+
+    FirestoreDatabaseRunner runner = new FirestoreDatabaseRunner(mockAgent, mockFirestore);
+    assertNotNull(runner);
+  }
+
+  /**
+   * Tests that the constructor throws an exception when the GCS bucket name property is missing.
+   *
+   * @throws Exception
+   */
+  @Test
+  void constructor_withAppName_throwsExceptionWhenBucketNameIsMissing() {
+    assertThrows(
+        RuntimeException.class,
+        () -> {
+          // Arrange: Use mockito-inline to mock the static method call.
+          try (MockedStatic<FirestoreProperties> mockedProps =
+              Mockito.mockStatic(FirestoreProperties.class)) {
+            FirestoreProperties mockPropsInstance = mock(FirestoreProperties.class);
+            mockedProps.when(FirestoreProperties::getInstance).thenReturn(mockPropsInstance);
+            when(mockPropsInstance.getGcsAdkBucketName()).thenReturn(" "); // Empty string
+
+            // Act
+            new FirestoreDatabaseRunner(
+                mockAgent, "test-app", new ArrayList<BasePlugin>(), mockFirestore);
+          }
+        });
+  }
+
+  /**
+   * Tests that the constructor throws an exception when the GCS bucket name is null.
+   *
+   * @throws Exception
+   */
+  @Test
+  void constructor_throwsExceptionWhenBucketNameIsNull() {
+    assertThrows(
+        RuntimeException.class,
+        () -> {
+          // Arrange: Use mockito-inline to mock the static method call.
+          try (MockedStatic<FirestoreProperties> mockedProps =
+              Mockito.mockStatic(FirestoreProperties.class)) {
+            FirestoreProperties mockPropsInstance = mock(FirestoreProperties.class);
+            mockedProps.when(FirestoreProperties::getInstance).thenReturn(mockPropsInstance);
+            when(mockPropsInstance.getGcsAdkBucketName())
+                .thenReturn(null); // Explicitly return null for bucketName
+            // Act
+            new FirestoreDatabaseRunner(mockAgent, mockFirestore);
+          }
+        });
+  }
+
+  /**
+   * Tests that run with user input creates a session and executes the agent.
+   *
+   * @throws Exception
+   */
+  @Test
+  void run_withUserInput_createsSessionAndExecutesAgent() throws Exception {
+    // Arrange
+    System.setProperty(ENV_PROPERTY_NAME, "default"); // Ensure properties are loaded
+    when(mockAgent.name()).thenReturn("test-agent");
+
+    // Mock user input
+    String userInput = "hello\nexit\n";
+    InputStream originalIn = System.in;
+    System.setIn(new ByteArrayInputStream(userInput.getBytes()));
+
+    // Mock the Firestore calls that SessionService will make
+    when(mockFirestore.collection("default-adk-session")).thenReturn(mockRootCollection);
+    when(mockRootCollection.document(anyString())).thenReturn(mockUserDocRef);
+    when(mockUserDocRef.collection(anyString())).thenReturn(mockSessionsCollection);
+    when(mockSessionsCollection.document(anyString())).thenReturn(mockSessionDocRef);
+
+    when(mockSessionDocRef.set(anyMap())).thenReturn(ApiFutures.immediateFuture(mockWriteResult));
+    when(mockSessionDocRef.update(anyMap()))
+        .thenReturn(ApiFutures.immediateFuture(mockWriteResult));
+    // Mock the event sub-collection chain
+    when(mockSessionDocRef.collection(anyString())).thenReturn(mockEventsCollection);
+    // THIS IS THE MISSING MOCK: Stub the no-arg document() call for ID generation.
+    when(mockEventsCollection.document()).thenReturn(mockEventDocRef);
+    when(mockEventDocRef.getId()).thenReturn("test-event-id");
+    when(mockEventsCollection.document(anyString())).thenReturn(mockEventDocRef);
+    when(mockEventDocRef.set(anyMap())).thenReturn(ApiFutures.immediateFuture(mockWriteResult));
+    // THIS IS THE MISSING MOCK: Stub the get() call on the session document.
+    when(mockSessionDocRef.get()).thenReturn(ApiFutures.immediateFuture(mockSessionSnapshot));
+    when(mockSessionSnapshot.exists()).thenReturn(true);
+    // Provide a complete map for the session data
+    when(mockSessionSnapshot.getData())
+        .thenReturn(
+            Map.of(
+                "id", "test-session-id",
+                "appName", "test-app",
+                "userId", "test-user-id",
+                "updateTime", Instant.now().toString(),
+                "state", Map.of()));
+    when(mockSessionSnapshot.getReference()).thenReturn(mockSessionDocRef);
+    // THIS IS THE MISSING MOCK: Stub the orderBy() call on the events collection.
+    when(mockEventsCollection.orderBy(anyString())).thenReturn(mockQuery);
+    when(mockQuery.get()).thenReturn(ApiFutures.immediateFuture(mockQuerySnapshot));
+
+    // Mock Agent behavior
+    Event mockAgentEvent =
+        Event.builder()
+            .content(Content.builder().parts(Part.fromText("Hi there!")).build())
+            .author(mockAgent.name())
+            .build();
+    when(mockAgent.runAsync(any(InvocationContext.class)))
+        .thenReturn(Flowable.just(mockAgentEvent));
+
+    // Create runner, which will internally create a FirestoreSessionService
+    // using our mocked Firestore object.
+    FirestoreDatabaseRunner runner =
+        new FirestoreDatabaseRunner(mockAgent, "test-app", mockFirestore);
+
+    // Act
+    // First, create a session to get a valid session ID
+    Session session =
+        runner.sessionService().createSession("test-app", "test-user-id").blockingGet();
+    // Now, run the agent with the user input
+    Content userContent = Content.builder().parts(Part.fromText("hello")).build();
+    runner
+        .runAsync(session.userId(), session.id(), userContent, RunConfig.builder().build())
+        .blockingSubscribe(); // block until the flow completes
+
+    // Assert
+    ArgumentCaptor<InvocationContext> contextCaptor =
+        ArgumentCaptor.forClass(InvocationContext.class);
+    verify(mockAgent).runAsync(contextCaptor.capture());
+    assertNotNull(contextCaptor.getValue().userContent().get().parts().get().get(0).text());
+
+    // Restore original System.in
+    System.setIn(originalIn);
+  }
+
+  /**
+   * Cleans up after each test.
+   *
+   * @throws Exception
+   */
+  @AfterEach
+  public void teardown() throws Exception {
+    // Clean up the environment variable after each test
+    FirestoreProperties.resetForTest(); // Reset the singleton instance
+    System.clearProperty(ENV_PROPERTY_NAME); // Clear the system property
+  }
+}

--- a/contrib/firestore-session-service/src/test/java/com/google/adk/sessions/FirestoreSessionServiceTest.java
+++ b/contrib/firestore-session-service/src/test/java/com/google/adk/sessions/FirestoreSessionServiceTest.java
@@ -1,0 +1,1003 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.adk.sessions;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.adk.events.Event;
+import com.google.adk.events.EventActions;
+import com.google.adk.utils.Constants;
+import com.google.api.core.ApiFutures;
+import com.google.cloud.firestore.CollectionReference;
+import com.google.cloud.firestore.DocumentReference;
+import com.google.cloud.firestore.DocumentSnapshot;
+import com.google.cloud.firestore.Firestore;
+import com.google.cloud.firestore.Query;
+import com.google.cloud.firestore.QueryDocumentSnapshot;
+import com.google.cloud.firestore.QuerySnapshot;
+import com.google.cloud.firestore.SetOptions;
+import com.google.cloud.firestore.WriteBatch;
+import com.google.cloud.firestore.WriteResult;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.genai.types.Content;
+import com.google.genai.types.Part;
+import io.reactivex.rxjava3.observers.TestObserver;
+import java.time.Instant;
+import java.util.AbstractMap;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/** Test class for {@link FirestoreSessionService}. */
+@ExtendWith(MockitoExtension.class)
+public class FirestoreSessionServiceTest {
+
+  // Constants for easier testing
+  private static final String APP_NAME = "test-app";
+  private static final String USER_ID = "test-user-id";
+  private static final String SESSION_ID = "test-session-id";
+  private static final String EVENT_ID = "test-event-id";
+  private static final Instant NOW = Instant.now();
+
+  @Mock private Firestore mockDb;
+  @Mock private CollectionReference mockRootCollection;
+  @Mock private CollectionReference mockSessionsCollection;
+  @Mock private CollectionReference mockEventsCollection;
+  @Mock private CollectionReference mockAppStateCollection;
+  @Mock private CollectionReference mockUserStateRootCollection;
+  @Mock private CollectionReference mockUserStateUsersCollection;
+  @Mock private DocumentReference mockUserDocRef;
+  @Mock private DocumentReference mockSessionDocRef;
+  @Mock private DocumentReference mockEventDocRef;
+  @Mock private DocumentReference mockAppStateDocRef;
+  @Mock private DocumentReference mockUserStateAppDocRef;
+  @Mock private DocumentReference mockUserStateUserDocRef;
+  @Mock private DocumentSnapshot mockSessionSnapshot;
+  @Mock private QueryDocumentSnapshot mockEventSnapshot;
+  @Mock private Query mockQuery;
+  @Mock private QuerySnapshot mockQuerySnapshot;
+  @Mock private WriteResult mockWriteResult;
+  @Mock private WriteBatch mockWriteBatch;
+
+  private FirestoreSessionService sessionService;
+
+  /** Sets up the FirestoreSessionService and common mock behaviors before each test. */
+  @BeforeEach
+  public void setup() {
+    sessionService = new FirestoreSessionService(mockDb);
+
+    // Mock the chain of calls for session and event retrieval
+    lenient()
+        .when(mockDb.collection(Constants.ROOT_COLLECTION_NAME))
+        .thenReturn(mockRootCollection);
+    lenient().when(mockRootCollection.document(USER_ID)).thenReturn(mockUserDocRef);
+    lenient()
+        .when(mockUserDocRef.collection(Constants.SESSION_COLLECTION_NAME))
+        .thenReturn(mockSessionsCollection);
+    lenient()
+        .when(mockSessionDocRef.collection(Constants.EVENTS_SUBCOLLECTION_NAME))
+        .thenReturn(mockEventsCollection);
+    lenient().when(mockEventsCollection.orderBy(Constants.KEY_TIMESTAMP)).thenReturn(mockQuery);
+
+    // Mock state collections with distinct mocks for each collection
+    lenient()
+        .when(mockDb.collection(Constants.APP_STATE_COLLECTION))
+        .thenReturn(mockAppStateCollection);
+    lenient().when(mockAppStateCollection.document(APP_NAME)).thenReturn(mockAppStateDocRef);
+    lenient()
+        .when(mockDb.collection(Constants.USER_STATE_COLLECTION))
+        .thenReturn(mockUserStateRootCollection);
+    lenient()
+        .when(mockUserStateRootCollection.document(APP_NAME))
+        .thenReturn(mockUserStateAppDocRef);
+    lenient()
+        .when(mockUserStateAppDocRef.collection("users"))
+        .thenReturn(mockUserStateUsersCollection);
+    lenient()
+        .when(mockUserStateUsersCollection.document(USER_ID))
+        .thenReturn(mockUserStateUserDocRef);
+
+    // Default mock for writes
+    lenient()
+        .when(mockSessionDocRef.set(anyMap()))
+        .thenReturn(ApiFutures.immediateFuture(mockWriteResult));
+    lenient()
+        .when(mockSessionDocRef.update(anyMap()))
+        .thenReturn(ApiFutures.immediateFuture(mockWriteResult));
+    lenient()
+        .when(mockSessionDocRef.update(anyString(), any()))
+        .thenReturn(ApiFutures.immediateFuture(mockWriteResult));
+    lenient()
+        .when(mockSessionDocRef.delete())
+        .thenReturn(ApiFutures.immediateFuture(mockWriteResult));
+    lenient()
+        .when(mockEventDocRef.set(anyMap()))
+        .thenReturn(ApiFutures.immediateFuture(mockWriteResult));
+    lenient()
+        .when(mockAppStateDocRef.set(anyMap(), any(SetOptions.class)))
+        .thenReturn(ApiFutures.immediateFuture(mockWriteResult));
+    lenient()
+        .when(mockUserStateUserDocRef.set(anyMap(), any(SetOptions.class)))
+        .thenReturn(ApiFutures.immediateFuture(mockWriteResult));
+
+    // Mock for batch operations in deleteSession
+    lenient().when(mockDb.batch()).thenReturn(mockWriteBatch);
+    lenient()
+        .when(mockWriteBatch.commit())
+        .thenReturn(ApiFutures.immediateFuture(ImmutableList.of(mockWriteResult)));
+  }
+
+  /** Tests that getSession returns the expected Session when it exists in Firestore. */
+  @Test
+  void getSession_sessionExists_returnsSession() {
+    // Arrange
+    when(mockSessionsCollection.document(SESSION_ID)).thenReturn(mockSessionDocRef);
+    when(mockSessionDocRef.get()).thenReturn(ApiFutures.immediateFuture(mockSessionSnapshot));
+    when(mockSessionSnapshot.exists()).thenReturn(true);
+    when(mockSessionSnapshot.getReference()).thenReturn(mockSessionDocRef);
+    when(mockSessionSnapshot.getData())
+        .thenReturn(
+            ImmutableMap.of(
+                "id",
+                SESSION_ID,
+                "appName",
+                APP_NAME,
+                "userId",
+                USER_ID,
+                "updateTime",
+                NOW.toString(),
+                "state",
+                Collections.emptyMap()));
+    when(mockQuery.get()).thenReturn(ApiFutures.immediateFuture(mockQuerySnapshot));
+    when(mockQuerySnapshot.getDocuments()).thenReturn(Collections.emptyList());
+
+    // Act
+    TestObserver<Session> testObserver =
+        sessionService.getSession(APP_NAME, USER_ID, SESSION_ID, Optional.empty()).test();
+
+    // Assert
+    testObserver.awaitCount(1);
+    testObserver.assertNoErrors();
+    testObserver.assertValue(
+        session -> {
+          assertThat(session.id()).isEqualTo(SESSION_ID);
+          assertThat(session.userId()).isEqualTo(USER_ID);
+          return true;
+        });
+  }
+
+  /** Tests that getSession emits an error when the session does not exist. */
+  @Test
+  void getSession_sessionDoesNotExist_emitsError() {
+    // Arrange
+    when(mockSessionsCollection.document(SESSION_ID)).thenReturn(mockSessionDocRef);
+    when(mockSessionDocRef.get()).thenReturn(ApiFutures.immediateFuture(mockSessionSnapshot));
+    when(mockSessionSnapshot.exists()).thenReturn(false);
+
+    // Act
+    TestObserver<Session> testObserver =
+        sessionService.getSession(APP_NAME, USER_ID, SESSION_ID, Optional.empty()).test();
+
+    // Assert
+    testObserver.assertError(SessionNotFoundException.class);
+  }
+
+  /** Tests that getSession returns Maybe.empty() when the session exists but has null data. */
+  @Test
+  void getSession_sessionExistsWithNullData_returnsEmpty() {
+    // Arrange
+    when(mockSessionsCollection.document(SESSION_ID)).thenReturn(mockSessionDocRef);
+    when(mockSessionDocRef.get()).thenReturn(ApiFutures.immediateFuture(mockSessionSnapshot));
+    when(mockSessionSnapshot.exists()).thenReturn(true);
+    when(mockSessionSnapshot.getData()).thenReturn(null);
+
+    // Act
+    TestObserver<Session> testObserver =
+        sessionService.getSession(APP_NAME, USER_ID, SESSION_ID, Optional.empty()).test();
+
+    // Assert
+    testObserver.assertNoErrors();
+    testObserver.assertComplete();
+    testObserver.assertNoValues();
+  }
+
+  /** Tests that getSession returns Maybe.empty() when the session exists but has empty data. */
+  @Test
+  void getSession_withNumRecentEvents_appliesLimitToQuery() {
+    // Arrange
+    int numEvents = 5;
+    GetSessionConfig config = GetSessionConfig.builder().numRecentEvents(numEvents).build();
+
+    when(mockSessionsCollection.document(SESSION_ID)).thenReturn(mockSessionDocRef);
+    when(mockSessionDocRef.get()).thenReturn(ApiFutures.immediateFuture(mockSessionSnapshot));
+    when(mockSessionSnapshot.exists()).thenReturn(true);
+    when(mockSessionSnapshot.getReference()).thenReturn(mockSessionDocRef);
+    when(mockSessionSnapshot.getData())
+        .thenReturn(
+            ImmutableMap.of(
+                "id", SESSION_ID,
+                "appName", APP_NAME,
+                "userId", USER_ID,
+                "updateTime", NOW.toString(),
+                "state", Collections.emptyMap()));
+    when(mockQuery.limitToLast(numEvents)).thenReturn(mockQuery); // Mock the limit call
+    when(mockQuery.get()).thenReturn(ApiFutures.immediateFuture(mockQuerySnapshot));
+    when(mockQuerySnapshot.getDocuments()).thenReturn(Collections.emptyList());
+
+    // Act
+    sessionService.getSession(APP_NAME, USER_ID, SESSION_ID, Optional.of(config)).test();
+
+    // Assert
+    verify(mockQuery).limitToLast(numEvents);
+  }
+
+  /** Tests that getSession applies the afterTimestamp filter to the events query when specified. */
+  @Test
+  void getSession_withAfterTimestamp_appliesFilterToQuery() {
+    // Arrange
+    Instant timestamp = Instant.now().minusSeconds(60);
+    GetSessionConfig config = GetSessionConfig.builder().afterTimestamp(timestamp).build();
+
+    when(mockSessionsCollection.document(SESSION_ID)).thenReturn(mockSessionDocRef);
+    when(mockSessionDocRef.get()).thenReturn(ApiFutures.immediateFuture(mockSessionSnapshot));
+    when(mockSessionSnapshot.exists()).thenReturn(true);
+    when(mockSessionSnapshot.getReference()).thenReturn(mockSessionDocRef);
+    when(mockSessionSnapshot.getData()).thenReturn(ImmutableMap.of("state", Map.of()));
+    when(mockQuery.whereGreaterThan(Constants.KEY_TIMESTAMP, timestamp.toString()))
+        .thenReturn(mockQuery);
+    when(mockQuery.get()).thenReturn(ApiFutures.immediateFuture(mockQuerySnapshot));
+
+    // Act
+    sessionService.getSession(APP_NAME, USER_ID, SESSION_ID, Optional.of(config)).test();
+
+    // Assert
+    verify(mockQuery).whereGreaterThan(Constants.KEY_TIMESTAMP, timestamp.toString());
+  }
+
+  // --- createSession Tests ---
+
+  /** Tests that createSession creates a new session with the specified session ID. */
+  @Test
+  void createSession_withSessionId_returnsNewSession() {
+    // Arrange
+    when(mockSessionsCollection.document(SESSION_ID)).thenReturn(mockSessionDocRef);
+    // Act
+    TestObserver<Session> testObserver =
+        sessionService
+            .createSession(APP_NAME, USER_ID, new ConcurrentHashMap<>(), SESSION_ID)
+            .test();
+
+    // Assert
+    testObserver.awaitCount(1);
+    testObserver.assertComplete();
+    testObserver.assertValue(
+        session -> {
+          assertThat(session.id()).isEqualTo(SESSION_ID);
+          return true;
+        });
+    verify(mockSessionDocRef).set(anyMap());
+  }
+
+  /** Tests that createSession creates a new session with a generated session ID. */
+  @Test
+  void createSession_withNullSessionId_generatesNewId() {
+    // Arrange
+    // Capture the dynamically generated session ID
+    ArgumentCaptor<String> sessionIdCaptor = ArgumentCaptor.forClass(String.class);
+    when(mockSessionsCollection.document(sessionIdCaptor.capture())).thenReturn(mockSessionDocRef);
+
+    // Act
+    TestObserver<Session> testObserver =
+        sessionService.createSession(APP_NAME, USER_ID, new ConcurrentHashMap<>(), null).test();
+
+    // Assert
+    testObserver.awaitCount(1);
+    testObserver.assertComplete();
+    testObserver.assertValue(
+        session -> {
+          // Check that the returned session has the same ID that was generated
+          assertThat(session.id()).isEqualTo(sessionIdCaptor.getValue());
+          // Check that the generated ID looks like a UUID
+          assertThat(session.id()).isNotNull();
+          assertThat(session.id()).isNotEmpty();
+          return true;
+        });
+    verify(mockSessionDocRef).set(anyMap());
+  }
+
+  /** Tests that createSession creates a new session with an empty session ID. */
+  @Test
+  void createSession_withEmptySessionId_generatesNewId() {
+    // Arrange
+    ArgumentCaptor<String> sessionIdCaptor = ArgumentCaptor.forClass(String.class);
+    when(mockSessionsCollection.document(sessionIdCaptor.capture())).thenReturn(mockSessionDocRef);
+
+    // Act
+    TestObserver<Session> testObserver =
+        sessionService.createSession(APP_NAME, USER_ID, new ConcurrentHashMap<>(), "  ").test();
+
+    // Assert
+    testObserver.awaitCount(1);
+    testObserver.assertComplete();
+    testObserver.assertValue(
+        session -> {
+          assertThat(session.id()).isNotNull();
+          assertThat(session.id()).isNotEmpty();
+          assertThat(session.id()).isNotEqualTo("  ");
+          return true;
+        });
+    verify(mockSessionDocRef).set(anyMap());
+  }
+
+  /** Tests that createSession creates a new session with an empty state when null state is */
+  @Test
+  void createSession_withNullState_createsSessionWithEmptyState() {
+    // Arrange
+    when(mockSessionsCollection.document(SESSION_ID)).thenReturn(mockSessionDocRef);
+
+    // Act
+    TestObserver<Session> testObserver =
+        sessionService.createSession(APP_NAME, USER_ID, null, SESSION_ID).test();
+
+    // Assert
+    testObserver.awaitCount(1);
+    testObserver.assertComplete();
+    testObserver.assertValue(
+        session -> {
+          assertThat(session.state()).isNotNull();
+          assertThat(session.state()).isEmpty();
+          return true;
+        });
+  }
+
+  /** Tests that createSession throws NullPointerException when appName is null. */
+  @Test
+  void createSession_withNullAppName_throwsNullPointerException() {
+    sessionService
+        .createSession(null, USER_ID, null, SESSION_ID)
+        .test()
+        .assertError(NullPointerException.class);
+  }
+
+  // --- appendEvent Tests ---
+  /** Tests that appendEvent persists the event and updates the session's updateTime. */
+  @Test
+  @SuppressWarnings("unchecked")
+  void appendEvent_persistsEventAndUpdatesSession() {
+    // Arrange
+    Session session =
+        Session.builder(SESSION_ID)
+            .appName(APP_NAME)
+            .userId(USER_ID)
+            .state(new ConcurrentHashMap<>())
+            .build();
+    Event event =
+        Event.builder()
+            .author(Constants.KEY_USER)
+            .content(Content.builder().parts(List.of(Part.fromText("hello world"))).build())
+            .build();
+    when(mockSessionsCollection.document(SESSION_ID)).thenReturn(mockSessionDocRef);
+    when(mockEventsCollection.document()).thenReturn(mockEventDocRef);
+    when(mockEventDocRef.getId()).thenReturn(EVENT_ID);
+    when(mockEventsCollection.document(EVENT_ID)).thenReturn(mockEventDocRef);
+    // Add the missing mock for the final session update call
+    when(mockSessionDocRef.update(anyMap()))
+        .thenReturn(ApiFutures.immediateFuture(mockWriteResult));
+
+    // Act
+    TestObserver<Event> testObserver = sessionService.appendEvent(session, event).test();
+
+    // Assert
+    testObserver.awaitCount(1);
+    testObserver.assertComplete();
+    testObserver.assertValue(event);
+
+    ArgumentCaptor<Map<String, Object>> eventCaptor = ArgumentCaptor.forClass(Map.class);
+    verify(mockEventDocRef).set(eventCaptor.capture());
+    assertThat(eventCaptor.getValue()).containsEntry(Constants.KEY_AUTHOR, USER_ID);
+    List<String> keywords = (List<String>) eventCaptor.getValue().get("keywords");
+    assertThat(keywords).containsExactly("hello", "world");
+  }
+
+  /** Tests that appendAndGet correctly serializes and deserializes events with all part types. */
+  @Test
+  void appendAndGet_withAllPartTypes_serializesAndDeserializesCorrectly() {
+    // ARRANGE (Serialization part)
+    Session session =
+        Session.builder(SESSION_ID)
+            .appName(APP_NAME)
+            .userId(USER_ID)
+            .state(new ConcurrentHashMap<>())
+            .build();
+
+    Event complexEvent =
+        Event.builder()
+            .author("model")
+            .content(
+                Content.builder()
+                    .parts(
+                        ImmutableList.of(
+                            Part.fromText("Here are the results."),
+                            Part.fromFunctionCall("search_tool", ImmutableMap.of("query", "genai")),
+                            Part.fromFunctionResponse(
+                                "search_tool", ImmutableMap.of("result", "Google AI")),
+                            Part.fromUri("gs://bucket/file.png", "image/png")))
+                    .build())
+            .build();
+
+    when(mockSessionsCollection.document(SESSION_ID)).thenReturn(mockSessionDocRef);
+    when(mockEventsCollection.document()).thenReturn(mockEventDocRef);
+    when(mockEventDocRef.getId()).thenReturn(EVENT_ID);
+    when(mockEventsCollection.document(EVENT_ID)).thenReturn(mockEventDocRef);
+    when(mockSessionDocRef.update(anyMap()))
+        .thenReturn(ApiFutures.immediateFuture(mockWriteResult));
+
+    // ACT (Serialization part)
+    sessionService.appendEvent(session, complexEvent).test().assertComplete();
+
+    when(mockSessionSnapshot.getData())
+        .thenReturn(
+            ImmutableMap.of(
+                "id", SESSION_ID,
+                "appName", APP_NAME,
+                "userId", USER_ID,
+                "updateTime", NOW.toString(),
+                "state", session.state())); // Use the session's state after appendEvent
+
+    // ARRANGE (Deserialization part)
+    ArgumentCaptor<Map<String, Object>> eventDataCaptor = ArgumentCaptor.forClass(Map.class);
+    verify(mockEventDocRef).set(eventDataCaptor.capture());
+    Map<String, Object> savedEventData = eventDataCaptor.getValue();
+
+    QueryDocumentSnapshot mockComplexEventSnapshot = mock(QueryDocumentSnapshot.class);
+    when(mockComplexEventSnapshot.getData()).thenReturn(savedEventData);
+
+    // Set up mocks for the getSession call right before it's used.
+    when(mockQuerySnapshot.getDocuments()).thenReturn(ImmutableList.of(mockComplexEventSnapshot));
+    when(mockSessionSnapshot.exists()).thenReturn(true); // This was the missing mock
+    when(mockSessionSnapshot.getReference()).thenReturn(mockSessionDocRef); // This is the fix
+    when(mockSessionDocRef.get()).thenReturn(ApiFutures.immediateFuture(mockSessionSnapshot));
+    when(mockEventsCollection.orderBy(Constants.KEY_TIMESTAMP)).thenReturn(mockQuery);
+    when(mockQuery.get()).thenReturn(ApiFutures.immediateFuture(mockQuerySnapshot));
+
+    // ACT & ASSERT (Deserialization part)
+    TestObserver<Session> testObserver =
+        sessionService.getSession(APP_NAME, USER_ID, SESSION_ID, Optional.empty()).test();
+    testObserver.awaitCount(1);
+    testObserver.assertNoErrors();
+    testObserver.assertValue(
+        retrievedSession -> {
+          assertThat(retrievedSession.events()).hasSize(1);
+          Event retrievedEvent = retrievedSession.events().get(0);
+
+          assertThat(retrievedEvent.content().get().parts().get().get(0).text().get())
+              .isEqualTo("Here are the results.");
+          assertThat(
+                  retrievedEvent.content().get().parts().get().get(1).functionCall().get().name())
+              .hasValue("search_tool");
+          assertThat(
+                  retrievedEvent
+                      .content()
+                      .get()
+                      .parts()
+                      .get()
+                      .get(2)
+                      .functionResponse()
+                      .get()
+                      .name())
+              .hasValue("search_tool");
+          assertThat(retrievedEvent.content().get().parts().get().get(3).fileData().get().fileUri())
+              .hasValue("gs://bucket/file.png");
+          assertThat(
+                  retrievedEvent.content().get().parts().get().get(3).fileData().get().mimeType())
+              .hasValue("image/png");
+          return true;
+        });
+  }
+
+  /**
+   * A wrapper class that implements ConcurrentMap but delegates to a HashMap. This is a workaround
+   * to allow putting null values, which ConcurrentHashMap forbids, for testing state removal logic.
+   */
+  private static class HashMapAsConcurrentMap<K, V> extends AbstractMap<K, V>
+      implements ConcurrentMap<K, V> {
+    private final HashMap<K, V> map;
+
+    public HashMapAsConcurrentMap(Map<K, V> map) {
+      this.map = new HashMap<>(map);
+    }
+
+    @Override
+    public Set<Entry<K, V>> entrySet() {
+      return map.entrySet();
+    }
+
+    @Override
+    public V putIfAbsent(K key, V value) {
+      return map.putIfAbsent(key, value);
+    }
+
+    @Override
+    public boolean remove(Object key, Object value) {
+      return map.remove(key, value);
+    }
+
+    @Override
+    public boolean replace(K key, V oldValue, V newValue) {
+      return map.replace(key, oldValue, newValue);
+    }
+
+    @Override
+    public V replace(K key, V value) {
+      return map.replace(key, value);
+    }
+  }
+
+  /** Tests that appendEvent with only app state deltas updates the correct stores. */
+  @Test
+  void appendEvent_withAppOnlyStateDeltas_updatesCorrectStores() {
+    // Arrange
+    Session session =
+        Session.builder(SESSION_ID)
+            .appName(APP_NAME)
+            .userId(USER_ID)
+            .state(new ConcurrentHashMap<>())
+            .build();
+
+    EventActions actions =
+        EventActions.builder()
+            .stateDelta(
+                new ConcurrentHashMap<>(
+                    ImmutableMap.of("_app_appKey", "appValue"))) // Corrected type and key
+            .build();
+
+    Event event =
+        Event.builder()
+            .author("model")
+            .content(Content.builder().parts(List.of(Part.fromText("..."))).build())
+            .actions(actions)
+            .build();
+
+    // Mock Firestore interactions for appendEvent
+    when(mockSessionsCollection.document(SESSION_ID)).thenReturn(mockSessionDocRef);
+    when(mockEventsCollection.document()).thenReturn(mockEventDocRef);
+    when(mockEventDocRef.getId()).thenReturn(EVENT_ID);
+    when(mockEventsCollection.document(EVENT_ID)).thenReturn(mockEventDocRef);
+    when(mockSessionDocRef.update(anyMap()))
+        .thenReturn(ApiFutures.immediateFuture(mockWriteResult));
+
+    // Act
+    sessionService.appendEvent(session, event).test().assertComplete();
+
+    // Assert
+    // Make sure only the app state is updated
+    ArgumentCaptor<Map<String, Object>> appStateCaptor = ArgumentCaptor.forClass(Map.class);
+    verify(mockAppStateDocRef).set(appStateCaptor.capture(), any(SetOptions.class));
+    assertThat(appStateCaptor.getValue()).containsEntry("appKey", "appValue");
+
+    // Verify that session state and user state are not updated
+    verify(mockUserStateUsersCollection, never()).document(anyString());
+    ArgumentCaptor<Map<String, Object>> sessionUpdateCaptor = ArgumentCaptor.forClass(Map.class);
+    verify(mockSessionDocRef).update(sessionUpdateCaptor.capture());
+    assertThat(sessionUpdateCaptor.getValue()).doesNotContainKey(Constants.KEY_STATE);
+  }
+
+  /** Tests that appendEvent with only user state deltas updates the correct stores. */
+  @Test
+  void appendEvent_withUserOnlyStateDeltas_updatesCorrectStores() {
+    // Arrange
+    Session session =
+        Session.builder(SESSION_ID)
+            .appName(APP_NAME)
+            .userId(USER_ID)
+            .state(new ConcurrentHashMap<>())
+            .build();
+
+    EventActions actions =
+        EventActions.builder()
+            .stateDelta(new ConcurrentHashMap<>(ImmutableMap.of("_user_userKey", "userValue")))
+            .build();
+
+    Event event =
+        Event.builder()
+            .author("model")
+            .content(Content.builder().parts(List.of(Part.fromText("..."))).build())
+            .actions(actions)
+            .build();
+
+    // Mock Firestore interactions for appendEvent
+    when(mockSessionsCollection.document(SESSION_ID)).thenReturn(mockSessionDocRef);
+    when(mockEventsCollection.document()).thenReturn(mockEventDocRef);
+    when(mockEventDocRef.getId()).thenReturn(EVENT_ID);
+    when(mockEventsCollection.document(EVENT_ID)).thenReturn(mockEventDocRef);
+    when(mockSessionDocRef.update(anyMap()))
+        .thenReturn(ApiFutures.immediateFuture(mockWriteResult));
+
+    // Act
+    sessionService.appendEvent(session, event).test().assertComplete();
+
+    // Assert
+    // Make sure only the user state is updated
+    ArgumentCaptor<Map<String, Object>> userStateCaptor = ArgumentCaptor.forClass(Map.class);
+    verify(mockUserStateUserDocRef).set(userStateCaptor.capture(), any(SetOptions.class));
+    assertThat(userStateCaptor.getValue()).containsEntry("userKey", "userValue");
+
+    // Verify that app state and session state are not updated
+    verify(mockAppStateDocRef, never()).set(anyMap(), any(SetOptions.class));
+    verify(mockSessionDocRef, never()).update(eq(Constants.KEY_STATE), any());
+  }
+
+  /**
+   * Tests that appendEvent with all types of state deltas updates the correct stores and session
+   * state.
+   */
+  @Test
+  void appendEvent_withAllStateDeltas_updatesCorrectStores() {
+    // Arrange
+    Session session =
+        Session.builder(SESSION_ID)
+            .appName(APP_NAME)
+            .userId(USER_ID)
+            .state(new ConcurrentHashMap<>()) // The session state itself must be concurrent
+            .build();
+    session.state().put("keyToRemove", "someValue");
+
+    Map<String, Object> stateDeltaMap = new HashMap<>();
+    stateDeltaMap.put("sessionKey", "sessionValue");
+    stateDeltaMap.put("_app_appKey", "appValue");
+    stateDeltaMap.put("_user_userKey", "userValue");
+    stateDeltaMap.put("keyToRemove", null);
+
+    // Use the wrapper to satisfy the ConcurrentMap interface for the builder
+    EventActions actions =
+        EventActions.builder().stateDelta(new HashMapAsConcurrentMap<>(stateDeltaMap)).build();
+
+    Event event =
+        Event.builder()
+            .author("model")
+            .content(Content.builder().parts(List.of(Part.fromText("..."))).build())
+            .actions(actions)
+            .build();
+
+    when(mockSessionsCollection.document(SESSION_ID)).thenReturn(mockSessionDocRef);
+    when(mockEventsCollection.document()).thenReturn(mockEventDocRef);
+    when(mockEventDocRef.getId()).thenReturn(EVENT_ID);
+    // THIS IS THE MISSING MOCK: Stub the call to get the document by its specific ID.
+    when(mockEventsCollection.document(EVENT_ID)).thenReturn(mockEventDocRef);
+    // Add the missing mock for the final session update call
+    when(mockSessionDocRef.update(anyMap()))
+        .thenReturn(ApiFutures.immediateFuture(mockWriteResult));
+
+    // Act
+    sessionService.appendEvent(session, event).test().assertComplete();
+
+    // Assert
+    assertThat(session.state()).containsEntry("sessionKey", "sessionValue");
+    assertThat(session.state()).doesNotContainKey("keyToRemove");
+
+    ArgumentCaptor<Map<String, Object>> appStateCaptor = ArgumentCaptor.forClass(Map.class);
+    verify(mockAppStateDocRef).set(appStateCaptor.capture(), any(SetOptions.class));
+    assertThat(appStateCaptor.getValue()).containsEntry("appKey", "appValue");
+
+    ArgumentCaptor<Map<String, Object>> userStateCaptor = ArgumentCaptor.forClass(Map.class);
+    verify(mockUserStateUserDocRef).set(userStateCaptor.capture(), any(SetOptions.class));
+    assertThat(userStateCaptor.getValue()).containsEntry("userKey", "userValue");
+  }
+
+  /** Tests that getSession skips malformed events and returns only the well-formed ones. */
+  @Test
+  @SuppressWarnings("unchecked")
+  void getSession_withMalformedEvent_skipsEventAndReturnsOthers() {
+    // Arrange
+    // A valid event document
+    QueryDocumentSnapshot mockValidEventSnapshot = mock(QueryDocumentSnapshot.class);
+    Map<String, Object> validEventData =
+        ImmutableMap.of(
+            Constants.KEY_AUTHOR,
+            USER_ID,
+            "timestamp",
+            NOW.toString(),
+            "content",
+            ImmutableMap.of("parts", ImmutableList.of(ImmutableMap.of("text", "a valid event"))));
+    when(mockValidEventSnapshot.getData()).thenReturn(validEventData);
+
+    // A malformed event document (missing timestamp)
+    QueryDocumentSnapshot mockMalformedEventSnapshot = mock(QueryDocumentSnapshot.class);
+    Map<String, Object> malformedEventData =
+        ImmutableMap.of(Constants.KEY_AUTHOR, USER_ID, "content", Map.of());
+    when(mockMalformedEventSnapshot.getData()).thenReturn(malformedEventData);
+
+    // Mock the session document itself
+    when(mockSessionsCollection.document(SESSION_ID)).thenReturn(mockSessionDocRef);
+    when(mockSessionDocRef.get()).thenReturn(ApiFutures.immediateFuture(mockSessionSnapshot));
+    when(mockSessionSnapshot.exists()).thenReturn(true);
+    when(mockSessionSnapshot.getReference()).thenReturn(mockSessionDocRef);
+    // FIX: Provide a complete session data map to avoid NPEs in the Session.builder()
+    when(mockSessionSnapshot.getData())
+        .thenReturn(
+            ImmutableMap.of(
+                "id", SESSION_ID,
+                "appName", APP_NAME,
+                "userId", USER_ID,
+                "updateTime", NOW.toString(),
+                "state", Collections.emptyMap()));
+
+    // Mock the query for events to return both the valid and malformed documents
+    when(mockQuery.get()).thenReturn(ApiFutures.immediateFuture(mockQuerySnapshot));
+    when(mockQuerySnapshot.getDocuments())
+        .thenReturn(ImmutableList.of(mockMalformedEventSnapshot, mockValidEventSnapshot));
+
+    // Act
+    TestObserver<Session> testObserver =
+        sessionService.getSession(APP_NAME, USER_ID, SESSION_ID, Optional.empty()).test();
+
+    // Assert
+    testObserver.awaitCount(1);
+    testObserver.assertNoErrors();
+    testObserver.assertValue(
+        session -> {
+          assertThat(session.events()).hasSize(1); // Only the valid event should be present
+          assertThat(session.events().get(0).content().get().parts().get().get(0).text().get())
+              .isEqualTo("a valid event");
+          return true;
+        });
+  }
+
+  /***
+   * Tests that getSession skips events with null data.
+   */
+  @Test
+  void getSession_withNullEventData_skipsEvent() {
+    // Arrange
+    // This test covers the `if (data == null)` branch in eventFromMap.
+    QueryDocumentSnapshot mockNullDataEventSnapshot = mock(QueryDocumentSnapshot.class);
+    when(mockNullDataEventSnapshot.getData()).thenReturn(null); // The specific condition to test
+
+    // Mock the session document itself
+    when(mockSessionsCollection.document(SESSION_ID)).thenReturn(mockSessionDocRef);
+    when(mockSessionDocRef.get()).thenReturn(ApiFutures.immediateFuture(mockSessionSnapshot));
+    when(mockSessionSnapshot.exists()).thenReturn(true);
+    when(mockSessionSnapshot.getReference()).thenReturn(mockSessionDocRef);
+    when(mockSessionSnapshot.getData())
+        .thenReturn(
+            ImmutableMap.of(
+                "id", SESSION_ID,
+                "appName", APP_NAME,
+                "userId", USER_ID,
+                "updateTime", NOW.toString(),
+                "state", Collections.emptyMap()));
+
+    // Mock the query for events to return the document with null data
+    when(mockQuery.get()).thenReturn(ApiFutures.immediateFuture(mockQuerySnapshot));
+    when(mockQuerySnapshot.getDocuments()).thenReturn(ImmutableList.of(mockNullDataEventSnapshot));
+
+    // Act
+    TestObserver<Session> testObserver =
+        sessionService.getSession(APP_NAME, USER_ID, SESSION_ID, Optional.empty()).test();
+
+    // Assert
+    testObserver.awaitCount(1);
+    testObserver.assertNoErrors();
+    testObserver.assertValue(
+        session -> {
+          assertThat(session.events()).isEmpty(); // Assert that the null-data event was skipped
+          return true;
+        });
+  }
+
+  /** Tests that getSession skips events with unparseable timestamps. */
+  @Test
+  void getSession_withUnparseableEvent_triggersCatchBlockAndSkipsEvent() {
+    // Arrange
+    // This test covers the `catch (Exception e)` block in eventFromMap.
+    QueryDocumentSnapshot mockBadTimestampEvent = mock(QueryDocumentSnapshot.class);
+    Map<String, Object> badData =
+        ImmutableMap.of(
+            Constants.KEY_AUTHOR,
+            USER_ID,
+            "timestamp",
+            "not-a-valid-timestamp", // This will cause Instant.parse() to fail
+            "content",
+            ImmutableMap.of("parts", Collections.emptyList()));
+    when(mockBadTimestampEvent.getData()).thenReturn(badData);
+
+    // Mock session and event query setup (similar to other tests)
+    when(mockSessionsCollection.document(SESSION_ID)).thenReturn(mockSessionDocRef);
+    when(mockSessionDocRef.get()).thenReturn(ApiFutures.immediateFuture(mockSessionSnapshot));
+    when(mockSessionSnapshot.exists()).thenReturn(true);
+    when(mockSessionSnapshot.getData())
+        .thenReturn(
+            ImmutableMap.of(
+                "id",
+                SESSION_ID,
+                "appName",
+                APP_NAME,
+                "userId",
+                USER_ID,
+                "updateTime",
+                NOW.toString(),
+                "state",
+                Collections.emptyMap()));
+    when(mockSessionSnapshot.getReference()).thenReturn(mockSessionDocRef);
+    when(mockSessionDocRef.collection(Constants.EVENTS_SUBCOLLECTION_NAME))
+        .thenReturn(mockEventsCollection);
+    when(mockEventsCollection.orderBy(Constants.KEY_TIMESTAMP)).thenReturn(mockQuery);
+    when(mockQuery.get()).thenReturn(ApiFutures.immediateFuture(mockQuerySnapshot));
+    when(mockQuerySnapshot.getDocuments()).thenReturn(ImmutableList.of(mockBadTimestampEvent));
+
+    // Act & Assert
+    sessionService
+        .getSession(APP_NAME, USER_ID, SESSION_ID, Optional.empty())
+        .test()
+        .assertNoErrors() // The error should be caught and logged, not propagated
+        .assertValue(session -> session.events().isEmpty()); // The bad event should be skipped
+  }
+
+  // --- listEvents Tests ---
+
+  /** Tests that listEvents returns the expected events when the session exists. */
+  @Test
+  void listEvents_sessionExists_returnsEvents() {
+    // Arrange
+    when(mockSessionsCollection.document(SESSION_ID)).thenReturn(mockSessionDocRef);
+    when(mockSessionDocRef.get()).thenReturn(ApiFutures.immediateFuture(mockSessionSnapshot));
+    when(mockSessionSnapshot.exists()).thenReturn(true);
+    when(mockSessionSnapshot.getReference()).thenReturn(mockSessionDocRef);
+    when(mockQuery.get()).thenReturn(ApiFutures.immediateFuture(mockQuerySnapshot));
+    Map<String, Object> eventData =
+        ImmutableMap.of(
+            Constants.KEY_AUTHOR,
+            USER_ID,
+            "timestamp",
+            NOW.toString(),
+            "content",
+            ImmutableMap.of("parts", ImmutableList.of(ImmutableMap.of("text", "an event"))));
+    when(mockEventSnapshot.getData()).thenReturn(eventData);
+    when(mockQuerySnapshot.getDocuments()).thenReturn(ImmutableList.of(mockEventSnapshot));
+
+    // Act
+    TestObserver<ListEventsResponse> testObserver =
+        sessionService.listEvents(APP_NAME, USER_ID, SESSION_ID).test();
+
+    // Assert
+    testObserver.awaitCount(1);
+    testObserver.assertComplete();
+    testObserver.assertValue(
+        response -> {
+          assertThat(response.events()).hasSize(1);
+          assertThat(response.events().get(0).author()).isEqualTo(USER_ID);
+          return true;
+        });
+  }
+
+  /** Tests that listEvents throws SessionNotFoundException when the session does not exist. */
+  @Test
+  void listEvents_sessionDoesNotExist_throwsException() {
+    // Arrange
+    when(mockSessionsCollection.document(SESSION_ID)).thenReturn(mockSessionDocRef);
+    when(mockSessionDocRef.get()).thenReturn(ApiFutures.immediateFuture(mockSessionSnapshot));
+    when(mockSessionSnapshot.exists()).thenReturn(false);
+
+    // Act
+    TestObserver<ListEventsResponse> testObserver =
+        sessionService.listEvents(APP_NAME, USER_ID, SESSION_ID).test();
+
+    // Assert
+    testObserver.assertError(SessionNotFoundException.class);
+  }
+
+  // --- deleteSession Tests ---
+  /** Tests that deleteSession deletes all events and the session itself. */
+  @Test
+  void deleteSession_deletesEventsAndSession() {
+    // Arrange
+    when(mockSessionsCollection.document(SESSION_ID)).thenReturn(mockSessionDocRef);
+    when(mockSessionDocRef.collection(Constants.EVENTS_SUBCOLLECTION_NAME))
+        .thenReturn(mockEventsCollection);
+    when(mockEventsCollection.get()).thenReturn(ApiFutures.immediateFuture(mockQuerySnapshot));
+
+    // Mock an event document to be deleted
+    QueryDocumentSnapshot mockEventDoc = mock(QueryDocumentSnapshot.class);
+    DocumentReference mockEventDocRefToDelete = mock(DocumentReference.class);
+    when(mockEventDoc.getReference()).thenReturn(mockEventDocRefToDelete);
+    when(mockQuerySnapshot.getDocuments()).thenReturn(ImmutableList.of(mockEventDoc));
+
+    // Act
+    sessionService.deleteSession(APP_NAME, USER_ID, SESSION_ID).test().assertComplete();
+
+    // Assert
+    verify(mockWriteBatch, times(1)).delete(mockEventDocRefToDelete); // Verify batch delete
+    verify(mockWriteBatch, times(1)).commit();
+    verify(mockSessionDocRef, times(1)).delete();
+  }
+
+  // --- listSessions Tests ---
+  /** Tests that listSessions returns a list of sessions for the specified app and user. */
+  @Test
+  void listSessions_returnsListOfSessions() {
+    // Arrange
+    when(mockSessionsCollection.whereEqualTo(Constants.KEY_APP_NAME, APP_NAME))
+        .thenReturn(mockQuery);
+    // Mock the query for listSessions
+    when(mockQuery.get()).thenReturn(ApiFutures.immediateFuture(mockQuerySnapshot));
+
+    // Mock the documents returned by the query
+    QueryDocumentSnapshot mockDoc1 = mock(QueryDocumentSnapshot.class);
+    Map<String, Object> doc1Data =
+        ImmutableMap.of(
+            "id",
+            "session-1",
+            "appName",
+            APP_NAME,
+            "userId",
+            USER_ID,
+            "updateTime",
+            NOW.toString());
+    when(mockDoc1.getData()).thenReturn(doc1Data);
+
+    QueryDocumentSnapshot mockDoc2 = mock(QueryDocumentSnapshot.class);
+    Map<String, Object> doc2Data =
+        ImmutableMap.of(
+            "id",
+            "session-2",
+            "appName",
+            APP_NAME,
+            "userId",
+            USER_ID,
+            "updateTime",
+            NOW.plusSeconds(10).toString());
+    when(mockDoc2.getData()).thenReturn(doc2Data);
+
+    when(mockQuerySnapshot.getDocuments()).thenReturn(ImmutableList.of(mockDoc1, mockDoc2));
+
+    // Act
+    TestObserver<ListSessionsResponse> testObserver =
+        sessionService.listSessions(APP_NAME, USER_ID).test();
+
+    // Assert
+    testObserver.awaitCount(1);
+    testObserver.assertComplete();
+    testObserver.assertValue(
+        response -> {
+          assertThat(response.sessions()).hasSize(2);
+          assertThat(response.sessions().get(0).id()).isEqualTo("session-1");
+          assertThat(response.sessions().get(1).id()).isEqualTo("session-2");
+          return true;
+        });
+  }
+}

--- a/contrib/firestore-session-service/src/test/java/com/google/adk/utils/ApiFutureUtilsTest.java
+++ b/contrib/firestore-session-service/src/test/java/com/google/adk/utils/ApiFutureUtilsTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.adk.utils;
+
+import com.google.api.core.SettableApiFuture;
+import com.google.common.util.concurrent.MoreExecutors;
+import io.reactivex.rxjava3.core.Maybe;
+import io.reactivex.rxjava3.core.Single;
+import io.reactivex.rxjava3.observers.TestObserver;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/** Test class for ApiFutureUtils. */
+public class ApiFutureUtilsTest {
+
+  @BeforeEach
+  public void setup() {
+    // Override the default executor to run on the same thread for tests.
+    // This prevents noisy async stack traces from being logged during failure tests.
+    ApiFutureUtils.executor = MoreExecutors.directExecutor();
+  }
+
+  /** Tests that ApiFutureUtils.toSingle emits the expected result on success. */
+  @Test
+  void toSingle_onSuccess_emitsResult() {
+    SettableApiFuture<String> future = SettableApiFuture.create();
+    Single<String> single = ApiFutureUtils.toSingle(future);
+    TestObserver<String> testObserver = single.test();
+
+    future.set("success");
+
+    testObserver.awaitCount(1);
+    testObserver.assertNoErrors();
+    testObserver.assertValue("success");
+  }
+
+  /** Tests that ApiFutureUtils.toSingle emits the expected error on failure. */
+  @Test
+  void toSingle_onFailure_emitsError() {
+    SettableApiFuture<String> future = SettableApiFuture.create();
+    Single<String> single = ApiFutureUtils.toSingle(future);
+    TestObserver<String> testObserver = single.test();
+    Exception testException = new RuntimeException("test-exception");
+
+    future.setException(testException);
+
+    testObserver.awaitCount(1);
+    testObserver.assertError(testException);
+    testObserver.assertNotComplete();
+  }
+
+  /** Tests that ApiFutureUtils.toMaybe emits the expected result on success. */
+  @Test
+  void toMaybe_onSuccess_emitsResult() {
+    SettableApiFuture<String> future = SettableApiFuture.create();
+    Maybe<String> maybe = ApiFutureUtils.toMaybe(future);
+    TestObserver<String> testObserver = maybe.test();
+
+    future.set("success");
+
+    testObserver.awaitCount(1);
+    testObserver.assertNoErrors();
+    testObserver.assertValue("success");
+  }
+
+  /** Tests that ApiFutureUtils.toMaybe emits the expected error on failure. */
+  @Test
+  void toMaybe_onFailure_emitsError() {
+    SettableApiFuture<String> future = SettableApiFuture.create();
+    Maybe<String> maybe = ApiFutureUtils.toMaybe(future);
+    TestObserver<String> testObserver = maybe.test();
+    Exception testException = new RuntimeException("test-exception");
+
+    future.setException(testException);
+
+    testObserver.awaitCount(1);
+    testObserver.assertError(testException);
+    testObserver.assertNotComplete();
+  }
+}

--- a/contrib/firestore-session-service/src/test/java/com/google/adk/utils/ConstantsTest.java
+++ b/contrib/firestore-session-service/src/test/java/com/google/adk/utils/ConstantsTest.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.adk.utils;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+/** Test class for Constants. */
+public class ConstantsTest {
+
+  /** Test to verify that the root collection name is as expected. */
+  @Test
+  void testRootCollectionName() {
+    String rootCollectionName = FirestoreProperties.getInstance().getFirebaseRootCollectionName();
+    assertThat(rootCollectionName).isEqualTo("default-adk-session");
+  }
+}

--- a/contrib/firestore-session-service/src/test/java/com/google/adk/utils/FirestorePropertiesTest.java
+++ b/contrib/firestore-session-service/src/test/java/com/google/adk/utils/FirestorePropertiesTest.java
@@ -1,0 +1,184 @@
+package com.google.adk.utils;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.lang.reflect.Field;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Map;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/** JUnit 4 test for FirestoreProperties. */
+public class FirestorePropertiesTest {
+
+  private static final String ENV_VAR_NAME = "env";
+
+  /**
+   * Helper method to set an environment variable using reflection. This is needed because
+   * System.getenv() returns an unmodifiable map.
+   */
+  private static void setEnv(String key, String value) throws Exception {
+    try {
+      Map<String, String> env = System.getenv();
+      Field field = env.getClass().getDeclaredField("m");
+      field.setAccessible(true);
+      @SuppressWarnings("unchecked")
+      Map<String, String> mutableEnv = (Map<String, String>) field.get(env);
+      if (value == null) {
+        mutableEnv.remove(key);
+      } else {
+        mutableEnv.put(key, value);
+      }
+    } catch (NoSuchFieldException e) {
+      // For other OS/JVMs that use a different internal class
+      Class<?> processEnvironmentClass = Class.forName("java.lang.ProcessEnvironment");
+      Field theEnvironmentField = processEnvironmentClass.getDeclaredField("theEnvironment");
+      theEnvironmentField.setAccessible(true);
+      @SuppressWarnings("unchecked")
+      Map<String, String> mutableEnv = (Map<String, String>) theEnvironmentField.get(null);
+      if (value == null) {
+        mutableEnv.remove(key);
+      } else {
+        mutableEnv.put(key, value);
+      }
+    }
+  }
+
+  /** Clears the 'env' variable before each test to ensure isolation. */
+  @BeforeEach
+  public void setup() {
+    try {
+      // Clear the variable to start from a clean state for each test
+      // Also reset the singleton instance to force reloading properties
+      FirestoreProperties.resetForTest();
+      setEnv(ENV_VAR_NAME, null);
+    } catch (Exception e) {
+      fail("Failed to set up environment for test: " + e.getMessage());
+    }
+  }
+
+  /** A cleanup step is good practice, though @Before handles our primary need. */
+  @AfterEach
+  public void teardown() {
+    try {
+      FirestoreProperties.resetForTest();
+      setEnv(ENV_VAR_NAME, null);
+    } catch (Exception e) {
+      fail("Failed to tear down environment for test: " + e.getMessage());
+    }
+  }
+
+  /**
+   * Tests that the default properties are loaded when the 'env' environment variable is not set.
+   */
+  @Test
+  void shouldLoadDefaultPropertiesWhenEnvIsNotSet() {
+    FirestoreProperties props = FirestoreProperties.getInstance();
+
+    assertEquals("default-adk-session", props.getFirebaseRootCollectionName());
+    assertEquals("default_value", props.getProperty("another.default.property"));
+    assertEquals("common_default", props.getProperty("common.property"));
+    assertNull(props.getProperty("non.existent.property"));
+  }
+
+  /**
+   * Tests that the default properties are loaded when the 'env' environment variable is set to an
+   *
+   * @throws Exception
+   */
+  @Test
+  void shouldLoadDefaultPropertiesWhenEnvIsEmpty() throws Exception {
+    setEnv(ENV_VAR_NAME, "");
+    FirestoreProperties props = FirestoreProperties.getInstance();
+
+    assertEquals("default-adk-session", props.getFirebaseRootCollectionName());
+    assertEquals("default_value", props.getProperty("another.default.property"));
+  }
+
+  /**
+   * Tests that the 'dev' properties are loaded when the 'env' environment variable is set to 'dev'.
+   *
+   * @throws Exception
+   */
+  @Test
+  void shouldLoadDevPropertiesWhenEnvIsSetToDev() throws Exception {
+    setEnv(ENV_VAR_NAME, "dev");
+    FirestoreProperties props = FirestoreProperties.getInstance();
+
+    assertEquals("dev-adk-session-override", props.getFirebaseRootCollectionName());
+    assertEquals("dev_value", props.getProperty("dev.specific.property"));
+    assertEquals("common_dev", props.getProperty("common.property")); // Check overridden property
+    // In JUnit 5, the message is the second argument.
+    assertNull(
+        props.getProperty("another.default.property"),
+        "Default-only property should not be present");
+  }
+
+  /**
+   * Tests that the default properties are loaded when the 'env' environment variable is set to a
+   * non-existent environment.
+   *
+   * @throws Exception
+   */
+  @Test
+  void shouldFallbackToDefaultWhenEnvSpecificFileNotFound() throws Exception {
+    // Assuming adk-firestore-nonexistent.properties does not exist
+    setEnv(ENV_VAR_NAME, "nonexistent");
+    FirestoreProperties props = FirestoreProperties.getInstance();
+
+    assertEquals("default-adk-session", props.getFirebaseRootCollectionName());
+    assertEquals("default_value", props.getProperty("another.default.property"));
+  }
+
+  /**
+   * Tests that the hardcoded default is returned when the property file has no entry for the key.
+   *
+   * @throws Exception
+   */
+  @Test
+  void shouldReturnHardcodedDefaultIfPropertyFileHasNoEntry() throws Exception {
+    // This test requires 'src/test/resources/adk-firestore-empty.properties'
+    // which contains some properties but NOT 'firebase.root.collection.name'
+    setEnv(ENV_VAR_NAME, "empty");
+    FirestoreProperties props = FirestoreProperties.getInstance();
+
+    // Should fall back to the hardcoded default value
+    assertEquals("adk-session", props.getFirebaseRootCollectionName());
+    // Verify that it did load the correct file
+    assertEquals("other_value", props.getProperty("other.key"));
+  }
+
+  @Test
+  void getInstanceShouldReturnAnInstance() {
+    assertNotNull(FirestoreProperties.getInstance());
+  }
+
+  /**
+   * Tests that the default stop words are returned when the property is not set in the file.
+   *
+   * @throws Exception
+   */
+  @Test
+  void shouldReturnDefaultStopWordsWhenPropertyNotSet() throws Exception {
+    // Set env to load a properties file without the stopwords key
+    setEnv(ENV_VAR_NAME, "empty");
+    FirestoreProperties props = FirestoreProperties.getInstance();
+
+    // The expected default stop words, matching the hardcoded list in FirestoreProperties
+    HashSet<String> expectedStopWords =
+        new HashSet<>(
+            Arrays.asList(
+                "a", "an", "and", "are", "as", "at", "be", "but", "by", "for", "if", "in", "into",
+                "is", "it", "i", "no", "not", "of", "on", "or", "such", "that", "the", "their",
+                "then", "there", "these", "they", "this", "to", "was", "will", "with", "what",
+                "where", "when", "why", "how", "help", "need", "like", "make", "got", "would",
+                "could", "should"));
+
+    assertEquals(expectedStopWords, props.getStopWords());
+  }
+}

--- a/contrib/firestore-session-service/src/test/resources/adk-firestore-dev.properties
+++ b/contrib/firestore-session-service/src/test/resources/adk-firestore-dev.properties
@@ -1,0 +1,4 @@
+firebase.root.collection.name=dev-adk-session-override
+dev.specific.property=dev_value
+common.property=common_dev
+gcs.adk.bucket.name=test-bucket

--- a/contrib/firestore-session-service/src/test/resources/adk-firestore-empty.properties
+++ b/contrib/firestore-session-service/src/test/resources/adk-firestore-empty.properties
@@ -1,0 +1,1 @@
+other.key=other_value

--- a/contrib/firestore-session-service/src/test/resources/adk-firestore.properties
+++ b/contrib/firestore-session-service/src/test/resources/adk-firestore.properties
@@ -1,0 +1,7 @@
+firebase.root.collection.name=default-adk-session
+another.default.property=default_value
+common.property=common_default
+gcs.adk.bucket.name=test-bucket
+
+# Comma-separated list of stop words for keyword extraction.
+keyword.extraction.stopwords=a,an,and,are,as,at,be,but,by,for,if,in,into,is,it,i,no,not,of,on,or,such,that,the,their,then,there,these,they,this,to,was,will,with,what,where,when,why,how,help,need,like,make,got,would,could,should

--- a/contrib/samples/a2a_remote/pom.xml
+++ b/contrib/samples/a2a_remote/pom.xml
@@ -1,13 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
     <groupId>com.google.adk</groupId>
     <artifactId>google-adk-parent</artifactId>
     <version>0.4.0-SNAPSHOT</version><!-- {x-version-update:google-adk:current} -->
+    <relativePath>../../../pom.xml</relativePath>
   </parent>
 
   <artifactId>google-adk-sample-a2a-remote</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,9 @@
  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  See the License for the specific language governing permissions and
  limitations under the License. -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>com.google.adk</groupId>
@@ -31,6 +33,7 @@
     <module>contrib/langchain4j</module>
     <module>contrib/spring-ai</module>
     <module>contrib/samples</module>
+    <module>contrib/firestore-session-service</module>
     <module>tutorials/city-time-weather</module>
     <module>tutorials/live-audio-single-agent</module>
     <module>a2a</module>
@@ -316,7 +319,8 @@
           </dependencies>
           <configuration>
             <reportFormat>plain</reportFormat>
-            <statelessTestsetInfoReporter implementation="org.apache.maven.plugin.surefire.extensions.junit5.JUnit5StatelessTestsetInfoTreeReporter"/>
+            <statelessTestsetInfoReporter
+              implementation="org.apache.maven.plugin.surefire.extensions.junit5.JUnit5StatelessTestsetInfoTreeReporter" />
             <includes>
               <include>**/*Test.java</include>
             </includes>
@@ -395,7 +399,7 @@
           </configuration>
         </plugin>
       </plugins>
-  </pluginManagement>
+    </pluginManagement>
     <plugins>
       <plugin>
         <groupId>org.sonatype.central</groupId>


### PR DESCRIPTION
This PR replaces my previous attempt and resolves all merge conflicts and build issueses for https://github.com/google/adk-java/pull/578

This pull request adds FirestoreSessionService by implementing BaseSessionService interface that uses Firestore as the data store to manage user sessions.

Added the feature to contrib folder

here is the discussion request link [https://github.com/google/adk-java/discussions/568](https://github.com/google/adk-java/pull/url)

Why Firestore:

Firestore is a scalable, managed, and widely-used Google Cloud database. It would provide a clear, simple, and robust path for developers needing persistent sessions in production scale

Transactional Design Consideration
The createSession, appendEvent, and deleteSession methods in this service use blocking .get() calls on their Firestore ApiFuture objects. This is a deliberate design choice to guarantee data consistency within the ADK's sequential execution flow.

The appendEvent method is particularly critical. A fully non-blocking implementation could create a race condition where the Runner proceeds to the next step (e.g., calling the LLM) before the latest event and state changes are persisted. This would result in the model operating on stale data, leading to an incomplete chat history.

By blocking within the reactive stream, we ensure that the database transaction is complete before the Single or Completable emits, providing strong consistency for the Runner. This synchronous-within-asynchronous pattern is applied to all write operations for predictable and reliable behavior.

Dependencies:

Added new dependacy 'Firestore'

Testing:
All test passed with > 80% test coverage

<img width="1057" height="285" alt="image" src="https://github.com/user-attachments/assets/660f3c29-662e-4fa1-bc6a-06eaee12924d" />


@glaforge  for your review 