### PR TITLE
feat: add missing tool resolution strategy

### DIFF
--- a/core/src/main/java/com/google/adk/agents/RunConfig.java
+++ b/core/src/main/java/com/google/adk/agents/RunConfig.java
@@ -16,6 +16,7 @@
 
 package com.google.adk.agents;
 
+import com.google.adk.tools.MissingToolResolutionStrategy;
 import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableList;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
@@ -70,6 +71,8 @@ public abstract class RunConfig {
 
   public abstract int maxLlmCalls();
 
+  public abstract MissingToolResolutionStrategy missingToolResolutionStrategy();
+
   public abstract Builder toBuilder();
 
   public static Builder builder() {
@@ -78,6 +81,7 @@ public abstract class RunConfig {
         .setResponseModalities(ImmutableList.of())
         .setStreamingMode(StreamingMode.NONE)
         .setToolExecutionMode(ToolExecutionMode.NONE)
+        .setMissingToolResolutionStrategy(MissingToolResolutionStrategy.THROW_EXCEPTION)
         .setMaxLlmCalls(500);
   }
 
@@ -90,7 +94,8 @@ public abstract class RunConfig {
         .setResponseModalities(runConfig.responseModalities())
         .setSpeechConfig(runConfig.speechConfig())
         .setOutputAudioTranscription(runConfig.outputAudioTranscription())
-        .setInputAudioTranscription(runConfig.inputAudioTranscription());
+        .setInputAudioTranscription(runConfig.inputAudioTranscription())
+        .setMissingToolResolutionStrategy(runConfig.missingToolResolutionStrategy());
   }
 
   /** Builder for {@link RunConfig}. */
@@ -122,6 +127,10 @@ public abstract class RunConfig {
 
     @CanIgnoreReturnValue
     public abstract Builder setMaxLlmCalls(int maxLlmCalls);
+
+    @CanIgnoreReturnValue
+    public abstract Builder setMissingToolResolutionStrategy(
+        MissingToolResolutionStrategy missingToolResolutionStrategy);
 
     abstract RunConfig autoBuild();
 

--- a/core/src/main/java/com/google/adk/tools/MissingToolResolutionStrategy.java
+++ b/core/src/main/java/com/google/adk/tools/MissingToolResolutionStrategy.java
@@ -1,0 +1,39 @@
+package com.google.adk.tools;
+
+import com.google.adk.agents.InvocationContext;
+import com.google.adk.events.Event;
+import com.google.common.base.VerifyException;
+import com.google.genai.types.FunctionCall;
+import io.reactivex.rxjava3.core.Maybe;
+import java.util.function.BiFunction;
+
+public interface MissingToolResolutionStrategy {
+  public static final MissingToolResolutionStrategy THROW_EXCEPTION =
+      (invocationContext, functionCall) -> {
+        throw new VerifyException(
+            "Tool not found: " + functionCall.name().orElse(functionCall.toJson()));
+      };
+
+  public static final MissingToolResolutionStrategy RETURN_ERROR =
+      (invocationContext, functionCall) ->
+          Maybe.error(
+              new VerifyException(
+                  "Tool not found: " + functionCall.name().orElse(functionCall.toJson())));
+
+  public static final MissingToolResolutionStrategy IGNORE =
+      (invocationContext, functionCall) -> Maybe.empty();
+
+  public static MissingToolResolutionStrategy respondWithEvent(
+      BiFunction<InvocationContext, FunctionCall, Maybe<Event>> eventFactory) {
+    return eventFactory::apply;
+  }
+
+  public static MissingToolResolutionStrategy respondWithEventSync(
+      BiFunction<InvocationContext, FunctionCall, Event> eventFactory) {
+    return respondWithEvent(
+        (invocationContext, functionCall) ->
+            Maybe.just(eventFactory.apply(invocationContext, functionCall)));
+  }
+
+  Maybe<Event> onMissingTool(InvocationContext invocationContext, FunctionCall functionCall);
+}


### PR DESCRIPTION
hi, I'm not sure if I had to create an issue first so please let me know if this is ok.

the use-case is recovering from exceptions thrown as a result of hallucinated tool calls. i tried to preserve behavior by using the current throwing behaviour wherever this new argument is passed.

also, some tests fail locally for me, i'll try to figure it out but hopefully ci passes