### PR TITLE
Enhance AgentTool to support custom services and plugins

### DIFF
--- a/core/src/main/java/com/google/adk/tools/AgentTool.java
+++ b/core/src/main/java/com/google/adk/tools/AgentTool.java
@@ -26,6 +26,7 @@ import com.google.adk.agents.ConfigAgentUtils;
 import com.google.adk.agents.ConfigAgentUtils.ConfigurationException;
 import com.google.adk.agents.LlmAgent;
 import com.google.adk.events.Event;
+import com.google.adk.plugins.Plugin;
 import com.google.adk.runner.InMemoryRunner;
 import com.google.adk.runner.Runner;
 import com.google.adk.sessions.State;
@@ -46,6 +47,7 @@ public class AgentTool extends BaseTool {
 
   private final BaseAgent agent;
   private final boolean skipSummarization;
+  private final List<Plugin> plugins;
 
   public static BaseTool fromConfig(ToolArgsConfig args, String configAbsPath)
       throws ConfigurationException {
@@ -62,21 +64,32 @@ public class AgentTool extends BaseTool {
     }
 
     BaseAgent agent = resolvedAgents.get(0);
-    return AgentTool.create(agent, args.getOrDefault("skipSummarization", false).booleanValue());
+    return AgentTool.create(
+        agent, args.getOrDefault("skipSummarization", false).booleanValue(), ImmutableList.of());
+  }
+
+  public static AgentTool create(
+      BaseAgent agent, boolean skipSummarization, List<? extends Plugin> plugins) {
+    return new AgentTool(agent, skipSummarization, plugins);
   }
 
   public static AgentTool create(BaseAgent agent, boolean skipSummarization) {
-    return new AgentTool(agent, skipSummarization);
+    return new AgentTool(agent, skipSummarization, ImmutableList.of());
   }
 
   public static AgentTool create(BaseAgent agent) {
-    return new AgentTool(agent, false);
+    return new AgentTool(agent, false, ImmutableList.of());
   }
 
   protected AgentTool(BaseAgent agent, boolean skipSummarization) {
+    this(agent, skipSummarization, ImmutableList.of());
+  }
+
+  protected AgentTool(BaseAgent agent, boolean skipSummarization, List<? extends Plugin> plugins) {
     super(agent.name(), agent.description());
     this.agent = agent;
     this.skipSummarization = skipSummarization;
+    this.plugins = ImmutableList.copyOf(plugins != null ? plugins : ImmutableList.of());
   }
 
   @VisibleForTesting
@@ -159,7 +172,7 @@ public class AgentTool extends BaseTool {
       content = Content.fromParts(Part.fromText(input.toString()));
     }
 
-    Runner runner = new InMemoryRunner(this.agent, toolContext.agentName());
+    Runner runner = new InMemoryRunner(this.agent, toolContext.agentName(), this.plugins);
     // Session state is final, can't update to toolContext state
     // session.toBuilder().setState(toolContext.getState());
     return runner
@@ -219,3 +232,4 @@ public class AgentTool extends BaseTool {
         });
   }
 }
+

--- a/core/src/test/java/com/google/adk/tools/AgentToolTest.java
+++ b/core/src/test/java/com/google/adk/tools/AgentToolTest.java
@@ -664,6 +664,62 @@ public final class AgentToolTest {
                 .build());
   }
 
+  @Test
+  public void create_withPlugins_initializesCorrectly() {
+    LlmAgent testAgent =
+        createTestAgentBuilder(createTestLlm(LlmResponse.builder().build()))
+            .name("agent name")
+            .description("agent description")
+            .build();
+
+    AgentTool agentTool = AgentTool.create(testAgent, false, ImmutableList.of());
+
+    assertThat(agentTool).isNotNull();
+    assertThat(agentTool.declaration()).isPresent();
+  }
+
+  @Test
+  public void runAsync_withPlugins_usesThem() {
+    LlmAgent testAgent =
+        createTestAgentBuilder(
+                createTestLlm(
+                    LlmResponse.builder()
+                        .content(Content.fromParts(Part.fromText("Sub-agent executed")))
+                        .build()))
+            .name("sub-agent")
+            .description("sub-agent description")
+            .build();
+
+    TestPlugin testPlugin = new TestPlugin();
+
+    AgentTool agentTool = AgentTool.create(testAgent, false, ImmutableList.of(testPlugin));
+
+    ToolContext toolContext = createToolContext(testAgent);
+
+    Map<String, Object> result =
+        agentTool.runAsync(ImmutableMap.of("request", "start"), toolContext).blockingGet();
+
+    assertThat(result).containsEntry("result", "Sub-agent executed");
+
+    assertThat(testPlugin.wasCalled.get()).isTrue();
+  }
+
+  private static class TestPlugin extends com.google.adk.plugins.BasePlugin {
+    final java.util.concurrent.atomic.AtomicBoolean wasCalled =
+        new java.util.concurrent.atomic.AtomicBoolean(false);
+
+    TestPlugin() {
+      super("test-plugin");
+    }
+
+    @Override
+    public Maybe<Content> onUserMessageCallback(
+        InvocationContext invocationContext, Content userMessage) {
+      wasCalled.set(true);
+      return Maybe.empty();
+    }
+  }
+
   private ToolContext createToolContext(BaseAgent agent) {
     Session session =
         sessionService.createSession("test-app", "test-user", null, "test-session").blockingGet();


### PR DESCRIPTION
This PR enhances `AgentTool` to support hierarchical agent execution with shared context and persistence with unbroken backward-compatibility.
Currently, `AgentTool` always instantiates fresh in-memory services (`Session`, `Artifact`, `Memory`) and no plugins for the sub-agent. This change adds a new factory method `AgentTool.create(...)` that allows injecting existing service instances and a list of plugins.
This enables scenarios where a parent agent needs to share a specific session store or memory context with a sub-agent, or when specific plugins (like logging or observability) need to be propagated to the sub-agent's runner.