### PR TITLE
feat: Support output schema with tools for LlmAgent

### DIFF
--- a/core/src/main/java/com/google/adk/flows/llmflows/Basic.java
+++ b/core/src/main/java/com/google/adk/flows/llmflows/Basic.java
@@ -57,7 +57,9 @@ public final class Basic implements RequestProcessor {
             .config(agent.generateContentConfig().orElse(GenerateContentConfig.builder().build()))
             .liveConnectConfig(liveConnectConfigBuilder.build());
 
-    agent.outputSchema().ifPresent(builder::outputSchema);
+    if (agent.outputSchema().isPresent() && agent.toolsUnion().isEmpty()) {
+      builder.outputSchema(agent.outputSchema().get());
+    }
     return Single.just(
         RequestProcessor.RequestProcessingResult.create(builder.build(), ImmutableList.of()));
   }

--- a/core/src/main/java/com/google/adk/tools/SetModelResponseTool.java
+++ b/core/src/main/java/com/google/adk/tools/SetModelResponseTool.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.adk.tools;
+
+import com.google.adk.SchemaUtils;
+import com.google.genai.types.FunctionDeclaration;
+import com.google.genai.types.Schema;
+import io.reactivex.rxjava3.core.Single;
+import java.util.Map;
+import java.util.Optional;
+
+/** Tool for setting model response when using output_schema with other tools. */
+public class SetModelResponseTool extends BaseTool {
+
+  private final Schema outputSchema;
+
+  public SetModelResponseTool(Schema outputSchema) {
+    super(
+        "set_model_response",
+        "Set your final response using the required output schema. Use this tool to provide your"
+            + " final structured answer instead of outputting text directly.");
+    this.outputSchema = outputSchema;
+  }
+
+  @Override
+  public Optional<FunctionDeclaration> declaration() {
+    return Optional.of(
+        FunctionDeclaration.builder()
+            .name(name())
+            .description(description())
+            .parameters(outputSchema)
+            .build());
+  }
+
+  @Override
+  public Single<Map<String, Object>> runAsync(Map<String, Object> args, ToolContext toolContext) {
+    try {
+      SchemaUtils.validateMapOnSchema(args, outputSchema, /* isInput= */ false);
+    } catch (IllegalArgumentException e) {
+      return Single.error(e);
+    }
+    return Single.just(args);
+  }
+}

--- a/core/src/test/java/com/google/adk/tools/SetModelResponseToolTest.java
+++ b/core/src/test/java/com/google/adk/tools/SetModelResponseToolTest.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.adk.tools;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertThrows;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.genai.types.FunctionDeclaration;
+import com.google.genai.types.Schema;
+import java.util.Map;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public final class SetModelResponseToolTest {
+
+  @Test
+  public void declaration_returnsCorrectFunctionDeclaration() {
+    Schema outputSchema =
+        Schema.builder()
+            .type("OBJECT")
+            .properties(ImmutableMap.of("field1", Schema.builder().type("STRING").build()))
+            .required(ImmutableList.of("field1"))
+            .build();
+
+    SetModelResponseTool tool = new SetModelResponseTool(outputSchema);
+    FunctionDeclaration declaration = tool.declaration().get();
+
+    assertThat(declaration.name()).hasValue("set_model_response");
+    assertThat(declaration.description()).isPresent();
+    assertThat(declaration.description().get()).contains("Set your final response");
+    assertThat(declaration.parameters()).hasValue(outputSchema);
+  }
+
+  @Test
+  public void runAsync_returnsArgs() {
+    Schema outputSchema =
+        Schema.builder()
+            .type("OBJECT")
+            .properties(ImmutableMap.of("field1", Schema.builder().type("STRING").build()))
+            .build();
+
+    SetModelResponseTool tool = new SetModelResponseTool(outputSchema);
+    Map<String, Object> args = ImmutableMap.of("field1", "value1");
+
+    Map<String, Object> result = tool.runAsync(args, null).blockingGet();
+
+    assertThat(result).isEqualTo(args);
+  }
+
+  @Test
+  public void runAsync_validatesArgs() {
+    Schema outputSchema =
+        Schema.builder()
+            .type("OBJECT")
+            .properties(ImmutableMap.of("field1", Schema.builder().type("STRING").build()))
+            .required(ImmutableList.of("field1"))
+            .build();
+
+    SetModelResponseTool tool = new SetModelResponseTool(outputSchema);
+    Map<String, Object> invalidArgs = ImmutableMap.of("field2", "value2");
+
+    // Should throw validation error
+    IllegalArgumentException exception =
+        assertThrows(
+            IllegalArgumentException.class, () -> tool.runAsync(invalidArgs, null).blockingGet());
+
+    assertThat(exception).hasMessageThat().contains("does not match agent output schema");
+  }
+
+  @Test
+  public void runAsync_validatesComplexArgs() {
+    Schema complexSchema =
+        Schema.builder()
+            .type("OBJECT")
+            .properties(
+                ImmutableMap.of(
+                    "id", Schema.builder().type("INTEGER").build(),
+                    "tags",
+                        Schema.builder()
+                            .type("ARRAY")
+                            .items(Schema.builder().type("STRING").build())
+                            .build(),
+                    "metadata",
+                        Schema.builder()
+                            .type("OBJECT")
+                            .properties(
+                                ImmutableMap.of("key", Schema.builder().type("STRING").build()))
+                            .build()))
+            .required(ImmutableList.of("id", "tags", "metadata"))
+            .build();
+
+    SetModelResponseTool tool = new SetModelResponseTool(complexSchema);
+    Map<String, Object> complexArgs =
+        ImmutableMap.of(
+            "id", 123,
+            "tags", ImmutableList.of("tag1", "tag2"),
+            "metadata", ImmutableMap.of("key", "value"));
+
+    Map<String, Object> result = tool.runAsync(complexArgs, null).blockingGet();
+
+    assertThat(result).containsEntry("id", 123);
+    assertThat(result).containsEntry("tags", ImmutableList.of("tag1", "tag2"));
+    assertThat(result).containsEntry("metadata", ImmutableMap.of("key", "value"));
+  }
+}


### PR DESCRIPTION
Fixes https://github.com/google/adk-java/issues/587

## Summary
Adds support for using both output_schema and tools simultaneously in Java ADK. Previously, LlmAgent threw an error when both were configured together. This feature enables structured output alongside tool usage by automatically injecting a special SetModelResponseTool.

## Changes

### Core Implementation
- A new tool SetModelResponseTool
- LlmAgent injects SetModelResponseTool when output_schema and tools are both present
- Basic.java sets output_schema only when toolsUnion is empty
- Removed validation error which prevented output_schema and tools combination

This achieves parity with [Python ADK: feat: Support both output_schema and tools at the same time in LlmAgent adk-python@af63567](https://github.com/google/adk-python/commit/af635674b5d3c128cf21737056e091646283aeb7#diff-225dc7ca23ba18e00f186c36d0e500eb1b6416d88afa3c59d10bf825a1930261)

### Testing
- Added 4 unit tests for SetModelResponseTool
- Updated LlmAgentTest to verify SetModelResponseTool injection
- All tests pass