### PR TITLE
feat: Implementation of MySQL-backed session service for ADK

### DIFF
--- a/.github/workflows/mysql-session-service-integration.yml
+++ b/.github/workflows/mysql-session-service-integration.yml
@@ -1,0 +1,43 @@
+name: MySQL session service integration
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "contrib/mysql-session-service/**"
+      - "core/**"
+      - "pom.xml"
+      - ".mvn/**"
+      - ".github/workflows/mysql-session-service-integration.yml"
+      - "mvnw"
+      - "mvnw.cmd"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  mysql-integration:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+
+      - name: Set up Java 17
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
+        with:
+          distribution: temurin
+          java-version: "17"
+          cache: maven
+
+      - name: Install ADK core without tests
+        run: ./mvnw -pl core -am -DskipTests install
+
+      - name: Run MySQL unit and container integration tests
+        run: ./mvnw -pl contrib/mysql-session-service -Pintegration-tests verify

--- a/contrib/mysql-session-service/README.md
+++ b/contrib/mysql-session-service/README.md
@@ -1,0 +1,130 @@
+# MySQL Session Service for ADK
+
+This sub-module contains an implementation of a session service for the ADK (Agent Development Kit) that uses MySQL as the backend for storing session data. This allows developers to manage user sessions in a scalable and reliable manner using MySQL's relational database capabilities and JSON column support.
+
+## Getting Started
+
+To integrate this MySQL session service into your ADK project, add the following dependencies to your project's build configuration.
+
+### Maven
+
+```xml
+<dependencies>
+    <!-- ADK Core -->
+    <dependency>
+        <groupId>com.google.adk</groupId>
+        <artifactId>google-adk</artifactId>
+        <version>0.4.1-SNAPSHOT</version>
+    </dependency>
+    <!-- MySQL Session Service -->
+    <dependency>
+        <groupId>com.google.adk.contrib</groupId>
+        <artifactId>google-adk-mysql-session-service</artifactId>
+        <version>0.4.1-SNAPSHOT</version>
+    </dependency>
+    <!-- MySQL Connector (or your preferred driver) -->
+    <dependency>
+        <groupId>com.mysql</groupId>
+        <artifactId>mysql-connector-j</artifactId>
+        <version>8.3.0</version>
+    </dependency>
+    <!-- HikariCP (Recommended for connection pooling) -->
+    <dependency>
+        <groupId>com.zaxxer</groupId>
+        <artifactId>HikariCP</artifactId>
+        <version>5.1.0</version>
+    </dependency>
+</dependencies>
+```
+
+## Database Schema
+
+You must create the following tables in your MySQL database (version 8.0+ required for JSON support).
+
+```sql
+CREATE TABLE IF NOT EXISTS adk_sessions (
+    session_id VARCHAR(255) PRIMARY KEY,
+    app_name VARCHAR(255) NOT NULL,
+    user_id VARCHAR(255) NOT NULL,
+    state JSON,
+    created_at TIMESTAMP(3) DEFAULT CURRENT_TIMESTAMP(3),
+    updated_at TIMESTAMP(3) DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3),
+    INDEX idx_app_user (app_name, user_id)
+);
+
+CREATE TABLE IF NOT EXISTS adk_events (
+    event_id VARCHAR(255) PRIMARY KEY,
+    session_id VARCHAR(255) NOT NULL,
+    event_data JSON,
+    created_at TIMESTAMP(3) DEFAULT CURRENT_TIMESTAMP(3),
+    FOREIGN KEY (session_id) REFERENCES adk_sessions(session_id) ON DELETE CASCADE,
+    INDEX idx_session_created (session_id, created_at)
+);
+
+CREATE TABLE IF NOT EXISTS adk_app_state (
+    app_name VARCHAR(255) NOT NULL,
+    state_key VARCHAR(768) NOT NULL,
+    state_value JSON,
+    PRIMARY KEY (app_name, state_key)
+);
+
+CREATE TABLE IF NOT EXISTS adk_user_state (
+    app_name VARCHAR(255) NOT NULL,
+    user_id VARCHAR(255) NOT NULL,
+    state_key VARCHAR(768) NOT NULL,
+    state_value JSON,
+    PRIMARY KEY (app_name, user_id, state_key)
+);
+```
+
+## Usage
+
+You can configure the `MySqlSessionService` by passing a `DataSource`. We recommend using HikariCP for production connection pooling.
+
+```java
+import com.google.adk.runner.Runner;
+import com.google.adk.sessions.MySqlSessionService;
+import com.zaxxer.hikari.HikariConfig;
+import com.zaxxer.hikari.HikariDataSource;
+import javax.sql.DataSource;
+
+public class MyApp {
+    public static void main(String[] args) {
+        // 1. Configure Data Source
+        HikariConfig config = new HikariConfig();
+        config.setJdbcUrl("jdbc:mysql://localhost:3306/my_db");
+        config.setUsername("user");
+        config.setPassword("password");
+        DataSource dataSource = new HikariDataSource(config);
+
+        // 2. Create the Session Service
+        MySqlSessionService sessionService = new MySqlSessionService(dataSource);
+
+        // 3. Pass it to the Runner
+        Runner runner = new Runner(
+            new MyAgent(), 
+            "MyAppName", 
+            new InMemoryArtifactService(), // or GcsArtifactService
+            sessionService,                // <--- Your MySQL Service
+            new InMemoryMemoryService()    // or FirestoreMemoryService
+        );
+        
+        runner.runLive();
+    }
+}
+```
+
+## Testing
+
+This module includes both unit tests and integration tests.
+
+*   **Unit Tests:** Fast, in-memory tests that mock the database connection. These verify the service logic without requiring a running database.
+    ```bash
+    mvn test
+    ```
+
+*   **Integration Tests:** Comprehensive tests that run against a real MySQL instance using [Testcontainers](https://testcontainers.com/). These require a Docker environment (e.g., Docker Desktop, or a CI runner with Docker support).
+    ```bash
+    mvn verify
+    ```
+

--- a/contrib/mysql-session-service/README.md
+++ b/contrib/mysql-session-service/README.md
@@ -1,0 +1,98 @@
+# MySQL Session Service for ADK
+
+This module provides a MySQL-backed implementation of ADK's `BaseSessionService`. It persists
+sessions, events, and app- and user-scoped state while keeping the MySQL JDBC driver and connection
+pool under the application's control.
+
+## Dependency
+
+Use the same version for ADK core and this module. The MySQL driver and a production connection pool
+are intentionally not forced on consumers; add the implementations used by your application.
+
+```xml
+<properties>
+    <adk.version>1.7.2-SNAPSHOT</adk.version>
+</properties>
+
+<dependencies>
+    <dependency>
+        <groupId>com.google.adk</groupId>
+        <artifactId>google-adk</artifactId>
+        <version>${adk.version}</version>
+    </dependency>
+    <dependency>
+        <groupId>com.google.adk</groupId>
+        <artifactId>google-adk-mysql-session-service</artifactId>
+        <version>${adk.version}</version>
+    </dependency>
+    <dependency>
+        <groupId>com.mysql</groupId>
+        <artifactId>mysql-connector-j</artifactId>
+        <version>8.3.0</version>
+    </dependency>
+    <dependency>
+        <groupId>com.zaxxer</groupId>
+        <artifactId>HikariCP</artifactId>
+        <version>5.1.0</version>
+    </dependency>
+</dependencies>
+```
+
+## Database schema
+
+MySQL 8.0 or newer is required. Apply the packaged
+[`mysql-session-service-schema.sql`](src/main/resources/mysql-session-service-schema.sql) before
+constructing the service.
+
+The session identity is the ADK `SessionKey` tuple `(app_name, user_id, session_id)`, so the same
+client-generated session ID can safely be reused in a different app or user scope. Events use an
+internal monotonic sequence to provide deterministic ordering when multiple events have the same
+millisecond timestamp.
+
+The schema in earlier preview revisions of this contribution used globally unique `session_id` and
+`event_id` primary keys. Recreate or migrate those tables before upgrading to this schema.
+
+## Usage
+
+Configure a `DataSource`, construct the service, and pass it to the current `Runner` builder.
+
+```java
+import com.google.adk.runner.Runner;
+import com.google.adk.sessions.MySqlSessionService;
+import com.zaxxer.hikari.HikariConfig;
+import com.zaxxer.hikari.HikariDataSource;
+
+HikariConfig config = new HikariConfig();
+config.setJdbcUrl("jdbc:mysql://localhost:3306/my_db");
+config.setUsername("user");
+config.setPassword("password");
+HikariDataSource dataSource = new HikariDataSource(config);
+
+MySqlSessionService sessionService = new MySqlSessionService(dataSource);
+Runner runner =
+    Runner.builder()
+        .agent(myAgent)
+        .appName("my-app")
+        .sessionService(sessionService)
+        .build();
+```
+
+App-prefixed (`app:`) and user-prefixed (`user:`) values supplied when creating a session are
+persisted in their respective shared state scopes. Temporary (`temp:`) values are returned on the
+newly created session but are intentionally not persisted and therefore do not appear after a
+reload.
+
+## Testing
+
+Unit and contract tests use H2 in MySQL compatibility mode and require no external services:
+
+```bash
+./mvnw -pl contrib/mysql-session-service -am test
+```
+
+The integration profile runs the `*IT` tests against a real MySQL container and therefore requires
+Docker:
+
+```bash
+./mvnw -pl contrib/mysql-session-service -am -Pintegration-tests verify
+```

--- a/contrib/mysql-session-service/pom.xml
+++ b/contrib/mysql-session-service/pom.xml
@@ -1,0 +1,121 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright 2025 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.google.adk</groupId>
+        <artifactId>google-adk-parent</artifactId>
+        <version>1.0.1-rc.1-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>google-adk-mysql-session-service</artifactId>
+    <name>Agent Development Kit - MySQL Session Management</name>
+    <description>MySQL integration with Agent Development Kit for User Session Management</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.google.adk</groupId>
+            <artifactId>google-adk</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.google.genai</groupId>
+            <artifactId>google-genai</artifactId>
+        </dependency>
+        
+        <dependency>
+            <groupId>com.mysql</groupId>
+            <artifactId>mysql-connector-j</artifactId>
+            <version>8.3.0</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- Testing -->
+        <dependency>
+            <groupId>com.google.truth</groupId>
+            <artifactId>truth</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>mysql</artifactId>
+            <version>1.19.7</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>1.19.7</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.zaxxer</groupId>
+            <artifactId>HikariCP</artifactId>
+            <version>5.1.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <version>2.0.17</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <version>2.2.224</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <version>3.2.5</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/contrib/mysql-session-service/pom.xml
+++ b/contrib/mysql-session-service/pom.xml
@@ -1,0 +1,133 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright 2025 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.google.adk</groupId>
+        <artifactId>google-adk-parent</artifactId>
+        <version>1.7.2-SNAPSHOT</version><!-- {x-version-update:google-adk:current} -->
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>google-adk-mysql-session-service</artifactId>
+    <name>Agent Development Kit - MySQL Session Management</name>
+    <description>MySQL integration with Agent Development Kit for User Session Management</description>
+
+    <properties>
+        <testcontainers.version>1.21.3</testcontainers.version>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.testcontainers</groupId>
+                <artifactId>testcontainers-bom</artifactId>
+                <version>${testcontainers.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.google.adk</groupId>
+            <artifactId>google-adk</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.mysql</groupId>
+            <artifactId>mysql-connector-j</artifactId>
+            <version>8.3.0</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- Testing -->
+        <dependency>
+            <groupId>com.google.truth</groupId>
+            <artifactId>truth</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>mysql</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.zaxxer</groupId>
+            <artifactId>HikariCP</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <profiles>
+        <profile>
+            <id>integration-tests</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <version>3.5.2</version>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>integration-test</goal>
+                                    <goal>verify</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+</project>

--- a/contrib/mysql-session-service/src/main/java/com/google/adk/sessions/MySqlDBHelper.java
+++ b/contrib/mysql-session-service/src/main/java/com/google/adk/sessions/MySqlDBHelper.java
@@ -1,0 +1,549 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.adk.sessions;
+
+import static java.util.stream.Collectors.toMap;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.adk.JsonBaseModel;
+import com.google.adk.events.Event;
+import io.reactivex.rxjava3.core.Completable;
+import io.reactivex.rxjava3.core.Maybe;
+import io.reactivex.rxjava3.core.Single;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import javax.sql.DataSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** Helper class for MySQL database operations. */
+public class MySqlDBHelper {
+
+  private static final Logger logger = LoggerFactory.getLogger(MySqlDBHelper.class);
+
+  private final DataSource dataSource;
+  private final ObjectMapper objectMapper;
+
+  public MySqlDBHelper(DataSource dataSource) {
+    this.dataSource = dataSource;
+    this.objectMapper = JsonBaseModel.getMapper();
+  }
+
+  public Completable saveSession(Session session) {
+    return Completable.fromAction(
+        () -> {
+          String sql =
+              "INSERT INTO adk_sessions (session_id, app_name, user_id, state, created_at,"
+                  + " updated_at) VALUES (?, ?, ?, ?, ?, ?)";
+          try (Connection conn = dataSource.getConnection();
+              PreparedStatement pstmt = conn.prepareStatement(sql)) {
+
+            // Filter out global and temporary state keys to prevent shadowing and persisting
+            // ephemeral state
+            Map<String, Object> localStateOnly =
+                session.state().entrySet().stream()
+                    .filter(
+                        e ->
+                            !e.getKey().startsWith(State.APP_PREFIX)
+                                && !e.getKey().startsWith(State.USER_PREFIX)
+                                && !e.getKey().startsWith(State.TEMP_PREFIX))
+                    .collect(toMap(Map.Entry::getKey, Map.Entry::getValue));
+            String stateJson = objectMapper.writeValueAsString(localStateOnly);
+
+            pstmt.setString(1, session.id());
+            pstmt.setString(2, session.appName());
+            pstmt.setString(3, session.userId());
+            pstmt.setString(4, stateJson);
+            pstmt.setTimestamp(5, Timestamp.from(session.lastUpdateTime()));
+            pstmt.setTimestamp(6, Timestamp.from(session.lastUpdateTime()));
+
+            pstmt.executeUpdate();
+          } catch (SQLException e) {
+            if (e.getErrorCode() == 1062
+                || (e.getSQLState() != null
+                    && e.getSQLState().startsWith("23"))) { // Duplicate entry
+              throw new SessionException("Session with id " + session.id() + " already exists.", e);
+            }
+            throw new SessionException("Failed to save session", e);
+          } catch (JsonProcessingException e) {
+            throw new SessionException("Failed to serialize session state", e);
+          }
+        });
+  }
+
+  public Completable appendEventAndUpdateState(Session session, Event event) {
+    return Completable.fromAction(
+        () -> {
+          String insertEventSql =
+              "INSERT INTO adk_events (event_id, session_id, event_data, created_at) VALUES (?,"
+                  + " ?, ?, ?)";
+          String updateSessionSql =
+              "UPDATE adk_sessions SET updated_at = ?, state = ? WHERE session_id = ? AND updated_at"
+                  + " = ?";
+
+          String upsertAppStateSql =
+              "INSERT INTO adk_app_state (app_name, state_key, state_value) VALUES (?, ?, ?)"
+                  + " ON DUPLICATE KEY UPDATE state_value = ?";
+          String upsertUserStateSql =
+              "INSERT INTO adk_user_state (app_name, user_id, state_key, state_value) VALUES"
+                  + " (?, ?, ?, ?) ON DUPLICATE KEY UPDATE state_value = ?";
+
+          String deleteAppStateSql =
+              "DELETE FROM adk_app_state WHERE app_name = ? AND state_key = ?";
+          String deleteUserStateSql =
+              "DELETE FROM adk_user_state WHERE app_name = ? AND user_id = ? AND state_key = ?";
+
+          Connection conn = null;
+          try {
+            conn = dataSource.getConnection();
+            conn.setAutoCommit(false);
+
+            // 1. Insert the event
+            try (PreparedStatement pstmt = conn.prepareStatement(insertEventSql)) {
+              String eventJson = objectMapper.writeValueAsString(event);
+              pstmt.setString(1, event.id());
+              pstmt.setString(2, session.id());
+              pstmt.setString(3, eventJson);
+              pstmt.setTimestamp(4, Timestamp.from(Instant.ofEpochMilli(event.timestamp())));
+              pstmt.executeUpdate();
+            }
+
+            // 2. Handle Global State Delta (App/User)
+            if (event.actions() != null && event.actions().stateDelta() != null) {
+              try (PreparedStatement upsertAppStmt = conn.prepareStatement(upsertAppStateSql);
+                  PreparedStatement upsertUserStmt = conn.prepareStatement(upsertUserStateSql);
+                  PreparedStatement deleteAppStmt = conn.prepareStatement(deleteAppStateSql);
+                  PreparedStatement deleteUserStmt = conn.prepareStatement(deleteUserStateSql)) {
+
+                for (Map.Entry<String, Object> entry : event.actions().stateDelta().entrySet()) {
+                  String key = entry.getKey();
+                  Object value = entry.getValue();
+
+                  if (key.startsWith(State.USER_PREFIX)) {
+                    // User State
+                    String dbKey = key.substring(State.USER_PREFIX.length());
+                    if (value == null || value == State.REMOVED) {
+                      deleteUserStmt.setString(1, session.appName());
+                      deleteUserStmt.setString(2, session.userId());
+                      deleteUserStmt.setString(3, dbKey);
+                      deleteUserStmt.addBatch();
+                    } else {
+                      String valueJson = objectMapper.writeValueAsString(value);
+                      upsertUserStmt.setString(1, session.appName());
+                      upsertUserStmt.setString(2, session.userId());
+                      upsertUserStmt.setString(3, dbKey);
+                      upsertUserStmt.setString(4, valueJson);
+                      upsertUserStmt.setString(5, valueJson);
+                      upsertUserStmt.addBatch();
+                    }
+                  } else if (key.startsWith(State.APP_PREFIX)) {
+                    // App State
+                    String dbKey = key.substring(State.APP_PREFIX.length());
+                    if (value == null || value == State.REMOVED) {
+                      deleteAppStmt.setString(1, session.appName());
+                      deleteAppStmt.setString(2, dbKey);
+                      deleteAppStmt.addBatch();
+                    } else {
+                      String valueJson = objectMapper.writeValueAsString(value);
+                      upsertAppStmt.setString(1, session.appName());
+                      upsertAppStmt.setString(2, dbKey);
+                      upsertAppStmt.setString(3, valueJson);
+                      upsertAppStmt.setString(4, valueJson);
+                      upsertAppStmt.addBatch();
+                    }
+                  }
+                }
+                upsertUserStmt.executeBatch();
+                upsertAppStmt.executeBatch();
+                deleteUserStmt.executeBatch();
+                deleteAppStmt.executeBatch();
+              }
+            }
+
+            // 3. Update session (Last Update Time AND State)
+            // Capture the new timestamp to be used for DB and Session object
+            Instant newLastUpdateTime = Instant.now().truncatedTo(ChronoUnit.MILLIS);
+            try (PreparedStatement pstmt = conn.prepareStatement(updateSessionSql)) {
+              // Start with local-only keys from the current session state (filtering out global
+              // and temp keys)
+              Map<String, Object> localStateOnly =
+                  session.state().entrySet().stream()
+                      .filter(
+                          e ->
+                              !e.getKey().startsWith(State.APP_PREFIX)
+                                  && !e.getKey().startsWith(State.USER_PREFIX)
+                                  && !e.getKey().startsWith(State.TEMP_PREFIX))
+                      .collect(toMap(Map.Entry::getKey, Map.Entry::getValue));
+
+              // Merge session-local deltas from the event into the map before serializing.
+              // This is necessary because the session object itself is updated only AFTER commit.
+              if (event.actions() != null && event.actions().stateDelta() != null) {
+                event
+                    .actions()
+                    .stateDelta()
+                    .forEach(
+                        (k, v) -> {
+                          if (!k.startsWith(State.APP_PREFIX)
+                              && !k.startsWith(State.USER_PREFIX)
+                              && !k.startsWith(State.TEMP_PREFIX)) {
+                            if (v == null || v == State.REMOVED) {
+                              localStateOnly.remove(k);
+                            } else {
+                              localStateOnly.put(k, v);
+                            }
+                          }
+                        });
+              }
+              String currentSessionStateJson = objectMapper.writeValueAsString(localStateOnly);
+
+              pstmt.setTimestamp(1, Timestamp.from(newLastUpdateTime));
+              pstmt.setString(2, currentSessionStateJson);
+              pstmt.setString(3, session.id());
+              pstmt.setTimestamp(4, Timestamp.from(session.lastUpdateTime()));
+              int updatedRows = pstmt.executeUpdate();
+              if (updatedRows == 0) {
+                throw new java.util.ConcurrentModificationException(
+                    "Session has been modified by another transaction");
+              }
+            }
+
+            conn.commit();
+            // Update the session object with the new timestamp so subsequent calls use the
+            // correct version
+            session.lastUpdateTime(newLastUpdateTime);
+          } catch (SQLException | JsonProcessingException e) {
+            if (conn != null) {
+              try {
+                conn.rollback();
+              } catch (SQLException ex) {
+                e.addSuppressed(ex);
+              }
+            }
+            throw new SessionException("Failed to append event and update state", e);
+          } finally {
+            if (conn != null) {
+              try {
+                conn.setAutoCommit(true);
+              } catch (SQLException e) {
+                logger.warn("Failed to reset auto-commit", e);
+              }
+              try {
+                conn.close();
+              } catch (SQLException e) {
+                logger.warn("Failed to close connection", e);
+              }
+            }
+          }
+        });
+  }
+
+  public Maybe<Session> getSession(
+      String appName, String userId, String sessionId, Optional<GetSessionConfig> configOpt) {
+    return Maybe.fromCallable(
+        () -> {
+          String sessionSql =
+              "SELECT * FROM adk_sessions WHERE session_id = ? AND app_name = ? AND user_id = ?";
+
+          GetSessionConfig config = configOpt.orElse(GetSessionConfig.builder().build());
+          StringBuilder eventsSqlBuilder =
+              new StringBuilder("SELECT event_data FROM adk_events WHERE session_id = ?");
+
+          config.afterTimestamp().ifPresent(ts -> eventsSqlBuilder.append(" AND created_at > ?"));
+
+          if (config.numRecentEvents().isPresent()) {
+            eventsSqlBuilder.append(" ORDER BY created_at DESC LIMIT ?");
+          } else {
+            eventsSqlBuilder.append(" ORDER BY created_at ASC");
+          }
+
+          try (Connection conn = dataSource.getConnection()) {
+            Session session = null;
+            ConcurrentHashMap<String, Object> finalState = new ConcurrentHashMap<>();
+
+            // 1. Get Global App State
+            try (PreparedStatement pstmt =
+                conn.prepareStatement(
+                    "SELECT state_key, state_value FROM adk_app_state WHERE app_name = ?")) {
+              pstmt.setString(1, appName);
+              try (ResultSet rs = pstmt.executeQuery()) {
+                while (rs.next()) {
+                  finalState.put(
+                      State.APP_PREFIX + rs.getString("state_key"),
+                      objectMapper.readValue(rs.getString("state_value"), Object.class));
+                }
+              }
+            }
+
+            // 2. Get Global User State
+            try (PreparedStatement pstmt =
+                conn.prepareStatement(
+                    "SELECT state_key, state_value FROM adk_user_state WHERE app_name = ? AND"
+                        + " user_id = ?")) {
+              pstmt.setString(1, appName);
+              pstmt.setString(2, userId);
+              try (ResultSet rs = pstmt.executeQuery()) {
+                while (rs.next()) {
+                  finalState.put(
+                      State.USER_PREFIX + rs.getString("state_key"),
+                      objectMapper.readValue(rs.getString("state_value"), Object.class));
+                }
+              }
+            }
+
+            try (PreparedStatement sessionPstmt = conn.prepareStatement(sessionSql)) {
+              sessionPstmt.setString(1, sessionId);
+              sessionPstmt.setString(2, appName);
+              sessionPstmt.setString(3, userId);
+              try (ResultSet rs = sessionPstmt.executeQuery()) {
+                if (rs.next()) {
+                  // 3. Merge Session State
+                  String stateJson = rs.getString("state");
+                  Map<String, Object> sessionStateMap =
+                      stateJson != null ? objectMapper.readValue(stateJson, Map.class) : Map.of();
+
+                  ConcurrentHashMap<String, Object> mergedState = new ConcurrentHashMap<>();
+                  finalState.forEach(
+                      (k, v) -> {
+                        if (v != null) mergedState.put(k, v);
+                      });
+                  sessionStateMap.forEach(
+                      (k, v) -> {
+                        if (v != null) mergedState.put(k, v);
+                      });
+                  finalState = mergedState;
+
+                  Instant updatedAt = rs.getTimestamp("updated_at").toInstant();
+                  session =
+                      Session.builder(rs.getString("session_id"))
+                          .appName(rs.getString("app_name"))
+                          .userId(rs.getString("user_id"))
+                          .state(new State(finalState))
+                          .events(new ArrayList<>())
+                          .lastUpdateTime(updatedAt)
+                          .build();
+                }
+              }
+            }
+
+            if (session != null) {
+              try (PreparedStatement eventsPstmt =
+                  conn.prepareStatement(eventsSqlBuilder.toString())) {
+                int paramIndex = 1;
+                eventsPstmt.setString(paramIndex++, sessionId);
+
+                if (config.afterTimestamp().isPresent()) {
+                  eventsPstmt.setTimestamp(
+                      paramIndex++, Timestamp.from(config.afterTimestamp().get()));
+                }
+                if (config.numRecentEvents().isPresent()) {
+                  eventsPstmt.setInt(paramIndex++, config.numRecentEvents().get());
+                }
+
+                try (ResultSet rs = eventsPstmt.executeQuery()) {
+                  while (rs.next()) {
+                    Event event = objectMapper.readValue(rs.getString("event_data"), Event.class);
+                    session.events().add(event);
+                  }
+                }
+              }
+              // If we fetched in DESC order to get the last N, we must reverse to restore
+              // chronological order.
+              if (config.numRecentEvents().isPresent()) {
+                java.util.Collections.reverse(session.events());
+              }
+              return session;
+            }
+            return null; // Will complete the Maybe
+          } catch (SQLException | JsonProcessingException e) {
+            throw new SessionException("Failed to get session", e);
+          }
+        });
+  }
+
+  public Single<List<Event>> listEvents(String appName, String userId, String sessionId) {
+    return Single.fromCallable(
+        () -> {
+          String sql =
+              "SELECT e.event_data FROM adk_events e JOIN adk_sessions s ON e.session_id ="
+                  + " s.session_id WHERE s.session_id = ? AND s.app_name = ? AND s.user_id = ?"
+                  + " ORDER BY e.created_at ASC";
+          List<Event> events = new ArrayList<>();
+          try (Connection conn = dataSource.getConnection();
+              PreparedStatement pstmt = conn.prepareStatement(sql)) {
+            pstmt.setString(1, sessionId);
+            pstmt.setString(2, appName);
+            pstmt.setString(3, userId);
+            try (ResultSet rs = pstmt.executeQuery()) {
+              while (rs.next()) {
+                Event event = objectMapper.readValue(rs.getString("event_data"), Event.class);
+                events.add(event);
+              }
+            }
+          } catch (SQLException | JsonProcessingException e) {
+            throw new SessionException("Failed to list events", e);
+          }
+          return events;
+        });
+  }
+
+  public Single<List<Session>> listSessions(String appName, String userId) {
+    return Single.fromCallable(
+        () -> {
+          String sql =
+              "SELECT session_id, app_name, user_id, created_at, updated_at, state FROM"
+                  + " adk_sessions WHERE app_name = ? AND user_id = ? ORDER BY created_at DESC";
+          List<Session> sessions = new ArrayList<>();
+          try (Connection conn = dataSource.getConnection()) {
+            ConcurrentHashMap<String, Object> globalState = new ConcurrentHashMap<>();
+
+            // 1. Get Global App State
+            try (PreparedStatement pstmt =
+                conn.prepareStatement(
+                    "SELECT state_key, state_value FROM adk_app_state WHERE app_name = ?")) {
+              pstmt.setString(1, appName);
+              try (ResultSet rs = pstmt.executeQuery()) {
+                while (rs.next()) {
+                  globalState.put(
+                      State.APP_PREFIX + rs.getString("state_key"),
+                      objectMapper.readValue(rs.getString("state_value"), Object.class));
+                }
+              }
+            }
+
+            // 2. Get Global User State
+            try (PreparedStatement pstmt =
+                conn.prepareStatement(
+                    "SELECT state_key, state_value FROM adk_user_state WHERE app_name = ? AND"
+                        + " user_id = ?")) {
+              pstmt.setString(1, appName);
+              pstmt.setString(2, userId);
+              try (ResultSet rs = pstmt.executeQuery()) {
+                while (rs.next()) {
+                  globalState.put(
+                      State.USER_PREFIX + rs.getString("state_key"),
+                      objectMapper.readValue(rs.getString("state_value"), Object.class));
+                }
+              }
+            }
+
+            // 3. Get Sessions
+            try (PreparedStatement pstmt = conn.prepareStatement(sql)) {
+              pstmt.setString(1, appName);
+              pstmt.setString(2, userId);
+              try (ResultSet rs = pstmt.executeQuery()) {
+                while (rs.next()) {
+                  Instant updatedAt = rs.getTimestamp("updated_at").toInstant();
+                  String stateJson = rs.getString("state");
+                  Map<String, Object> sessionStateMap =
+                      stateJson != null ? objectMapper.readValue(stateJson, Map.class) : Map.of();
+
+                  ConcurrentHashMap<String, Object> mergedState = new ConcurrentHashMap<>();
+                  globalState.forEach(
+                      (k, v) -> {
+                        if (v != null) mergedState.put(k, v);
+                      });
+                  sessionStateMap.forEach(
+                      (k, v) -> {
+                        if (v != null) mergedState.put(k, v);
+                      });
+
+                  sessions.add(
+                      Session.builder(rs.getString("session_id"))
+                          .appName(rs.getString("app_name"))
+                          .userId(rs.getString("user_id"))
+                          .state(new State(mergedState))
+                          .events(new ArrayList<>())
+                          .lastUpdateTime(updatedAt)
+                          .build());
+                }
+              }
+            }
+          } catch (SQLException e) {
+            throw new SessionException("Failed to list sessions", e);
+          }
+          return sessions;
+        });
+  }
+
+  public Single<ConcurrentHashMap<String, Object>> getInitialState(String appName, String userId) {
+    return Single.fromCallable(
+        () -> {
+          ConcurrentHashMap<String, Object> initialState = new ConcurrentHashMap<>();
+          try (Connection conn = dataSource.getConnection()) {
+            // 1. Get Global App State
+            try (PreparedStatement pstmt =
+                conn.prepareStatement(
+                    "SELECT state_key, state_value FROM adk_app_state WHERE app_name = ?")) {
+              pstmt.setString(1, appName);
+              try (ResultSet rs = pstmt.executeQuery()) {
+                while (rs.next()) {
+                  initialState.put(
+                      State.APP_PREFIX + rs.getString("state_key"),
+                      objectMapper.readValue(rs.getString("state_value"), Object.class));
+                }
+              }
+            }
+
+            // 2. Get Global User State and merge it, overwriting app state if keys conflict
+            try (PreparedStatement pstmt =
+                conn.prepareStatement(
+                    "SELECT state_key, state_value FROM adk_user_state WHERE app_name = ? AND"
+                        + " user_id = ?")) {
+              pstmt.setString(1, appName);
+              pstmt.setString(2, userId);
+              try (ResultSet rs = pstmt.executeQuery()) {
+                while (rs.next()) {
+                  initialState.put(
+                      State.USER_PREFIX + rs.getString("state_key"),
+                      objectMapper.readValue(rs.getString("state_value"), Object.class));
+                }
+              }
+            }
+          } catch (SQLException | JsonProcessingException e) {
+            throw new SessionException("Failed to get initial state", e);
+          }
+          return initialState;
+        });
+  }
+
+  public Completable deleteSession(String appName, String userId, String sessionId) {
+    return Completable.fromAction(
+        () -> {
+          String deleteSessionSql =
+              "DELETE FROM adk_sessions WHERE session_id = ? AND app_name = ? AND user_id = ?";
+          try (Connection conn = dataSource.getConnection();
+              PreparedStatement pstmt = conn.prepareStatement(deleteSessionSql)) {
+            pstmt.setString(1, sessionId);
+            pstmt.setString(2, appName);
+            pstmt.setString(3, userId);
+            pstmt.executeUpdate();
+          } catch (SQLException e) {
+            throw new SessionException("Failed to delete session", e);
+          }
+        });
+  }
+}

--- a/contrib/mysql-session-service/src/main/java/com/google/adk/sessions/MySqlDBHelper.java
+++ b/contrib/mysql-session-service/src/main/java/com/google/adk/sessions/MySqlDBHelper.java
@@ -1,0 +1,549 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.adk.sessions;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.google.adk.JsonBaseModel;
+import com.google.adk.events.Event;
+import io.reactivex.rxjava3.core.Completable;
+import io.reactivex.rxjava3.core.Maybe;
+import io.reactivex.rxjava3.core.Single;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import javax.sql.DataSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** Helper class for MySQL database operations. */
+public class MySqlDBHelper {
+
+  private static final Logger logger = LoggerFactory.getLogger(MySqlDBHelper.class);
+  private static final String LEGACY_REMOVED_SENTINEL = "__ADK_SENTINEL_REMOVED__";
+  private static final int EVENT_FORMAT_VERSION = 2;
+
+  private static final String UPSERT_APP_STATE_SQL =
+      "INSERT INTO adk_app_state (app_name, state_key, state_value) VALUES (?, ?, ?)"
+          + " ON DUPLICATE KEY UPDATE state_value = ?";
+  private static final String UPSERT_USER_STATE_SQL =
+      "INSERT INTO adk_user_state (app_name, user_id, state_key, state_value) VALUES"
+          + " (?, ?, ?, ?) ON DUPLICATE KEY UPDATE state_value = ?";
+  private static final String DELETE_APP_STATE_SQL =
+      "DELETE FROM adk_app_state WHERE app_name = ? AND state_key = ?";
+  private static final String DELETE_USER_STATE_SQL =
+      "DELETE FROM adk_user_state WHERE app_name = ? AND user_id = ? AND state_key = ?";
+
+  private final DataSource dataSource;
+  private final ObjectMapper objectMapper;
+
+  public MySqlDBHelper(DataSource dataSource) {
+    this.dataSource = dataSource;
+    this.objectMapper = JsonBaseModel.getMapper();
+  }
+
+  /** Saves a session and any app- or user-scoped values supplied in its initial state. */
+  public Completable saveSession(Session session) {
+    return Completable.fromAction(
+        () -> {
+          String insertSessionSql =
+              "INSERT INTO adk_sessions (app_name, user_id, session_id, state, created_at,"
+                  + " updated_at) VALUES (?, ?, ?, ?, ?, ?)";
+          Connection conn = null;
+          try {
+            conn = dataSource.getConnection();
+            conn.setAutoCommit(false);
+
+            try (PreparedStatement pstmt = conn.prepareStatement(insertSessionSql)) {
+              String stateJson = objectMapper.writeValueAsString(localState(session.state()));
+              pstmt.setString(1, session.appName());
+              pstmt.setString(2, session.userId());
+              pstmt.setString(3, session.id());
+              pstmt.setString(4, stateJson);
+              pstmt.setTimestamp(5, Timestamp.from(session.lastUpdateTime()));
+              pstmt.setTimestamp(6, Timestamp.from(session.lastUpdateTime()));
+              pstmt.executeUpdate();
+            }
+
+            applyGlobalStateChanges(conn, session.appName(), session.userId(), session.state());
+            conn.commit();
+          } catch (Exception e) {
+            rollback(conn, e);
+            if (e instanceof SQLException sqlException && isDuplicateKey(sqlException)) {
+              throw new SessionException(
+                  "Session " + session.sessionKey() + " already exists.", sqlException);
+            }
+            if (e instanceof SessionException sessionException) {
+              throw sessionException;
+            }
+            throw new SessionException("Failed to save session", e);
+          } finally {
+            closeTransactionConnection(conn);
+          }
+        });
+  }
+
+  /** Persists an event and all resulting state changes in one transaction. */
+  public Completable appendEventAndUpdateState(Session session, Event event) {
+    return Completable.fromAction(
+        () -> {
+          String insertEventSql =
+              "INSERT INTO adk_events (app_name, user_id, session_id, event_id, event_data,"
+                  + " created_at) VALUES (?, ?, ?, ?, ?, ?)";
+          String updateSessionSql =
+              "UPDATE adk_sessions SET updated_at = ?, state = ? WHERE app_name = ? AND user_id ="
+                  + " ? AND session_id = ? AND updated_at = ?";
+
+          Connection conn = null;
+          try {
+            conn = dataSource.getConnection();
+            conn.setAutoCommit(false);
+
+            try (PreparedStatement pstmt = conn.prepareStatement(insertEventSql)) {
+              pstmt.setString(1, session.appName());
+              pstmt.setString(2, session.userId());
+              pstmt.setString(3, session.id());
+              pstmt.setString(4, event.id());
+              pstmt.setString(5, serializeEvent(event));
+              pstmt.setTimestamp(6, Timestamp.from(Instant.ofEpochMilli(event.timestamp())));
+              pstmt.executeUpdate();
+            }
+
+            Map<String, Object> stateDelta =
+                event.actions() == null ? Map.of() : event.actions().stateDelta();
+            applyGlobalStateChanges(conn, session.appName(), session.userId(), stateDelta);
+
+            Map<String, Object> localState = localState(session.state());
+            applyLocalStateChanges(localState, stateDelta);
+            Instant newLastUpdateTime = nextUpdateTime(session.lastUpdateTime());
+            try (PreparedStatement pstmt = conn.prepareStatement(updateSessionSql)) {
+              pstmt.setTimestamp(1, Timestamp.from(newLastUpdateTime));
+              pstmt.setString(2, objectMapper.writeValueAsString(localState));
+              pstmt.setString(3, session.appName());
+              pstmt.setString(4, session.userId());
+              pstmt.setString(5, session.id());
+              pstmt.setTimestamp(6, Timestamp.from(session.lastUpdateTime()));
+              if (pstmt.executeUpdate() == 0) {
+                throw new java.util.ConcurrentModificationException(
+                    "Session has been modified by another transaction");
+              }
+            }
+
+            conn.commit();
+            session.lastUpdateTime(newLastUpdateTime);
+          } catch (Exception e) {
+            rollback(conn, e);
+            if (e instanceof java.util.ConcurrentModificationException concurrentModification) {
+              throw concurrentModification;
+            }
+            if (e instanceof SessionException sessionException) {
+              throw sessionException;
+            }
+            throw new SessionException("Failed to append event and update state", e);
+          } finally {
+            closeTransactionConnection(conn);
+          }
+        });
+  }
+
+  public Maybe<Session> getSession(
+      String appName, String userId, String sessionId, Optional<GetSessionConfig> configOpt) {
+    return Maybe.fromCallable(
+        () -> {
+          String sessionSql =
+              "SELECT session_id, app_name, user_id, updated_at, state FROM adk_sessions WHERE"
+                  + " app_name = ? AND user_id = ? AND session_id = ?";
+          GetSessionConfig config = configOpt.orElseGet(() -> GetSessionConfig.builder().build());
+
+          try (Connection conn = dataSource.getConnection();
+              PreparedStatement sessionPstmt = conn.prepareStatement(sessionSql)) {
+            sessionPstmt.setString(1, appName);
+            sessionPstmt.setString(2, userId);
+            sessionPstmt.setString(3, sessionId);
+
+            Session session;
+            try (ResultSet rs = sessionPstmt.executeQuery()) {
+              if (!rs.next()) {
+                return null;
+              }
+              Map<String, Object> mergedState = loadGlobalState(conn, appName, userId);
+              mergeNonNullValues(mergedState, readState(rs.getString("state")));
+              session = sessionFromRow(rs, mergedState, new ArrayList<>());
+            }
+
+            loadEvents(conn, appName, userId, sessionId, config, session.events());
+            return session;
+          } catch (SQLException | JsonProcessingException e) {
+            throw new SessionException("Failed to get session", e);
+          }
+        });
+  }
+
+  public Single<List<Event>> listEvents(String appName, String userId, String sessionId) {
+    return Single.fromCallable(
+        () -> {
+          String sql =
+              "SELECT event_data FROM adk_events WHERE app_name = ? AND user_id = ? AND"
+                  + " session_id = ? ORDER BY created_at ASC, event_sequence ASC";
+          List<Event> events = new ArrayList<>();
+          try (Connection conn = dataSource.getConnection();
+              PreparedStatement pstmt = conn.prepareStatement(sql)) {
+            pstmt.setString(1, appName);
+            pstmt.setString(2, userId);
+            pstmt.setString(3, sessionId);
+            try (ResultSet rs = pstmt.executeQuery()) {
+              while (rs.next()) {
+                events.add(deserializeEvent(rs.getString("event_data")));
+              }
+            }
+          } catch (SQLException | JsonProcessingException e) {
+            throw new SessionException("Failed to list events", e);
+          }
+          return events;
+        });
+  }
+
+  public Single<List<Session>> listSessions(String appName, String userId) {
+    return Single.fromCallable(
+        () -> {
+          String sql =
+              "SELECT session_id, app_name, user_id, updated_at, state FROM adk_sessions WHERE"
+                  + " app_name = ? AND user_id = ? ORDER BY created_at DESC, session_id ASC";
+          List<Session> sessions = new ArrayList<>();
+          try (Connection conn = dataSource.getConnection()) {
+            Map<String, Object> globalState = loadGlobalState(conn, appName, userId);
+            try (PreparedStatement pstmt = conn.prepareStatement(sql)) {
+              pstmt.setString(1, appName);
+              pstmt.setString(2, userId);
+              try (ResultSet rs = pstmt.executeQuery()) {
+                while (rs.next()) {
+                  Map<String, Object> mergedState = new HashMap<>(globalState);
+                  mergeNonNullValues(mergedState, readState(rs.getString("state")));
+                  sessions.add(sessionFromRow(rs, mergedState, new ArrayList<>()));
+                }
+              }
+            }
+          } catch (SQLException | JsonProcessingException e) {
+            throw new SessionException("Failed to list sessions", e);
+          }
+          return sessions;
+        });
+  }
+
+  public Single<ConcurrentHashMap<String, Object>> getInitialState(String appName, String userId) {
+    return Single.fromCallable(
+        () -> {
+          try (Connection conn = dataSource.getConnection()) {
+            return new ConcurrentHashMap<>(loadGlobalState(conn, appName, userId));
+          } catch (SQLException | JsonProcessingException e) {
+            throw new SessionException("Failed to get initial state", e);
+          }
+        });
+  }
+
+  public Completable deleteSession(String appName, String userId, String sessionId) {
+    return Completable.fromAction(
+        () -> {
+          String sql =
+              "DELETE FROM adk_sessions WHERE app_name = ? AND user_id = ? AND session_id = ?";
+          try (Connection conn = dataSource.getConnection();
+              PreparedStatement pstmt = conn.prepareStatement(sql)) {
+            pstmt.setString(1, appName);
+            pstmt.setString(2, userId);
+            pstmt.setString(3, sessionId);
+            pstmt.executeUpdate();
+          } catch (SQLException e) {
+            throw new SessionException("Failed to delete session", e);
+          }
+        });
+  }
+
+  private void loadEvents(
+      Connection conn,
+      String appName,
+      String userId,
+      String sessionId,
+      GetSessionConfig config,
+      List<Event> destination)
+      throws SQLException, JsonProcessingException {
+    StringBuilder sql =
+        new StringBuilder(
+            "SELECT event_data FROM adk_events WHERE app_name = ? AND user_id = ? AND"
+                + " session_id = ?");
+    config.afterTimestamp().ifPresent(unused -> sql.append(" AND created_at >= ?"));
+    if (config.numRecentEvents().isPresent()) {
+      sql.append(" ORDER BY created_at DESC, event_sequence DESC LIMIT ?");
+    } else {
+      sql.append(" ORDER BY created_at ASC, event_sequence ASC");
+    }
+
+    try (PreparedStatement pstmt = conn.prepareStatement(sql.toString())) {
+      int index = 1;
+      pstmt.setString(index++, appName);
+      pstmt.setString(index++, userId);
+      pstmt.setString(index++, sessionId);
+      if (config.afterTimestamp().isPresent()) {
+        pstmt.setTimestamp(index++, Timestamp.from(config.afterTimestamp().get()));
+      }
+      if (config.numRecentEvents().isPresent()) {
+        pstmt.setInt(index, config.numRecentEvents().get());
+      }
+      try (ResultSet rs = pstmt.executeQuery()) {
+        while (rs.next()) {
+          destination.add(deserializeEvent(rs.getString("event_data")));
+        }
+      }
+    }
+    if (config.numRecentEvents().isPresent()) {
+      Collections.reverse(destination);
+    }
+  }
+
+  private Map<String, Object> loadGlobalState(Connection conn, String appName, String userId)
+      throws SQLException, JsonProcessingException {
+    Map<String, Object> state = new HashMap<>();
+    try (PreparedStatement pstmt =
+        conn.prepareStatement(
+            "SELECT state_key, state_value FROM adk_app_state WHERE app_name = ?")) {
+      pstmt.setString(1, appName);
+      loadStateRows(pstmt, State.APP_PREFIX, state);
+    }
+    try (PreparedStatement pstmt =
+        conn.prepareStatement(
+            "SELECT state_key, state_value FROM adk_user_state WHERE app_name = ? AND user_id ="
+                + " ?")) {
+      pstmt.setString(1, appName);
+      pstmt.setString(2, userId);
+      loadStateRows(pstmt, State.USER_PREFIX, state);
+    }
+    return state;
+  }
+
+  private void loadStateRows(
+      PreparedStatement pstmt, String prefix, Map<String, Object> destination)
+      throws SQLException, JsonProcessingException {
+    try (ResultSet rs = pstmt.executeQuery()) {
+      while (rs.next()) {
+        Object value = objectMapper.readValue(rs.getString("state_value"), Object.class);
+        if (value != null) {
+          destination.put(prefix + rs.getString("state_key"), value);
+        }
+      }
+    }
+  }
+
+  private void applyGlobalStateChanges(
+      Connection conn, String appName, String userId, Map<String, Object> stateDelta)
+      throws SQLException, JsonProcessingException {
+    if (stateDelta == null || stateDelta.isEmpty()) {
+      return;
+    }
+    try (PreparedStatement upsertApp = conn.prepareStatement(UPSERT_APP_STATE_SQL);
+        PreparedStatement upsertUser = conn.prepareStatement(UPSERT_USER_STATE_SQL);
+        PreparedStatement deleteApp = conn.prepareStatement(DELETE_APP_STATE_SQL);
+        PreparedStatement deleteUser = conn.prepareStatement(DELETE_USER_STATE_SQL)) {
+      for (Map.Entry<String, Object> entry : stateDelta.entrySet()) {
+        String key = entry.getKey();
+        Object value = entry.getValue();
+        if (key.startsWith(State.APP_PREFIX)) {
+          String dbKey = key.substring(State.APP_PREFIX.length());
+          if (isRemoved(value)) {
+            deleteApp.setString(1, appName);
+            deleteApp.setString(2, dbKey);
+            deleteApp.addBatch();
+          } else {
+            String valueJson = objectMapper.writeValueAsString(value);
+            upsertApp.setString(1, appName);
+            upsertApp.setString(2, dbKey);
+            upsertApp.setString(3, valueJson);
+            upsertApp.setString(4, valueJson);
+            upsertApp.addBatch();
+          }
+        } else if (key.startsWith(State.USER_PREFIX)) {
+          String dbKey = key.substring(State.USER_PREFIX.length());
+          if (isRemoved(value)) {
+            deleteUser.setString(1, appName);
+            deleteUser.setString(2, userId);
+            deleteUser.setString(3, dbKey);
+            deleteUser.addBatch();
+          } else {
+            String valueJson = objectMapper.writeValueAsString(value);
+            upsertUser.setString(1, appName);
+            upsertUser.setString(2, userId);
+            upsertUser.setString(3, dbKey);
+            upsertUser.setString(4, valueJson);
+            upsertUser.setString(5, valueJson);
+            upsertUser.addBatch();
+          }
+        }
+      }
+      upsertApp.executeBatch();
+      upsertUser.executeBatch();
+      deleteApp.executeBatch();
+      deleteUser.executeBatch();
+    }
+  }
+
+  private String serializeEvent(Event event) throws JsonProcessingException {
+    JsonNode eventJson = objectMapper.valueToTree(event);
+    JsonNode stateDelta = eventJson.path("actions").path("stateDelta");
+    if (stateDelta instanceof ObjectNode stateDeltaObject && event.actions() != null) {
+      event
+          .actions()
+          .stateDelta()
+          .forEach(
+              (key, value) -> {
+                if (value == State.REMOVED) {
+                  stateDeltaObject.putNull(key);
+                }
+              });
+    }
+    ObjectNode storedEvent = objectMapper.createObjectNode();
+    storedEvent.put("formatVersion", EVENT_FORMAT_VERSION);
+    storedEvent.set("event", eventJson);
+    return objectMapper.writeValueAsString(storedEvent);
+  }
+
+  private Event deserializeEvent(String eventJson) throws JsonProcessingException {
+    JsonNode storedEvent = objectMapper.readTree(eventJson);
+    boolean currentFormat =
+        storedEvent.path("formatVersion").asInt() == EVENT_FORMAT_VERSION
+            && storedEvent.has("event");
+    JsonNode serializedEvent = currentFormat ? storedEvent.get("event") : storedEvent;
+    Event event = objectMapper.treeToValue(serializedEvent, Event.class);
+    if (!currentFormat && event.actions() != null) {
+      event
+          .actions()
+          .stateDelta()
+          .replaceAll(
+              (unused, value) -> LEGACY_REMOVED_SENTINEL.equals(value) ? State.REMOVED : value);
+    }
+    return event;
+  }
+
+  @SuppressWarnings("unchecked")
+  private Map<String, Object> readState(String stateJson) throws JsonProcessingException {
+    return stateJson == null ? Map.of() : objectMapper.readValue(stateJson, Map.class);
+  }
+
+  private static Session sessionFromRow(ResultSet rs, Map<String, Object> state, List<Event> events)
+      throws SQLException {
+    return Session.builder(rs.getString("session_id"))
+        .appName(rs.getString("app_name"))
+        .userId(rs.getString("user_id"))
+        .state(new State(state))
+        .events(events)
+        .lastUpdateTime(rs.getTimestamp("updated_at").toInstant())
+        .build();
+  }
+
+  private static Map<String, Object> localState(Map<String, Object> state) {
+    Map<String, Object> localState = new HashMap<>();
+    state.forEach(
+        (key, value) -> {
+          if (!isGlobalOrTemporary(key) && !isRemoved(value)) {
+            localState.put(key, value);
+          }
+        });
+    return localState;
+  }
+
+  private static void applyLocalStateChanges(
+      Map<String, Object> localState, Map<String, Object> stateDelta) {
+    if (stateDelta == null) {
+      return;
+    }
+    stateDelta.forEach(
+        (key, value) -> {
+          if (!isGlobalOrTemporary(key)) {
+            if (isRemoved(value)) {
+              localState.remove(key);
+            } else {
+              localState.put(key, value);
+            }
+          }
+        });
+  }
+
+  private static boolean isGlobalOrTemporary(String key) {
+    return key.startsWith(State.APP_PREFIX)
+        || key.startsWith(State.USER_PREFIX)
+        || key.startsWith(State.TEMP_PREFIX);
+  }
+
+  private static boolean isRemoved(Object value) {
+    return value == null || value == State.REMOVED;
+  }
+
+  private static void mergeNonNullValues(
+      Map<String, Object> destination, Map<String, Object> values) {
+    values.forEach(
+        (key, value) -> {
+          if (value != null && value != State.REMOVED) {
+            destination.put(key, value);
+          }
+        });
+  }
+
+  private static Instant nextUpdateTime(Instant previousUpdateTime) {
+    Instant now = Instant.now().truncatedTo(ChronoUnit.MILLIS);
+    return now.isAfter(previousUpdateTime) ? now : previousUpdateTime.plusMillis(1);
+  }
+
+  private static boolean isDuplicateKey(SQLException e) {
+    return e.getErrorCode() == 1062 || "23505".equals(e.getSQLState());
+  }
+
+  private static void rollback(Connection conn, Exception original) {
+    if (conn == null) {
+      return;
+    }
+    try {
+      conn.rollback();
+    } catch (SQLException rollbackFailure) {
+      original.addSuppressed(rollbackFailure);
+    }
+  }
+
+  private static void closeTransactionConnection(Connection conn) {
+    if (conn == null) {
+      return;
+    }
+    try {
+      conn.setAutoCommit(true);
+    } catch (SQLException e) {
+      logger.warn("Failed to reset auto-commit", e);
+    }
+    try {
+      conn.close();
+    } catch (SQLException e) {
+      logger.warn("Failed to close connection", e);
+    }
+  }
+}

--- a/contrib/mysql-session-service/src/main/java/com/google/adk/sessions/MySqlSessionService.java
+++ b/contrib/mysql-session-service/src/main/java/com/google/adk/sessions/MySqlSessionService.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.adk.sessions;
+
+import com.google.adk.events.Event;
+import io.reactivex.rxjava3.core.Completable;
+import io.reactivex.rxjava3.core.Maybe;
+import io.reactivex.rxjava3.core.Single;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import javax.sql.DataSource;
+import org.jspecify.annotations.Nullable;
+
+/** A MySQL-backed implementation of {@link BaseSessionService}. */
+public class MySqlSessionService implements BaseSessionService {
+
+  private final MySqlDBHelper dbHelper;
+
+  public MySqlSessionService(DataSource dataSource) {
+    this.dbHelper = new MySqlDBHelper(dataSource);
+  }
+
+  // For testing purposes
+  MySqlSessionService(MySqlDBHelper dbHelper) {
+    this.dbHelper = dbHelper;
+  }
+
+  @Deprecated
+  @Override
+  public Single<Session> createSession(
+      String appName,
+      String userId,
+      @Nullable ConcurrentMap<String, Object> state,
+      @Nullable String sessionId) {
+    return createSession(appName, userId, (Map<String, Object>) state, sessionId);
+  }
+
+  @Override
+  public Single<Session> createSession(
+      String appName,
+      String userId,
+      @Nullable Map<String, Object> state,
+      @Nullable String sessionId) {
+    return validateAppAndUser(appName, userId)
+        .andThen(createNewSession(appName, userId, state, sessionId));
+  }
+
+  private Single<Session> createNewSession(
+      String appName,
+      String userId,
+      @Nullable Map<String, Object> state,
+      @Nullable String sessionId) {
+    ConcurrentMap<String, Object> sessionState =
+        (state != null) ? new ConcurrentHashMap<>(state) : new ConcurrentHashMap<>();
+    String newSessionId =
+        (sessionId == null || sessionId.trim().isEmpty())
+            ? UUID.randomUUID().toString()
+            : sessionId;
+
+    return dbHelper
+        .getInitialState(appName, userId)
+        .flatMap(
+            globalState -> {
+              // Start with global state (defaults)
+              ConcurrentHashMap<String, Object> mergedState = new ConcurrentHashMap<>(globalState);
+              // Overlay initial session state (overrides)
+              mergedState.putAll(sessionState);
+
+              Session session =
+                  Session.builder(newSessionId)
+                      .appName(appName)
+                      .userId(userId)
+                      .state(new State(mergedState))
+                      .events(new ArrayList<>())
+                      .lastUpdateTime(Instant.now().truncatedTo(ChronoUnit.MILLIS))
+                      .build();
+
+              return dbHelper.saveSession(session).toSingleDefault(session);
+            });
+  }
+
+  @Override
+  public Maybe<Session> getSession(
+      String appName, String userId, String sessionId, Optional<GetSessionConfig> config) {
+    return validateAppAndUser(appName, userId)
+        .andThen(validateSessionId(sessionId))
+        .andThen(dbHelper.getSession(appName, userId, sessionId, config));
+  }
+
+  @Override
+  public Single<ListSessionsResponse> listSessions(String appName, String userId) {
+    return validateAppAndUser(appName, userId)
+        .andThen(
+            dbHelper
+                .listSessions(appName, userId)
+                .map(sessions -> ListSessionsResponse.builder().sessions(sessions).build()));
+  }
+
+  @Override
+  public Completable deleteSession(String appName, String userId, String sessionId) {
+    return validateAppAndUser(appName, userId)
+        .andThen(validateSessionId(sessionId))
+        .andThen(dbHelper.deleteSession(appName, userId, sessionId));
+  }
+
+  @Override
+  public Single<ListEventsResponse> listEvents(String appName, String userId, String sessionId) {
+    return validateAppAndUser(appName, userId)
+        .andThen(validateSessionId(sessionId))
+        .andThen(
+            dbHelper
+                .listEvents(appName, userId, sessionId)
+                .map(events -> ListEventsResponse.builder().events(events).build()));
+  }
+
+  @Override
+  public Single<Event> appendEvent(Session session, Event event) {
+    if (session == null) {
+      return Single.error(new IllegalArgumentException("session cannot be null."));
+    }
+    if (event == null) {
+      return Single.error(new IllegalArgumentException("event cannot be null."));
+    }
+
+    // If the event indicates it's partial or incomplete, don't process it yet.
+    if (event.partial().orElse(false)) {
+      return Single.just(event);
+    }
+
+    // Persist the new event and update state transactionally first.
+    // Only if DB update succeeds, update the in-memory session object using the base
+    // implementation.
+    return dbHelper
+        .appendEventAndUpdateState(session, event)
+        .andThen(BaseSessionService.super.appendEvent(session, event));
+  }
+
+  private Completable validateAppAndUser(String appName, String userId) {
+    if (appName == null || appName.trim().isEmpty()) {
+      return Completable.error(new IllegalArgumentException("appName cannot be null or empty."));
+    }
+    if (userId == null || userId.trim().isEmpty()) {
+      return Completable.error(new IllegalArgumentException("userId cannot be null or empty."));
+    }
+    return Completable.complete();
+  }
+
+  private Completable validateSessionId(String sessionId) {
+    if (sessionId == null || sessionId.trim().isEmpty()) {
+      return Completable.error(new IllegalArgumentException("sessionId cannot be null or empty."));
+    }
+    return Completable.complete();
+  }
+}

--- a/contrib/mysql-session-service/src/main/java/com/google/adk/sessions/MySqlSessionService.java
+++ b/contrib/mysql-session-service/src/main/java/com/google/adk/sessions/MySqlSessionService.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.adk.sessions;
+
+import com.google.adk.events.Event;
+import io.reactivex.rxjava3.core.Completable;
+import io.reactivex.rxjava3.core.Maybe;
+import io.reactivex.rxjava3.core.Single;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import javax.sql.DataSource;
+import org.jspecify.annotations.Nullable;
+
+/** A MySQL-backed implementation of {@link BaseSessionService}. */
+public class MySqlSessionService implements BaseSessionService {
+
+  private final MySqlDBHelper dbHelper;
+
+  public MySqlSessionService(DataSource dataSource) {
+    this.dbHelper = new MySqlDBHelper(dataSource);
+  }
+
+  // For testing purposes
+  MySqlSessionService(MySqlDBHelper dbHelper) {
+    this.dbHelper = dbHelper;
+  }
+
+  @Deprecated
+  @Override
+  public Single<Session> createSession(
+      String appName,
+      String userId,
+      @Nullable ConcurrentMap<String, Object> state,
+      @Nullable String sessionId) {
+    return createSession(appName, userId, (Map<String, Object>) state, sessionId);
+  }
+
+  @Override
+  public Single<Session> createSession(
+      String appName,
+      String userId,
+      @Nullable Map<String, Object> state,
+      @Nullable String sessionId) {
+    return validateAppAndUser(appName, userId)
+        .andThen(createNewSession(appName, userId, state, sessionId));
+  }
+
+  private Single<Session> createNewSession(
+      String appName,
+      String userId,
+      @Nullable Map<String, Object> state,
+      @Nullable String sessionId) {
+    ConcurrentMap<String, Object> sessionState =
+        (state != null) ? new ConcurrentHashMap<>(state) : new ConcurrentHashMap<>();
+    String newSessionId =
+        (sessionId == null || sessionId.trim().isEmpty())
+            ? UUID.randomUUID().toString()
+            : sessionId;
+
+    return dbHelper
+        .getInitialState(appName, userId)
+        .flatMap(
+            globalState -> {
+              // Start with global state (defaults)
+              ConcurrentHashMap<String, Object> mergedState = new ConcurrentHashMap<>(globalState);
+              // Overlay initial session state (overrides)
+              mergedState.putAll(sessionState);
+
+              Session session =
+                  Session.builder(newSessionId)
+                      .appName(appName)
+                      .userId(userId)
+                      .state(new State(mergedState))
+                      .events(new ArrayList<>())
+                      .lastUpdateTime(Instant.now().truncatedTo(ChronoUnit.MILLIS))
+                      .build();
+
+              return dbHelper.saveSession(session).toSingleDefault(session);
+            });
+  }
+
+  @Override
+  public Maybe<Session> getSession(
+      String appName, String userId, String sessionId, Optional<GetSessionConfig> config) {
+    if (config == null) {
+      return Maybe.error(new IllegalArgumentException("config cannot be null."));
+    }
+    return validateAppAndUser(appName, userId)
+        .andThen(validateSessionId(sessionId))
+        .andThen(dbHelper.getSession(appName, userId, sessionId, config));
+  }
+
+  @Override
+  public Single<ListSessionsResponse> listSessions(String appName, String userId) {
+    return validateAppAndUser(appName, userId)
+        .andThen(
+            dbHelper
+                .listSessions(appName, userId)
+                .map(sessions -> ListSessionsResponse.builder().sessions(sessions).build()));
+  }
+
+  @Override
+  public Completable deleteSession(String appName, String userId, String sessionId) {
+    return validateAppAndUser(appName, userId)
+        .andThen(validateSessionId(sessionId))
+        .andThen(dbHelper.deleteSession(appName, userId, sessionId));
+  }
+
+  @Override
+  public Single<ListEventsResponse> listEvents(String appName, String userId, String sessionId) {
+    return validateAppAndUser(appName, userId)
+        .andThen(validateSessionId(sessionId))
+        .andThen(
+            dbHelper
+                .listEvents(appName, userId, sessionId)
+                .map(events -> ListEventsResponse.builder().events(events).build()));
+  }
+
+  @Override
+  public Single<Event> appendEvent(Session session, Event event) {
+    if (session == null) {
+      return Single.error(new IllegalArgumentException("session cannot be null."));
+    }
+    if (event == null) {
+      return Single.error(new IllegalArgumentException("event cannot be null."));
+    }
+
+    return validateAppAndUser(session.appName(), session.userId())
+        .andThen(validateSessionId(session.id()))
+        .andThen(
+            event.partial().orElse(false)
+                ? Single.just(event)
+                : dbHelper
+                    .appendEventAndUpdateState(session, event)
+                    .andThen(BaseSessionService.super.appendEvent(session, event)));
+  }
+
+  private Completable validateAppAndUser(String appName, String userId) {
+    if (appName == null || appName.trim().isEmpty()) {
+      return Completable.error(new IllegalArgumentException("appName cannot be null or empty."));
+    }
+    if (userId == null || userId.trim().isEmpty()) {
+      return Completable.error(new IllegalArgumentException("userId cannot be null or empty."));
+    }
+    return Completable.complete();
+  }
+
+  private Completable validateSessionId(String sessionId) {
+    if (sessionId == null || sessionId.trim().isEmpty()) {
+      return Completable.error(new IllegalArgumentException("sessionId cannot be null or empty."));
+    }
+    return Completable.complete();
+  }
+}

--- a/contrib/mysql-session-service/src/main/resources/mysql-session-service-schema.sql
+++ b/contrib/mysql-session-service/src/main/resources/mysql-session-service-schema.sql
@@ -1,0 +1,40 @@
+CREATE TABLE IF NOT EXISTS adk_sessions (
+    app_name VARCHAR(255) NOT NULL,
+    user_id VARCHAR(255) NOT NULL,
+    session_id VARCHAR(255) NOT NULL,
+    state JSON NOT NULL,
+    created_at TIMESTAMP(3) NOT NULL,
+    updated_at TIMESTAMP(3) NOT NULL,
+    PRIMARY KEY (app_name, user_id, session_id),
+    INDEX idx_adk_sessions_updated (app_name, user_id, updated_at)
+);
+
+CREATE TABLE IF NOT EXISTS adk_events (
+    event_sequence BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    app_name VARCHAR(255) NOT NULL,
+    user_id VARCHAR(255) NOT NULL,
+    session_id VARCHAR(255) NOT NULL,
+    event_id VARCHAR(255) NOT NULL,
+    event_data JSON NOT NULL,
+    created_at TIMESTAMP(3) NOT NULL,
+    CONSTRAINT fk_adk_events_session
+        FOREIGN KEY (app_name, user_id, session_id)
+        REFERENCES adk_sessions (app_name, user_id, session_id)
+        ON DELETE CASCADE,
+    INDEX idx_adk_events_session (app_name, user_id, session_id)
+);
+
+CREATE TABLE IF NOT EXISTS adk_app_state (
+    app_name VARCHAR(255) NOT NULL,
+    state_key VARCHAR(255) NOT NULL,
+    state_value JSON NOT NULL,
+    PRIMARY KEY (app_name, state_key)
+);
+
+CREATE TABLE IF NOT EXISTS adk_user_state (
+    app_name VARCHAR(255) NOT NULL,
+    user_id VARCHAR(255) NOT NULL,
+    state_key VARCHAR(255) NOT NULL,
+    state_value JSON NOT NULL,
+    PRIMARY KEY (app_name, user_id, state_key)
+);

--- a/contrib/mysql-session-service/src/test/java/com/google/adk/sessions/MySqlDBHelperTest.java
+++ b/contrib/mysql-session-service/src/test/java/com/google/adk/sessions/MySqlDBHelperTest.java
@@ -1,0 +1,435 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.adk.sessions;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.adk.events.Event;
+import com.google.adk.events.EventActions;
+import com.zaxxer.hikari.HikariConfig;
+import com.zaxxer.hikari.HikariDataSource;
+import io.reactivex.rxjava3.core.Single;
+import java.sql.Connection;
+import java.sql.Statement;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import javax.sql.DataSource;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link MySqlDBHelper} using H2 in MySQL compatibility mode. This ensures SQL
+ * syntax is valid without requiring a real MySQL container.
+ */
+class MySqlDBHelperTest {
+
+  private DataSource dataSource;
+  private MySqlDBHelper dbHelper;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    HikariConfig config = new HikariConfig();
+    config.setJdbcUrl("jdbc:h2:mem:testdb;MODE=MySQL;DB_CLOSE_DELAY=-1");
+    config.setUsername("sa");
+    config.setPassword("");
+    dataSource = new HikariDataSource(config);
+
+    try (Connection conn = dataSource.getConnection();
+        Statement stmt = conn.createStatement()) {
+
+      stmt.execute("DROP TABLE IF EXISTS adk_events");
+      stmt.execute("DROP TABLE IF EXISTS adk_sessions");
+      stmt.execute("DROP TABLE IF EXISTS adk_app_state");
+      stmt.execute("DROP TABLE IF EXISTS adk_user_state");
+
+      stmt.execute(
+          "CREATE TABLE adk_sessions ("
+              + "session_id VARCHAR(255) PRIMARY KEY, "
+              + "app_name VARCHAR(255) NOT NULL, "
+              + "user_id VARCHAR(255) NOT NULL, "
+              + "state TEXT, "
+              + "created_at TIMESTAMP(3) DEFAULT CURRENT_TIMESTAMP(3), "
+              + "updated_at TIMESTAMP(3) DEFAULT CURRENT_TIMESTAMP(3), "
+              + "INDEX idx_app_user (app_name, user_id))");
+
+      stmt.execute(
+          "CREATE TABLE adk_events ("
+              + "event_id VARCHAR(255) PRIMARY KEY, "
+              + "session_id VARCHAR(255) NOT NULL, "
+              + "event_data TEXT, "
+              + "created_at TIMESTAMP(3) DEFAULT CURRENT_TIMESTAMP(3), "
+              + "FOREIGN KEY (session_id) REFERENCES adk_sessions(session_id) ON DELETE CASCADE, "
+              + "INDEX idx_session_created (session_id, created_at))");
+
+      stmt.execute(
+          "CREATE TABLE adk_app_state ("
+              + "app_name VARCHAR(255) NOT NULL, "
+              + "state_key VARCHAR(255) NOT NULL, "
+              + "state_value TEXT, "
+              + "PRIMARY KEY (app_name, state_key))");
+
+      stmt.execute(
+          "CREATE TABLE adk_user_state ("
+              + "app_name VARCHAR(255) NOT NULL, "
+              + "user_id VARCHAR(255) NOT NULL, "
+              + "state_key VARCHAR(255) NOT NULL, "
+              + "state_value TEXT, "
+              + "PRIMARY KEY (app_name, user_id, state_key))");
+    }
+
+    dbHelper = new MySqlDBHelper(dataSource);
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (dataSource instanceof HikariDataSource) {
+      ((HikariDataSource) dataSource).close();
+    }
+  }
+
+  @Test
+  void appendEvent_withAppState_executesSqlSuccessfully() {
+    // Create a session first
+    Session session =
+        Session.builder(UUID.randomUUID().toString())
+            .appName("testApp")
+            .userId("testUser")
+            .state(new ConcurrentHashMap<>())
+            .events(new ArrayList<>())
+            .lastUpdateTime(Instant.now().truncatedTo(ChronoUnit.MILLIS))
+            .build();
+
+    dbHelper.saveSession(session).blockingAwait();
+
+    // Create event with App State delta
+    ConcurrentMap<String, Object> stateDelta = new ConcurrentHashMap<>();
+    stateDelta.put(State.APP_PREFIX + "someKey", "someValue");
+
+    Event event =
+        Event.builder()
+            .id(UUID.randomUUID().toString())
+            .timestamp(System.currentTimeMillis())
+            .actions(EventActions.builder().stateDelta(stateDelta).build())
+            .build();
+
+    // This triggers the upsertAppStateSql.
+    // If there is a parameter mismatch (3 columns vs 4 placeholders), this will fail.
+    dbHelper.appendEventAndUpdateState(session, event).blockingAwait();
+
+    // Verify it was inserted
+    Single<ConcurrentHashMap<String, Object>> stateSingle =
+        dbHelper.getInitialState("testApp", "testUser");
+    ConcurrentHashMap<String, Object> state = stateSingle.blockingGet();
+    assertThat(state).containsEntry(State.APP_PREFIX + "someKey", "someValue");
+  }
+
+  @Test
+  void appendEvent_withUserState_executesSqlSuccessfully() {
+    // Create a session
+    Session session =
+        Session.builder(UUID.randomUUID().toString())
+            .appName("testApp")
+            .userId("testUser")
+            .state(new ConcurrentHashMap<>())
+            .events(new ArrayList<>())
+            .lastUpdateTime(Instant.now().truncatedTo(ChronoUnit.MILLIS))
+            .build();
+
+    dbHelper.saveSession(session).blockingAwait();
+
+    // Create event with User State delta
+    ConcurrentMap<String, Object> stateDelta = new ConcurrentHashMap<>();
+    stateDelta.put(State.USER_PREFIX + "someUserKey", "someUserValue");
+
+    Event event =
+        Event.builder()
+            .id(UUID.randomUUID().toString())
+            .timestamp(System.currentTimeMillis())
+            .actions(EventActions.builder().stateDelta(stateDelta).build())
+            .build();
+
+    dbHelper.appendEventAndUpdateState(session, event).blockingAwait();
+
+    // Verify it was inserted
+    ConcurrentHashMap<String, Object> state =
+        dbHelper.getInitialState("testApp", "testUser").blockingGet();
+    assertThat(state).containsEntry(State.USER_PREFIX + "someUserKey", "someUserValue");
+  }
+
+  @Test
+  void listSessions_retrievesSessionState() {
+    ConcurrentMap<String, Object> state = new ConcurrentHashMap<>();
+    state.put("key1", "value1");
+
+    Session session =
+        Session.builder(UUID.randomUUID().toString())
+            .appName("testApp")
+            .userId("testUser")
+            .state(state)
+            .events(new ArrayList<>())
+            .lastUpdateTime(Instant.now().truncatedTo(ChronoUnit.MILLIS))
+            .build();
+
+    dbHelper.saveSession(session).blockingAwait();
+
+    java.util.List<Session> sessions = dbHelper.listSessions("testApp", "testUser").blockingGet();
+
+    assertThat(sessions).hasSize(1);
+    assertThat(sessions.get(0).state()).containsEntry("key1", "value1");
+  }
+
+  @Test
+  void listEvents_enforcesOwnership() {
+    String sessionId = UUID.randomUUID().toString();
+    Session session =
+        Session.builder(sessionId)
+            .appName("correctApp")
+            .userId("correctUser")
+            .state(new ConcurrentHashMap<>())
+            .events(new ArrayList<>())
+            .lastUpdateTime(Instant.now().truncatedTo(ChronoUnit.MILLIS))
+            .build();
+
+    dbHelper.saveSession(session).blockingAwait();
+
+    Event event =
+        Event.builder()
+            .id(UUID.randomUUID().toString())
+            .timestamp(System.currentTimeMillis())
+            .build();
+
+    dbHelper.appendEventAndUpdateState(session, event).blockingAwait();
+
+    // 1. Correct credentials should return the event
+    java.util.List<Event> events =
+        dbHelper.listEvents("correctApp", "correctUser", sessionId).blockingGet();
+    assertThat(events).hasSize(1);
+
+    // 2. Wrong App Name should return empty
+    java.util.List<Event> eventsWrongApp =
+        dbHelper.listEvents("wrongApp", "correctUser", sessionId).blockingGet();
+    assertThat(eventsWrongApp).isEmpty();
+
+    // 3. Wrong User ID should return empty
+    java.util.List<Event> eventsWrongUser =
+        dbHelper.listEvents("correctApp", "wrongUser", sessionId).blockingGet();
+    assertThat(eventsWrongUser).isEmpty();
+  }
+
+  @Test
+  void getSession_mergesStateCorrectly() throws Exception {
+    // 1. Setup Global App State directly in DB
+    try (Connection conn = dataSource.getConnection();
+        Statement stmt = conn.createStatement()) {
+      stmt.execute(
+          "INSERT INTO adk_app_state (app_name, state_key, state_value) VALUES ('testApp', 'sharedKey', '\"globalValue\"')");
+      stmt.execute(
+          "INSERT INTO adk_app_state (app_name, state_key, state_value) VALUES ('testApp', 'globalOnly', '\"globalOnlyValue\"')");
+    }
+
+    // 2. Create Session with conflicting key
+    ConcurrentMap<String, Object> sessionState = new ConcurrentHashMap<>();
+    sessionState.put("sharedKey", "sessionValue");
+
+    Session session =
+        Session.builder(UUID.randomUUID().toString())
+            .appName("testApp")
+            .userId("testUser")
+            .state(sessionState)
+            .events(new ArrayList<>())
+            .lastUpdateTime(Instant.now().truncatedTo(ChronoUnit.MILLIS))
+            .build();
+
+    dbHelper.saveSession(session).blockingAwait();
+
+    // 3. Retrieve Session
+    Session retrievedSession =
+        dbHelper
+            .getSession("testApp", "testUser", session.id(), java.util.Optional.empty())
+            .blockingGet();
+
+    // 4. Verify Merge Logic
+    // Session-specific value should override Global value
+    assertThat(retrievedSession.state()).containsEntry("sharedKey", "sessionValue");
+    // Non-conflicting Global value should be present with prefix
+    assertThat(retrievedSession.state())
+        .containsEntry(State.APP_PREFIX + "globalOnly", "globalOnlyValue");
+    // The shared key from global state should also be present with prefix
+    assertThat(retrievedSession.state())
+        .containsEntry(State.APP_PREFIX + "sharedKey", "globalValue");
+  }
+
+  @Test
+  void deleteSession_executesSqlSuccessfully() {
+    Session session =
+        Session.builder(UUID.randomUUID().toString())
+            .appName("testApp")
+            .userId("testUser")
+            .state(new ConcurrentHashMap<>())
+            .events(new ArrayList<>())
+            .lastUpdateTime(Instant.now().truncatedTo(ChronoUnit.MILLIS))
+            .build();
+
+    dbHelper.saveSession(session).blockingAwait();
+
+    dbHelper.deleteSession("testApp", "testUser", session.id()).blockingAwait();
+
+    Session deletedSession =
+        dbHelper
+            .getSession("testApp", "testUser", session.id(), java.util.Optional.empty())
+            .blockingGet();
+    assertThat(deletedSession).isNull();
+  }
+
+  @Test
+  public void listSessions_mergesGlobalState() throws Exception {
+    // 1. Setup Global App State directly in DB
+    try (Connection conn = dataSource.getConnection();
+        Statement stmt = conn.createStatement()) {
+      stmt.execute(
+          "INSERT INTO adk_app_state (app_name, state_key, state_value) VALUES ('testApp', 'globalKey', '\"globalValue\"')");
+      stmt.execute(
+          "INSERT INTO adk_user_state (app_name, user_id, state_key, state_value) VALUES ('testApp', 'testUser', 'userKey', '\"userValue\"')");
+    }
+
+    Session session =
+        Session.builder(UUID.randomUUID().toString())
+            .appName("testApp")
+            .userId("testUser")
+            .state(new ConcurrentHashMap<>())
+            .events(new ArrayList<>())
+            .lastUpdateTime(Instant.now().truncatedTo(ChronoUnit.MILLIS))
+            .build();
+
+    dbHelper.saveSession(session).blockingAwait();
+
+    java.util.List<Session> sessions = dbHelper.listSessions("testApp", "testUser").blockingGet();
+
+    assertThat(sessions).hasSize(1);
+    assertThat(sessions.get(0).state())
+        .containsEntry(State.APP_PREFIX + "globalKey", "globalValue");
+    assertThat(sessions.get(0).state()).containsEntry(State.USER_PREFIX + "userKey", "userValue");
+  }
+
+  @Test
+  void prefixHandling_storesCleanKeysInDb() throws Exception {
+    Session session =
+        Session.builder(UUID.randomUUID().toString())
+            .appName("testApp")
+            .userId("testUser")
+            .state(new ConcurrentHashMap<>())
+            .events(new ArrayList<>())
+            .lastUpdateTime(Instant.now().truncatedTo(ChronoUnit.MILLIS))
+            .build();
+
+    dbHelper.saveSession(session).blockingAwait();
+
+    ConcurrentMap<String, Object> stateDelta = new ConcurrentHashMap<>();
+    stateDelta.put(State.APP_PREFIX + "cleanAppKey", "val1");
+    stateDelta.put(State.USER_PREFIX + "cleanUserKey", "val2");
+
+    Event event =
+        Event.builder()
+            .id(UUID.randomUUID().toString())
+            .timestamp(System.currentTimeMillis())
+            .actions(EventActions.builder().stateDelta(stateDelta).build())
+            .build();
+
+    dbHelper.appendEventAndUpdateState(session, event).blockingAwait();
+
+    // Verify DB storage directly
+    try (Connection conn = dataSource.getConnection();
+        Statement stmt = conn.createStatement()) {
+
+      // Check App State
+      try (java.sql.ResultSet rs =
+          stmt.executeQuery(
+              "SELECT state_key FROM adk_app_state WHERE app_name = 'testApp' AND state_key = 'cleanAppKey'")) {
+        assertThat(rs.next()).isTrue();
+        assertThat(rs.getString("state_key")).isEqualTo("cleanAppKey"); // Should NOT have prefix
+      }
+
+      // Check User State
+      try (java.sql.ResultSet rs =
+          stmt.executeQuery(
+              "SELECT state_key FROM adk_user_state WHERE app_name = 'testApp' AND user_id = 'testUser' AND state_key = 'cleanUserKey'")) {
+        assertThat(rs.next()).isTrue();
+        assertThat(rs.getString("state_key")).isEqualTo("cleanUserKey"); // Should NOT have prefix
+      }
+    }
+  }
+
+  @Test
+  void prefixHandling_removesKeysFromDb() throws Exception {
+    // 1. Setup existing state in DB
+    try (Connection conn = dataSource.getConnection();
+        Statement stmt = conn.createStatement()) {
+      stmt.execute(
+          "INSERT INTO adk_app_state (app_name, state_key, state_value) VALUES ('testApp', 'keyToRemove', '\"val\"')");
+      stmt.execute(
+          "INSERT INTO adk_user_state (app_name, user_id, state_key, state_value) VALUES ('testApp', 'testUser', 'keyToRemove', '\"val\"')");
+    }
+
+    Session session =
+        Session.builder(UUID.randomUUID().toString())
+            .appName("testApp")
+            .userId("testUser")
+            .state(new ConcurrentHashMap<>())
+            .events(new ArrayList<>())
+            .lastUpdateTime(Instant.now().truncatedTo(ChronoUnit.MILLIS))
+            .build();
+
+    dbHelper.saveSession(session).blockingAwait();
+
+    // 2. Create event with REMOVED delta
+    ConcurrentMap<String, Object> stateDelta = new ConcurrentHashMap<>();
+    stateDelta.put(State.APP_PREFIX + "keyToRemove", State.REMOVED);
+    stateDelta.put(State.USER_PREFIX + "keyToRemove", State.REMOVED);
+
+    Event event =
+        Event.builder()
+            .id(UUID.randomUUID().toString())
+            .timestamp(System.currentTimeMillis())
+            .actions(EventActions.builder().stateDelta(stateDelta).build())
+            .build();
+
+    dbHelper.appendEventAndUpdateState(session, event).blockingAwait();
+
+    // 3. Verify deletion in DB
+    try (Connection conn = dataSource.getConnection();
+        Statement stmt = conn.createStatement()) {
+
+      // Check App State
+      try (java.sql.ResultSet rs =
+          stmt.executeQuery(
+              "SELECT state_key FROM adk_app_state WHERE app_name = 'testApp' AND state_key = 'keyToRemove'")) {
+        assertThat(rs.next()).isFalse(); // Should be gone
+      }
+
+      // Check User State
+      try (java.sql.ResultSet rs =
+          stmt.executeQuery(
+              "SELECT state_key FROM adk_user_state WHERE app_name = 'testApp' AND user_id = 'testUser' AND state_key = 'keyToRemove'")) {
+        assertThat(rs.next()).isFalse(); // Should be gone
+      }
+    }
+  }
+}

--- a/contrib/mysql-session-service/src/test/java/com/google/adk/sessions/MySqlDBHelperTest.java
+++ b/contrib/mysql-session-service/src/test/java/com/google/adk/sessions/MySqlDBHelperTest.java
@@ -1,0 +1,394 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.adk.sessions;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.adk.events.Event;
+import com.google.adk.events.EventActions;
+import com.zaxxer.hikari.HikariConfig;
+import com.zaxxer.hikari.HikariDataSource;
+import io.reactivex.rxjava3.core.Single;
+import java.sql.Connection;
+import java.sql.Statement;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import javax.sql.DataSource;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link MySqlDBHelper} using H2 in MySQL compatibility mode. This ensures SQL
+ * syntax is valid without requiring a real MySQL container.
+ */
+class MySqlDBHelperTest {
+
+  private DataSource dataSource;
+  private MySqlDBHelper dbHelper;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    HikariConfig config = new HikariConfig();
+    config.setJdbcUrl("jdbc:h2:mem:testdb;MODE=MySQL;DB_CLOSE_DELAY=-1");
+    config.setUsername("sa");
+    config.setPassword("");
+    dataSource = new HikariDataSource(config);
+
+    MySqlTestSchema.reset(dataSource);
+
+    dbHelper = new MySqlDBHelper(dataSource);
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (dataSource instanceof HikariDataSource) {
+      ((HikariDataSource) dataSource).close();
+    }
+  }
+
+  @Test
+  void appendEvent_withAppState_executesSqlSuccessfully() {
+    // Create a session first
+    Session session =
+        Session.builder(UUID.randomUUID().toString())
+            .appName("testApp")
+            .userId("testUser")
+            .state(new ConcurrentHashMap<>())
+            .events(new ArrayList<>())
+            .lastUpdateTime(Instant.now().truncatedTo(ChronoUnit.MILLIS))
+            .build();
+
+    dbHelper.saveSession(session).blockingAwait();
+
+    // Create event with App State delta
+    ConcurrentMap<String, Object> stateDelta = new ConcurrentHashMap<>();
+    stateDelta.put(State.APP_PREFIX + "someKey", "someValue");
+
+    Event event =
+        Event.builder()
+            .id(UUID.randomUUID().toString())
+            .timestamp(System.currentTimeMillis())
+            .actions(EventActions.builder().stateDelta(stateDelta).build())
+            .build();
+
+    // This triggers the upsertAppStateSql.
+    // If there is a parameter mismatch (3 columns vs 4 placeholders), this will fail.
+    dbHelper.appendEventAndUpdateState(session, event).blockingAwait();
+
+    // Verify it was inserted
+    Single<ConcurrentHashMap<String, Object>> stateSingle =
+        dbHelper.getInitialState("testApp", "testUser");
+    ConcurrentHashMap<String, Object> state = stateSingle.blockingGet();
+    assertThat(state).containsEntry(State.APP_PREFIX + "someKey", "someValue");
+  }
+
+  @Test
+  void appendEvent_withUserState_executesSqlSuccessfully() {
+    // Create a session
+    Session session =
+        Session.builder(UUID.randomUUID().toString())
+            .appName("testApp")
+            .userId("testUser")
+            .state(new ConcurrentHashMap<>())
+            .events(new ArrayList<>())
+            .lastUpdateTime(Instant.now().truncatedTo(ChronoUnit.MILLIS))
+            .build();
+
+    dbHelper.saveSession(session).blockingAwait();
+
+    // Create event with User State delta
+    ConcurrentMap<String, Object> stateDelta = new ConcurrentHashMap<>();
+    stateDelta.put(State.USER_PREFIX + "someUserKey", "someUserValue");
+
+    Event event =
+        Event.builder()
+            .id(UUID.randomUUID().toString())
+            .timestamp(System.currentTimeMillis())
+            .actions(EventActions.builder().stateDelta(stateDelta).build())
+            .build();
+
+    dbHelper.appendEventAndUpdateState(session, event).blockingAwait();
+
+    // Verify it was inserted
+    ConcurrentHashMap<String, Object> state =
+        dbHelper.getInitialState("testApp", "testUser").blockingGet();
+    assertThat(state).containsEntry(State.USER_PREFIX + "someUserKey", "someUserValue");
+  }
+
+  @Test
+  void listSessions_retrievesSessionState() {
+    ConcurrentMap<String, Object> state = new ConcurrentHashMap<>();
+    state.put("key1", "value1");
+
+    Session session =
+        Session.builder(UUID.randomUUID().toString())
+            .appName("testApp")
+            .userId("testUser")
+            .state(state)
+            .events(new ArrayList<>())
+            .lastUpdateTime(Instant.now().truncatedTo(ChronoUnit.MILLIS))
+            .build();
+
+    dbHelper.saveSession(session).blockingAwait();
+
+    java.util.List<Session> sessions = dbHelper.listSessions("testApp", "testUser").blockingGet();
+
+    assertThat(sessions).hasSize(1);
+    assertThat(sessions.get(0).state()).containsEntry("key1", "value1");
+  }
+
+  @Test
+  void listEvents_enforcesOwnership() {
+    String sessionId = UUID.randomUUID().toString();
+    Session session =
+        Session.builder(sessionId)
+            .appName("correctApp")
+            .userId("correctUser")
+            .state(new ConcurrentHashMap<>())
+            .events(new ArrayList<>())
+            .lastUpdateTime(Instant.now().truncatedTo(ChronoUnit.MILLIS))
+            .build();
+
+    dbHelper.saveSession(session).blockingAwait();
+
+    Event event =
+        Event.builder()
+            .id(UUID.randomUUID().toString())
+            .timestamp(System.currentTimeMillis())
+            .build();
+
+    dbHelper.appendEventAndUpdateState(session, event).blockingAwait();
+
+    // 1. Correct credentials should return the event
+    java.util.List<Event> events =
+        dbHelper.listEvents("correctApp", "correctUser", sessionId).blockingGet();
+    assertThat(events).hasSize(1);
+
+    // 2. Wrong App Name should return empty
+    java.util.List<Event> eventsWrongApp =
+        dbHelper.listEvents("wrongApp", "correctUser", sessionId).blockingGet();
+    assertThat(eventsWrongApp).isEmpty();
+
+    // 3. Wrong User ID should return empty
+    java.util.List<Event> eventsWrongUser =
+        dbHelper.listEvents("correctApp", "wrongUser", sessionId).blockingGet();
+    assertThat(eventsWrongUser).isEmpty();
+  }
+
+  @Test
+  void getSession_mergesStateCorrectly() throws Exception {
+    // 1. Setup Global App State directly in DB
+    try (Connection conn = dataSource.getConnection();
+        Statement stmt = conn.createStatement()) {
+      stmt.execute(
+          "INSERT INTO adk_app_state (app_name, state_key, state_value) VALUES ('testApp', 'sharedKey', '\"globalValue\"')");
+      stmt.execute(
+          "INSERT INTO adk_app_state (app_name, state_key, state_value) VALUES ('testApp', 'globalOnly', '\"globalOnlyValue\"')");
+    }
+
+    // 2. Create Session with conflicting key
+    ConcurrentMap<String, Object> sessionState = new ConcurrentHashMap<>();
+    sessionState.put("sharedKey", "sessionValue");
+
+    Session session =
+        Session.builder(UUID.randomUUID().toString())
+            .appName("testApp")
+            .userId("testUser")
+            .state(sessionState)
+            .events(new ArrayList<>())
+            .lastUpdateTime(Instant.now().truncatedTo(ChronoUnit.MILLIS))
+            .build();
+
+    dbHelper.saveSession(session).blockingAwait();
+
+    // 3. Retrieve Session
+    Session retrievedSession =
+        dbHelper
+            .getSession("testApp", "testUser", session.id(), java.util.Optional.empty())
+            .blockingGet();
+
+    // 4. Verify Merge Logic
+    // Session-specific value should override Global value
+    assertThat(retrievedSession.state()).containsEntry("sharedKey", "sessionValue");
+    // Non-conflicting Global value should be present with prefix
+    assertThat(retrievedSession.state())
+        .containsEntry(State.APP_PREFIX + "globalOnly", "globalOnlyValue");
+    // The shared key from global state should also be present with prefix
+    assertThat(retrievedSession.state())
+        .containsEntry(State.APP_PREFIX + "sharedKey", "globalValue");
+  }
+
+  @Test
+  void deleteSession_executesSqlSuccessfully() {
+    Session session =
+        Session.builder(UUID.randomUUID().toString())
+            .appName("testApp")
+            .userId("testUser")
+            .state(new ConcurrentHashMap<>())
+            .events(new ArrayList<>())
+            .lastUpdateTime(Instant.now().truncatedTo(ChronoUnit.MILLIS))
+            .build();
+
+    dbHelper.saveSession(session).blockingAwait();
+
+    dbHelper.deleteSession("testApp", "testUser", session.id()).blockingAwait();
+
+    Session deletedSession =
+        dbHelper
+            .getSession("testApp", "testUser", session.id(), java.util.Optional.empty())
+            .blockingGet();
+    assertThat(deletedSession).isNull();
+  }
+
+  @Test
+  public void listSessions_mergesGlobalState() throws Exception {
+    // 1. Setup Global App State directly in DB
+    try (Connection conn = dataSource.getConnection();
+        Statement stmt = conn.createStatement()) {
+      stmt.execute(
+          "INSERT INTO adk_app_state (app_name, state_key, state_value) VALUES ('testApp', 'globalKey', '\"globalValue\"')");
+      stmt.execute(
+          "INSERT INTO adk_user_state (app_name, user_id, state_key, state_value) VALUES ('testApp', 'testUser', 'userKey', '\"userValue\"')");
+    }
+
+    Session session =
+        Session.builder(UUID.randomUUID().toString())
+            .appName("testApp")
+            .userId("testUser")
+            .state(new ConcurrentHashMap<>())
+            .events(new ArrayList<>())
+            .lastUpdateTime(Instant.now().truncatedTo(ChronoUnit.MILLIS))
+            .build();
+
+    dbHelper.saveSession(session).blockingAwait();
+
+    java.util.List<Session> sessions = dbHelper.listSessions("testApp", "testUser").blockingGet();
+
+    assertThat(sessions).hasSize(1);
+    assertThat(sessions.get(0).state())
+        .containsEntry(State.APP_PREFIX + "globalKey", "globalValue");
+    assertThat(sessions.get(0).state()).containsEntry(State.USER_PREFIX + "userKey", "userValue");
+  }
+
+  @Test
+  void prefixHandling_storesCleanKeysInDb() throws Exception {
+    Session session =
+        Session.builder(UUID.randomUUID().toString())
+            .appName("testApp")
+            .userId("testUser")
+            .state(new ConcurrentHashMap<>())
+            .events(new ArrayList<>())
+            .lastUpdateTime(Instant.now().truncatedTo(ChronoUnit.MILLIS))
+            .build();
+
+    dbHelper.saveSession(session).blockingAwait();
+
+    ConcurrentMap<String, Object> stateDelta = new ConcurrentHashMap<>();
+    stateDelta.put(State.APP_PREFIX + "cleanAppKey", "val1");
+    stateDelta.put(State.USER_PREFIX + "cleanUserKey", "val2");
+
+    Event event =
+        Event.builder()
+            .id(UUID.randomUUID().toString())
+            .timestamp(System.currentTimeMillis())
+            .actions(EventActions.builder().stateDelta(stateDelta).build())
+            .build();
+
+    dbHelper.appendEventAndUpdateState(session, event).blockingAwait();
+
+    // Verify DB storage directly
+    try (Connection conn = dataSource.getConnection();
+        Statement stmt = conn.createStatement()) {
+
+      // Check App State
+      try (java.sql.ResultSet rs =
+          stmt.executeQuery(
+              "SELECT state_key FROM adk_app_state WHERE app_name = 'testApp' AND state_key = 'cleanAppKey'")) {
+        assertThat(rs.next()).isTrue();
+        assertThat(rs.getString("state_key")).isEqualTo("cleanAppKey"); // Should NOT have prefix
+      }
+
+      // Check User State
+      try (java.sql.ResultSet rs =
+          stmt.executeQuery(
+              "SELECT state_key FROM adk_user_state WHERE app_name = 'testApp' AND user_id = 'testUser' AND state_key = 'cleanUserKey'")) {
+        assertThat(rs.next()).isTrue();
+        assertThat(rs.getString("state_key")).isEqualTo("cleanUserKey"); // Should NOT have prefix
+      }
+    }
+  }
+
+  @Test
+  void prefixHandling_removesKeysFromDb() throws Exception {
+    // 1. Setup existing state in DB
+    try (Connection conn = dataSource.getConnection();
+        Statement stmt = conn.createStatement()) {
+      stmt.execute(
+          "INSERT INTO adk_app_state (app_name, state_key, state_value) VALUES ('testApp', 'keyToRemove', '\"val\"')");
+      stmt.execute(
+          "INSERT INTO adk_user_state (app_name, user_id, state_key, state_value) VALUES ('testApp', 'testUser', 'keyToRemove', '\"val\"')");
+    }
+
+    Session session =
+        Session.builder(UUID.randomUUID().toString())
+            .appName("testApp")
+            .userId("testUser")
+            .state(new ConcurrentHashMap<>())
+            .events(new ArrayList<>())
+            .lastUpdateTime(Instant.now().truncatedTo(ChronoUnit.MILLIS))
+            .build();
+
+    dbHelper.saveSession(session).blockingAwait();
+
+    // 2. Create event with REMOVED delta
+    ConcurrentMap<String, Object> stateDelta = new ConcurrentHashMap<>();
+    stateDelta.put(State.APP_PREFIX + "keyToRemove", State.REMOVED);
+    stateDelta.put(State.USER_PREFIX + "keyToRemove", State.REMOVED);
+
+    Event event =
+        Event.builder()
+            .id(UUID.randomUUID().toString())
+            .timestamp(System.currentTimeMillis())
+            .actions(EventActions.builder().stateDelta(stateDelta).build())
+            .build();
+
+    dbHelper.appendEventAndUpdateState(session, event).blockingAwait();
+
+    // 3. Verify deletion in DB
+    try (Connection conn = dataSource.getConnection();
+        Statement stmt = conn.createStatement()) {
+
+      // Check App State
+      try (java.sql.ResultSet rs =
+          stmt.executeQuery(
+              "SELECT state_key FROM adk_app_state WHERE app_name = 'testApp' AND state_key = 'keyToRemove'")) {
+        assertThat(rs.next()).isFalse(); // Should be gone
+      }
+
+      // Check User State
+      try (java.sql.ResultSet rs =
+          stmt.executeQuery(
+              "SELECT state_key FROM adk_user_state WHERE app_name = 'testApp' AND user_id = 'testUser' AND state_key = 'keyToRemove'")) {
+        assertThat(rs.next()).isFalse(); // Should be gone
+      }
+    }
+  }
+}

--- a/contrib/mysql-session-service/src/test/java/com/google/adk/sessions/MySqlSessionServiceContractTest.java
+++ b/contrib/mysql-session-service/src/test/java/com/google/adk/sessions/MySqlSessionServiceContractTest.java
@@ -1,0 +1,327 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.adk.sessions;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.adk.JsonBaseModel;
+import com.google.adk.events.Event;
+import com.google.adk.events.EventActions;
+import com.zaxxer.hikari.HikariConfig;
+import com.zaxxer.hikari.HikariDataSource;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import javax.sql.DataSource;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/** Contract tests aligned with the behavior of {@link InMemorySessionService}. */
+class MySqlSessionServiceContractTest {
+
+  private DataSource dataSource;
+  private MySqlSessionService sessionService;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    HikariConfig config = new HikariConfig();
+    config.setJdbcUrl("jdbc:h2:mem:contractdb;MODE=MySQL;DB_CLOSE_DELAY=-1");
+    config.setUsername("sa");
+    config.setPassword("");
+    dataSource = new HikariDataSource(config);
+    MySqlTestSchema.reset(dataSource);
+    sessionService = new MySqlSessionService(dataSource);
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (dataSource instanceof HikariDataSource hikariDataSource) {
+      hikariDataSource.close();
+    }
+  }
+
+  @Test
+  void sameSessionIdCanExistInDifferentScopes() {
+    Session first =
+        sessionService.createSession("app-1", "user-1", Map.of(), "shared").blockingGet();
+    Session second =
+        sessionService.createSession("app-2", "user-1", Map.of(), "shared").blockingGet();
+    Session third =
+        sessionService.createSession("app-1", "user-2", Map.of(), "shared").blockingGet();
+
+    sessionService.appendEvent(first, event("first", 100, Map.of("value", 1))).blockingGet();
+    sessionService.appendEvent(second, event("second", 100, Map.of("value", 2))).blockingGet();
+    sessionService.appendEvent(third, event("third", 100, Map.of("value", 3))).blockingGet();
+
+    assertThat(get(first).state()).containsEntry("value", 1);
+    assertThat(get(second).state()).containsEntry("value", 2);
+    assertThat(get(third).state()).containsEntry("value", 3);
+
+    sessionService.deleteSession("app-1", "user-1", "shared").blockingAwait();
+    assertThat(getOrNull("app-1", "user-1", "shared")).isNull();
+    assertThat(get(second)).isNotNull();
+    assertThat(get(third)).isNotNull();
+  }
+
+  @Test
+  void initialScopedStateIsPersistedAndTemporaryStateIsEphemeral() {
+    Map<String, Object> initialState = new HashMap<>();
+    initialState.put("local", "local-value");
+    initialState.put(State.APP_PREFIX + "setting", "app-value");
+    initialState.put(State.USER_PREFIX + "setting", "user-value");
+    initialState.put(State.TEMP_PREFIX + "request", "temporary-value");
+
+    Session created =
+        sessionService.createSession("app", "user", initialState, "session-1").blockingGet();
+    assertThat(created.state()).containsEntry(State.TEMP_PREFIX + "request", "temporary-value");
+
+    Session reloaded = get(created);
+    assertThat(reloaded.state()).containsEntry("local", "local-value");
+    assertThat(reloaded.state()).containsEntry(State.APP_PREFIX + "setting", "app-value");
+    assertThat(reloaded.state()).containsEntry(State.USER_PREFIX + "setting", "user-value");
+    assertThat(reloaded.state()).doesNotContainKey(State.TEMP_PREFIX + "request");
+
+    Session another =
+        sessionService.createSession("app", "user", Map.of(), "session-2").blockingGet();
+    assertThat(another.state()).containsEntry(State.APP_PREFIX + "setting", "app-value");
+    assertThat(another.state()).containsEntry(State.USER_PREFIX + "setting", "user-value");
+    assertThat(another.state()).doesNotContainKey("local");
+  }
+
+  @Test
+  void appStateIsSharedAcrossUsersButUserStateIsIsolated() {
+    sessionService
+        .createSession(
+            "app",
+            "user-1",
+            Map.of(
+                State.APP_PREFIX + "shared", "app-value",
+                State.USER_PREFIX + "private", "user-value"),
+            "first")
+        .blockingGet();
+
+    Session anotherUser =
+        sessionService.createSession("app", "user-2", Map.of(), "second").blockingGet();
+    assertThat(anotherUser.state()).containsEntry(State.APP_PREFIX + "shared", "app-value");
+    assertThat(anotherUser.state()).doesNotContainKey(State.USER_PREFIX + "private");
+
+    Session anotherApp =
+        sessionService.createSession("other-app", "user-1", Map.of(), "third").blockingGet();
+    assertThat(anotherApp.state()).doesNotContainKey(State.APP_PREFIX + "shared");
+    assertThat(anotherApp.state()).doesNotContainKey(State.USER_PREFIX + "private");
+  }
+
+  @Test
+  void getSessionComposesRecentAndInclusiveTimestampFilters() {
+    Session session = sessionService.createSession("app", "user").blockingGet();
+    for (long timestamp : new long[] {100, 200, 300, 400, 500}) {
+      sessionService
+          .appendEvent(session, event("event-" + timestamp, timestamp, Map.of()))
+          .blockingGet();
+    }
+    GetSessionConfig config =
+        GetSessionConfig.builder()
+            .numRecentEvents(4)
+            .afterTimestamp(Instant.ofEpochMilli(300))
+            .build();
+
+    Session retrieved =
+        sessionService.getSession("app", "user", session.id(), Optional.of(config)).blockingGet();
+
+    assertThat(retrieved.events().stream().map(Event::timestamp))
+        .containsExactly(300L, 400L, 500L)
+        .inOrder();
+  }
+
+  @Test
+  void equalTimestampsRetainInsertionOrder() {
+    Session session = sessionService.createSession("app", "user").blockingGet();
+    for (String id : List.of("first", "second", "third")) {
+      sessionService.appendEvent(session, event(id, 1000, Map.of())).blockingGet();
+    }
+
+    assertThat(
+            sessionService.listEvents("app", "user", session.id()).blockingGet().events().stream()
+                .map(Event::id))
+        .containsExactly("first", "second", "third")
+        .inOrder();
+  }
+
+  @Test
+  void removedStateRoundTripsAsSentinelAndUsesJsonNull() throws Exception {
+    Session session =
+        sessionService
+            .createSession(
+                "app",
+                "user",
+                Map.of(
+                    "local",
+                    "value",
+                    State.APP_PREFIX + "app-key",
+                    "value",
+                    State.USER_PREFIX + "user-key",
+                    "value"),
+                "session")
+            .blockingGet();
+    ConcurrentMap<String, Object> removals = new ConcurrentHashMap<>();
+    removals.put("local", State.REMOVED);
+    removals.put(State.APP_PREFIX + "app-key", State.REMOVED);
+    removals.put(State.USER_PREFIX + "user-key", State.REMOVED);
+    sessionService.appendEvent(session, event("removed", 1000, removals)).blockingGet();
+
+    Event persisted =
+        sessionService.listEvents("app", "user", "session").blockingGet().events().get(0);
+    assertThat(persisted.actions().stateDelta().get("local")).isSameInstanceAs(State.REMOVED);
+    assertThat(persisted.actions().stateDelta().get(State.APP_PREFIX + "app-key"))
+        .isSameInstanceAs(State.REMOVED);
+    assertThat(get(session).state()).doesNotContainKey("local");
+
+    String eventJson = readOnlyEventJson();
+    assertThat(eventJson).contains("\"local\":null");
+    assertThat(eventJson).doesNotContain("__ADK_SENTINEL_REMOVED__");
+  }
+
+  @Test
+  void legacyRemovedSentinelStillDeserializes() throws Exception {
+    Session session = sessionService.createSession("app", "user").blockingGet();
+    ConcurrentMap<String, Object> removals = new ConcurrentHashMap<>();
+    removals.put("legacy", State.REMOVED);
+    sessionService.appendEvent(session, event("legacy", 1000, removals)).blockingGet();
+
+    String currentJson = readOnlyEventJson();
+    String directEventJson =
+        JsonBaseModel.getMapper()
+            .writeValueAsString(JsonBaseModel.getMapper().readTree(currentJson).get("event"));
+    String legacyJson =
+        directEventJson.replace("\"legacy\":null", "\"legacy\":\"__ADK_SENTINEL_REMOVED__\"");
+    assertThat(legacyJson).isNotEqualTo(directEventJson);
+    try (Connection conn = dataSource.getConnection();
+        PreparedStatement pstmt =
+            conn.prepareStatement("UPDATE adk_events SET event_data = ? WHERE event_id = ?")) {
+      pstmt.setString(1, legacyJson);
+      pstmt.setString(2, "legacy");
+      pstmt.executeUpdate();
+    }
+
+    Event persisted =
+        sessionService.listEvents("app", "user", session.id()).blockingGet().events().get(0);
+    assertThat(persisted.actions().stateDelta().get("legacy")).isSameInstanceAs(State.REMOVED);
+  }
+
+  @Test
+  void literalLegacySentinelStringIsPreservedInCurrentFormat() {
+    Session session = sessionService.createSession("app", "user").blockingGet();
+    sessionService
+        .appendEvent(session, event("literal", 1000, Map.of("literal", "__ADK_SENTINEL_REMOVED__")))
+        .blockingGet();
+
+    Event persisted =
+        sessionService.listEvents("app", "user", session.id()).blockingGet().events().get(0);
+    assertThat(persisted.actions().stateDelta())
+        .containsEntry("literal", "__ADK_SENTINEL_REMOVED__");
+  }
+
+  @Test
+  void partialEventIsNotPersistedOrApplied() {
+    Session session = sessionService.createSession("app", "user").blockingGet();
+    Event partial =
+        Event.builder()
+            .id("partial")
+            .partial(true)
+            .actions(EventActions.builder().stateDelta(Map.of("key", "value")).build())
+            .build();
+
+    sessionService.appendEvent(session, partial).blockingGet();
+
+    assertThat(session.events()).isEmpty();
+    assertThat(session.state()).doesNotContainKey("key");
+    assertThat(sessionService.listEvents("app", "user", session.id()).blockingGet().events())
+        .isEmpty();
+  }
+
+  @Test
+  void staleSessionFailsOptimisticLockAndRollsBackEvent() {
+    Session created = sessionService.createSession("app", "user").blockingGet();
+    Session firstWriter = get(created);
+    Session staleWriter = get(created);
+
+    sessionService
+        .appendEvent(firstWriter, event("committed", 1000, Map.of("key", "committed")))
+        .blockingGet();
+    sessionService
+        .appendEvent(staleWriter, event("rolled-back", 2000, Map.of("key", "stale")))
+        .test()
+        .assertError(java.util.ConcurrentModificationException.class);
+
+    Session reloaded = get(created);
+    assertThat(reloaded.state()).containsEntry("key", "committed");
+    assertThat(reloaded.events().stream().map(Event::id)).containsExactly("committed");
+  }
+
+  @Test
+  void duplicateEventIdsAreAllowedLikeInMemoryService() {
+    Session session = sessionService.createSession("app", "user").blockingGet();
+    sessionService.appendEvent(session, event("duplicate", 1000, Map.of())).blockingGet();
+    sessionService.appendEvent(session, event("duplicate", 2000, Map.of())).blockingGet();
+
+    assertThat(sessionService.listEvents("app", "user", session.id()).blockingGet().events())
+        .hasSize(2);
+  }
+
+  @Test
+  void missingSessionOperationsAreNoOpsOrEmpty() {
+    assertThat(getOrNull("app", "user", "missing")).isNull();
+    assertThat(sessionService.listEvents("app", "user", "missing").blockingGet().events())
+        .isEmpty();
+    sessionService.deleteSession("app", "user", "missing").blockingAwait();
+  }
+
+  private Session get(Session session) {
+    return sessionService
+        .getSession(session.appName(), session.userId(), session.id(), Optional.empty())
+        .blockingGet();
+  }
+
+  private Session getOrNull(String appName, String userId, String sessionId) {
+    return sessionService.getSession(appName, userId, sessionId, Optional.empty()).blockingGet();
+  }
+
+  private String readOnlyEventJson() throws Exception {
+    try (Connection conn = dataSource.getConnection();
+        PreparedStatement pstmt =
+            conn.prepareStatement("SELECT event_data FROM adk_events ORDER BY event_sequence");
+        ResultSet rs = pstmt.executeQuery()) {
+      assertThat(rs.next()).isTrue();
+      return rs.getString(1);
+    }
+  }
+
+  private static Event event(String id, long timestamp, Map<String, Object> stateDelta) {
+    return Event.builder()
+        .id(id)
+        .timestamp(timestamp)
+        .actions(EventActions.builder().stateDelta(stateDelta).build())
+        .build();
+  }
+}

--- a/contrib/mysql-session-service/src/test/java/com/google/adk/sessions/MySqlSessionServiceIT.java
+++ b/contrib/mysql-session-service/src/test/java/com/google/adk/sessions/MySqlSessionServiceIT.java
@@ -1,0 +1,356 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.adk.sessions;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.adk.events.Event;
+import com.google.adk.events.EventActions;
+import com.zaxxer.hikari.HikariConfig;
+import com.zaxxer.hikari.HikariDataSource;
+import io.reactivex.rxjava3.core.Single;
+import java.sql.Connection;
+import java.sql.Statement;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import javax.sql.DataSource;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+/** Unit tests for {@link MySqlSessionService} using Testcontainers. */
+@Testcontainers
+public final class MySqlSessionServiceIT {
+
+  @Container
+  private static final MySQLContainer<?> mysql =
+      new MySQLContainer<>("mysql:8.3.0").withDatabaseName("adk_test");
+
+  private static DataSource dataSource;
+  private MySqlSessionService sessionService;
+
+  @BeforeAll
+  public static void setUpClass() {
+    HikariConfig config = new HikariConfig();
+    config.setJdbcUrl(mysql.getJdbcUrl());
+    config.setUsername(mysql.getUsername());
+    config.setPassword(mysql.getPassword());
+    dataSource = new HikariDataSource(config);
+  }
+
+  @AfterAll
+  public static void tearDownClass() {
+    if (dataSource instanceof HikariDataSource) {
+      ((HikariDataSource) dataSource).close();
+    }
+  }
+
+  @BeforeEach
+  public void setUp() throws Exception {
+    try (Connection conn = dataSource.getConnection();
+        Statement stmt = conn.createStatement()) {
+      stmt.execute("SET FOREIGN_KEY_CHECKS = 0");
+      stmt.execute("DROP TABLE IF EXISTS adk_events");
+      stmt.execute("DROP TABLE IF EXISTS adk_sessions");
+      stmt.execute("DROP TABLE IF EXISTS adk_app_state");
+      stmt.execute("DROP TABLE IF EXISTS adk_user_state");
+      stmt.execute("SET FOREIGN_KEY_CHECKS = 1");
+
+      stmt.execute(
+          "CREATE TABLE adk_sessions ("
+              + "session_id VARCHAR(255) PRIMARY KEY, "
+              + "app_name VARCHAR(255) NOT NULL, "
+              + "user_id VARCHAR(255) NOT NULL, "
+              + "state JSON, "
+              + "created_at TIMESTAMP(3) DEFAULT CURRENT_TIMESTAMP(3), "
+              + "updated_at TIMESTAMP(3) DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE"
+              + " CURRENT_TIMESTAMP(3), "
+              + "INDEX idx_app_user (app_name, user_id))");
+
+      stmt.execute(
+          "CREATE TABLE adk_events ("
+              + "event_id VARCHAR(255) PRIMARY KEY, "
+              + "session_id VARCHAR(255) NOT NULL, "
+              + "event_data JSON, "
+              + "created_at TIMESTAMP(3) DEFAULT CURRENT_TIMESTAMP(3), "
+              + "FOREIGN KEY (session_id) REFERENCES adk_sessions(session_id) ON DELETE CASCADE, "
+              + "INDEX idx_session_created (session_id, created_at))");
+
+      stmt.execute(
+          "CREATE TABLE adk_app_state ("
+              + "app_name VARCHAR(255) NOT NULL, "
+              + "state_key VARCHAR(255) NOT NULL, "
+              + "state_value JSON, "
+              + "PRIMARY KEY (app_name, state_key))");
+
+      stmt.execute(
+          "CREATE TABLE adk_user_state ("
+              + "app_name VARCHAR(255) NOT NULL, "
+              + "user_id VARCHAR(255) NOT NULL, "
+              + "state_key VARCHAR(255) NOT NULL, "
+              + "state_value JSON, "
+              + "PRIMARY KEY (app_name, user_id, state_key))");
+    }
+
+    sessionService = new MySqlSessionService(dataSource);
+  }
+
+  @Test
+  public void lifecycle_noSession() {
+    assertThat(
+            sessionService
+                .getSession("app-name", "user-id", "session-id", Optional.empty())
+                .blockingGet())
+        .isNull();
+
+    assertThat(sessionService.listSessions("app-name", "user-id").blockingGet().sessions())
+        .isEmpty();
+
+    assertThat(
+            sessionService.listEvents("app-name", "user-id", "session-id").blockingGet().events())
+        .isEmpty();
+  }
+
+  @Test
+  public void lifecycle_createSession() {
+    Single<Session> sessionSingle = sessionService.createSession("app-name", "user-id");
+
+    Session session = sessionSingle.blockingGet();
+
+    assertThat(session.id()).isNotNull();
+    assertThat(session.appName()).isEqualTo("app-name");
+    assertThat(session.userId()).isEqualTo("user-id");
+    assertThat(session.state()).isEmpty();
+  }
+
+  @Test
+  public void lifecycle_getSession() {
+    Session session = sessionService.createSession("app-name", "user-id").blockingGet();
+
+    Session retrievedSession =
+        sessionService
+            .getSession(session.appName(), session.userId(), session.id(), Optional.empty())
+            .blockingGet();
+
+    assertThat(retrievedSession).isNotNull();
+    assertThat(retrievedSession.id()).isEqualTo(session.id());
+  }
+
+  @Test
+  public void lifecycle_listSessions() {
+    Session session = sessionService.createSession("app-name", "user-id").blockingGet();
+
+    ListSessionsResponse response =
+        sessionService.listSessions(session.appName(), session.userId()).blockingGet();
+
+    assertThat(response.sessions()).hasSize(1);
+    assertThat(response.sessions().get(0).id()).isEqualTo(session.id());
+  }
+
+  @Test
+  public void lifecycle_deleteSession() {
+    Session session = sessionService.createSession("app-name", "user-id").blockingGet();
+
+    sessionService.deleteSession(session.appName(), session.userId(), session.id()).blockingAwait();
+
+    assertThat(
+            sessionService
+                .getSession(session.appName(), session.userId(), session.id(), Optional.empty())
+                .blockingGet())
+        .isNull();
+  }
+
+  @Test
+  public void appendEvent_updatesSessionState() {
+    Session session =
+        sessionService
+            .createSession("app", "user", new ConcurrentHashMap<>(), "session1")
+            .blockingGet();
+
+    ConcurrentMap<String, Object> stateDelta = new ConcurrentHashMap<>();
+    stateDelta.put("sessionKey", "sessionValue");
+    stateDelta.put(State.APP_PREFIX + "appKey", "appValue");
+    stateDelta.put(State.USER_PREFIX + "userKey", "userValue");
+
+    Event event =
+        Event.builder()
+            .id(UUID.randomUUID().toString()) // Assign a unique ID
+            .actions(EventActions.builder().stateDelta(stateDelta).build())
+            .build();
+
+    sessionService.appendEvent(session, event).blockingGet();
+
+    assertThat(session.state()).containsEntry("sessionKey", "sessionValue");
+
+    Session retrievedSession =
+        sessionService
+            .getSession(session.appName(), session.userId(), session.id(), Optional.empty())
+            .blockingGet();
+
+    assertThat(retrievedSession.state()).containsEntry("sessionKey", "sessionValue");
+    assertThat(retrievedSession.state()).containsEntry(State.APP_PREFIX + "appKey", "appValue");
+    assertThat(retrievedSession.state()).containsEntry(State.USER_PREFIX + "userKey", "userValue");
+  }
+
+  @Test
+  public void listSessions_includesGlobalState() {
+    Session session =
+        sessionService
+            .createSession("app", "user", new ConcurrentHashMap<>(), "session1")
+            .blockingGet();
+
+    ConcurrentMap<String, Object> stateDelta = new ConcurrentHashMap<>();
+    stateDelta.put(State.APP_PREFIX + "appKey", "appValue");
+    stateDelta.put(State.USER_PREFIX + "userKey", "userValue");
+
+    Event event =
+        Event.builder()
+            .id(UUID.randomUUID().toString())
+            .actions(EventActions.builder().stateDelta(stateDelta).build())
+            .build();
+
+    sessionService.appendEvent(session, event).blockingGet();
+
+    ListSessionsResponse response = sessionService.listSessions("app", "user").blockingGet();
+
+    assertThat(response.sessions()).hasSize(1);
+    Session listedSession = response.sessions().get(0);
+
+    // This asserts that the list operation merged the global state correctly
+    assertThat(listedSession.state()).containsEntry(State.APP_PREFIX + "appKey", "appValue");
+    assertThat(listedSession.state()).containsEntry(State.USER_PREFIX + "userKey", "userValue");
+  }
+
+  @Test
+  public void storesCleanKeysInDb_integration() throws Exception {
+    Session session =
+        sessionService
+            .createSession("app", "user", new ConcurrentHashMap<>(), "session1")
+            .blockingGet();
+
+    ConcurrentMap<String, Object> stateDelta = new ConcurrentHashMap<>();
+    stateDelta.put(State.APP_PREFIX + "cleanAppKey", "val1");
+    stateDelta.put(State.USER_PREFIX + "cleanUserKey", "val2");
+
+    Event event =
+        Event.builder()
+            .id(UUID.randomUUID().toString())
+            .actions(EventActions.builder().stateDelta(stateDelta).build())
+            .build();
+
+    sessionService.appendEvent(session, event).blockingGet();
+
+    // Verify DB storage directly
+    try (Connection conn = dataSource.getConnection();
+        Statement stmt = conn.createStatement()) {
+
+      // Check App State
+      try (java.sql.ResultSet rs =
+          stmt.executeQuery(
+              "SELECT state_key FROM adk_app_state WHERE app_name = 'app' AND state_key ="
+                  + " 'cleanAppKey'")) {
+        assertThat(rs.next()).isTrue();
+        assertThat(rs.getString("state_key")).isEqualTo("cleanAppKey"); // Should NOT have prefix
+      }
+
+      // Check User State
+      try (java.sql.ResultSet rs =
+          stmt.executeQuery(
+              "SELECT state_key FROM adk_user_state WHERE app_name = 'app' AND user_id = 'user'"
+                  + " AND state_key = 'cleanUserKey'")) {
+        assertThat(rs.next()).isTrue();
+        assertThat(rs.getString("state_key")).isEqualTo("cleanUserKey"); // Should NOT have prefix
+      }
+    }
+
+    // Verify retrieval adds prefix back
+    Session retrievedSession =
+        sessionService
+            .getSession(session.appName(), session.userId(), session.id(), Optional.empty())
+            .blockingGet();
+
+    assertThat(retrievedSession.state()).containsEntry(State.APP_PREFIX + "cleanAppKey", "val1");
+    assertThat(retrievedSession.state()).containsEntry(State.USER_PREFIX + "cleanUserKey", "val2");
+  }
+
+  @Test
+  public void removesKeysFromDb_integration() throws Exception {
+    Session session =
+        sessionService
+            .createSession("app", "user", new ConcurrentHashMap<>(), "session1")
+            .blockingGet();
+
+    // 1. Setup existing state in DB directly
+    try (Connection conn = dataSource.getConnection();
+        Statement stmt = conn.createStatement()) {
+      stmt.execute(
+          "INSERT INTO adk_app_state (app_name, state_key, state_value) VALUES ('app',"
+              + " 'keyToRemove', '\"val\"')");
+      stmt.execute(
+          "INSERT INTO adk_user_state (app_name, user_id, state_key, state_value) VALUES ('app',"
+              + " 'user', 'keyToRemove', '\"val\"')");
+    }
+
+    // 2. Create event with REMOVED delta
+    ConcurrentMap<String, Object> stateDelta = new ConcurrentHashMap<>();
+    stateDelta.put(State.APP_PREFIX + "keyToRemove", State.REMOVED);
+    stateDelta.put(State.USER_PREFIX + "keyToRemove", State.REMOVED);
+
+    Event event =
+        Event.builder()
+            .id(UUID.randomUUID().toString())
+            .actions(EventActions.builder().stateDelta(stateDelta).build())
+            .build();
+
+    sessionService.appendEvent(session, event).blockingGet();
+
+    // 3. Verify deletion in DB
+    try (Connection conn = dataSource.getConnection();
+        Statement stmt = conn.createStatement()) {
+
+      // Check App State
+      try (java.sql.ResultSet rs =
+          stmt.executeQuery(
+              "SELECT state_key FROM adk_app_state WHERE app_name = 'app' AND state_key ="
+                  + " 'keyToRemove'")) {
+        assertThat(rs.next()).isFalse();
+      }
+
+      // Check User State
+      try (java.sql.ResultSet rs =
+          stmt.executeQuery(
+              "SELECT state_key FROM adk_user_state WHERE app_name = 'app' AND user_id = 'user'"
+                  + " AND state_key = 'keyToRemove'")) {
+        assertThat(rs.next()).isFalse();
+      }
+    }
+
+    // 4. Verify retrieval does not have keys
+    Session retrievedSession =
+        sessionService
+            .getSession(session.appName(), session.userId(), session.id(), Optional.empty())
+            .blockingGet();
+
+    assertThat(retrievedSession.state()).doesNotContainKey(State.APP_PREFIX + "keyToRemove");
+    assertThat(retrievedSession.state()).doesNotContainKey(State.USER_PREFIX + "keyToRemove");
+  }
+}

--- a/contrib/mysql-session-service/src/test/java/com/google/adk/sessions/MySqlSessionServiceIT.java
+++ b/contrib/mysql-session-service/src/test/java/com/google/adk/sessions/MySqlSessionServiceIT.java
@@ -1,0 +1,313 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.adk.sessions;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.adk.events.Event;
+import com.google.adk.events.EventActions;
+import com.zaxxer.hikari.HikariConfig;
+import com.zaxxer.hikari.HikariDataSource;
+import io.reactivex.rxjava3.core.Single;
+import java.sql.Connection;
+import java.sql.Statement;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import javax.sql.DataSource;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+/** Unit tests for {@link MySqlSessionService} using Testcontainers. */
+@Testcontainers
+public final class MySqlSessionServiceIT {
+
+  @Container
+  private static final MySQLContainer<?> mysql =
+      new MySQLContainer<>("mysql:8.3.0").withDatabaseName("adk_test");
+
+  private static DataSource dataSource;
+  private MySqlSessionService sessionService;
+
+  @BeforeAll
+  public static void setUpClass() {
+    HikariConfig config = new HikariConfig();
+    config.setJdbcUrl(mysql.getJdbcUrl());
+    config.setUsername(mysql.getUsername());
+    config.setPassword(mysql.getPassword());
+    dataSource = new HikariDataSource(config);
+  }
+
+  @AfterAll
+  public static void tearDownClass() {
+    if (dataSource instanceof HikariDataSource) {
+      ((HikariDataSource) dataSource).close();
+    }
+  }
+
+  @BeforeEach
+  public void setUp() throws Exception {
+    MySqlTestSchema.reset(dataSource);
+
+    sessionService = new MySqlSessionService(dataSource);
+  }
+
+  @Test
+  public void lifecycle_noSession() {
+    assertThat(
+            sessionService
+                .getSession("app-name", "user-id", "session-id", Optional.empty())
+                .blockingGet())
+        .isNull();
+
+    assertThat(sessionService.listSessions("app-name", "user-id").blockingGet().sessions())
+        .isEmpty();
+
+    assertThat(
+            sessionService.listEvents("app-name", "user-id", "session-id").blockingGet().events())
+        .isEmpty();
+  }
+
+  @Test
+  public void lifecycle_createSession() {
+    Single<Session> sessionSingle = sessionService.createSession("app-name", "user-id");
+
+    Session session = sessionSingle.blockingGet();
+
+    assertThat(session.id()).isNotNull();
+    assertThat(session.appName()).isEqualTo("app-name");
+    assertThat(session.userId()).isEqualTo("user-id");
+    assertThat(session.state()).isEmpty();
+  }
+
+  @Test
+  public void lifecycle_getSession() {
+    Session session = sessionService.createSession("app-name", "user-id").blockingGet();
+
+    Session retrievedSession =
+        sessionService
+            .getSession(session.appName(), session.userId(), session.id(), Optional.empty())
+            .blockingGet();
+
+    assertThat(retrievedSession).isNotNull();
+    assertThat(retrievedSession.id()).isEqualTo(session.id());
+  }
+
+  @Test
+  public void lifecycle_listSessions() {
+    Session session = sessionService.createSession("app-name", "user-id").blockingGet();
+
+    ListSessionsResponse response =
+        sessionService.listSessions(session.appName(), session.userId()).blockingGet();
+
+    assertThat(response.sessions()).hasSize(1);
+    assertThat(response.sessions().get(0).id()).isEqualTo(session.id());
+  }
+
+  @Test
+  public void lifecycle_deleteSession() {
+    Session session = sessionService.createSession("app-name", "user-id").blockingGet();
+
+    sessionService.deleteSession(session.appName(), session.userId(), session.id()).blockingAwait();
+
+    assertThat(
+            sessionService
+                .getSession(session.appName(), session.userId(), session.id(), Optional.empty())
+                .blockingGet())
+        .isNull();
+  }
+
+  @Test
+  public void appendEvent_updatesSessionState() {
+    Session session =
+        sessionService
+            .createSession("app", "user", new ConcurrentHashMap<>(), "session1")
+            .blockingGet();
+
+    ConcurrentMap<String, Object> stateDelta = new ConcurrentHashMap<>();
+    stateDelta.put("sessionKey", "sessionValue");
+    stateDelta.put(State.APP_PREFIX + "appKey", "appValue");
+    stateDelta.put(State.USER_PREFIX + "userKey", "userValue");
+
+    Event event =
+        Event.builder()
+            .id(UUID.randomUUID().toString()) // Assign a unique ID
+            .actions(EventActions.builder().stateDelta(stateDelta).build())
+            .build();
+
+    sessionService.appendEvent(session, event).blockingGet();
+
+    assertThat(session.state()).containsEntry("sessionKey", "sessionValue");
+
+    Session retrievedSession =
+        sessionService
+            .getSession(session.appName(), session.userId(), session.id(), Optional.empty())
+            .blockingGet();
+
+    assertThat(retrievedSession.state()).containsEntry("sessionKey", "sessionValue");
+    assertThat(retrievedSession.state()).containsEntry(State.APP_PREFIX + "appKey", "appValue");
+    assertThat(retrievedSession.state()).containsEntry(State.USER_PREFIX + "userKey", "userValue");
+  }
+
+  @Test
+  public void listSessions_includesGlobalState() {
+    Session session =
+        sessionService
+            .createSession("app", "user", new ConcurrentHashMap<>(), "session1")
+            .blockingGet();
+
+    ConcurrentMap<String, Object> stateDelta = new ConcurrentHashMap<>();
+    stateDelta.put(State.APP_PREFIX + "appKey", "appValue");
+    stateDelta.put(State.USER_PREFIX + "userKey", "userValue");
+
+    Event event =
+        Event.builder()
+            .id(UUID.randomUUID().toString())
+            .actions(EventActions.builder().stateDelta(stateDelta).build())
+            .build();
+
+    sessionService.appendEvent(session, event).blockingGet();
+
+    ListSessionsResponse response = sessionService.listSessions("app", "user").blockingGet();
+
+    assertThat(response.sessions()).hasSize(1);
+    Session listedSession = response.sessions().get(0);
+
+    // This asserts that the list operation merged the global state correctly
+    assertThat(listedSession.state()).containsEntry(State.APP_PREFIX + "appKey", "appValue");
+    assertThat(listedSession.state()).containsEntry(State.USER_PREFIX + "userKey", "userValue");
+  }
+
+  @Test
+  public void storesCleanKeysInDb_integration() throws Exception {
+    Session session =
+        sessionService
+            .createSession("app", "user", new ConcurrentHashMap<>(), "session1")
+            .blockingGet();
+
+    ConcurrentMap<String, Object> stateDelta = new ConcurrentHashMap<>();
+    stateDelta.put(State.APP_PREFIX + "cleanAppKey", "val1");
+    stateDelta.put(State.USER_PREFIX + "cleanUserKey", "val2");
+
+    Event event =
+        Event.builder()
+            .id(UUID.randomUUID().toString())
+            .actions(EventActions.builder().stateDelta(stateDelta).build())
+            .build();
+
+    sessionService.appendEvent(session, event).blockingGet();
+
+    // Verify DB storage directly
+    try (Connection conn = dataSource.getConnection();
+        Statement stmt = conn.createStatement()) {
+
+      // Check App State
+      try (java.sql.ResultSet rs =
+          stmt.executeQuery(
+              "SELECT state_key FROM adk_app_state WHERE app_name = 'app' AND state_key ="
+                  + " 'cleanAppKey'")) {
+        assertThat(rs.next()).isTrue();
+        assertThat(rs.getString("state_key")).isEqualTo("cleanAppKey"); // Should NOT have prefix
+      }
+
+      // Check User State
+      try (java.sql.ResultSet rs =
+          stmt.executeQuery(
+              "SELECT state_key FROM adk_user_state WHERE app_name = 'app' AND user_id = 'user'"
+                  + " AND state_key = 'cleanUserKey'")) {
+        assertThat(rs.next()).isTrue();
+        assertThat(rs.getString("state_key")).isEqualTo("cleanUserKey"); // Should NOT have prefix
+      }
+    }
+
+    // Verify retrieval adds prefix back
+    Session retrievedSession =
+        sessionService
+            .getSession(session.appName(), session.userId(), session.id(), Optional.empty())
+            .blockingGet();
+
+    assertThat(retrievedSession.state()).containsEntry(State.APP_PREFIX + "cleanAppKey", "val1");
+    assertThat(retrievedSession.state()).containsEntry(State.USER_PREFIX + "cleanUserKey", "val2");
+  }
+
+  @Test
+  public void removesKeysFromDb_integration() throws Exception {
+    Session session =
+        sessionService
+            .createSession("app", "user", new ConcurrentHashMap<>(), "session1")
+            .blockingGet();
+
+    // 1. Setup existing state in DB directly
+    try (Connection conn = dataSource.getConnection();
+        Statement stmt = conn.createStatement()) {
+      stmt.execute(
+          "INSERT INTO adk_app_state (app_name, state_key, state_value) VALUES ('app',"
+              + " 'keyToRemove', '\"val\"')");
+      stmt.execute(
+          "INSERT INTO adk_user_state (app_name, user_id, state_key, state_value) VALUES ('app',"
+              + " 'user', 'keyToRemove', '\"val\"')");
+    }
+
+    // 2. Create event with REMOVED delta
+    ConcurrentMap<String, Object> stateDelta = new ConcurrentHashMap<>();
+    stateDelta.put(State.APP_PREFIX + "keyToRemove", State.REMOVED);
+    stateDelta.put(State.USER_PREFIX + "keyToRemove", State.REMOVED);
+
+    Event event =
+        Event.builder()
+            .id(UUID.randomUUID().toString())
+            .actions(EventActions.builder().stateDelta(stateDelta).build())
+            .build();
+
+    sessionService.appendEvent(session, event).blockingGet();
+
+    // 3. Verify deletion in DB
+    try (Connection conn = dataSource.getConnection();
+        Statement stmt = conn.createStatement()) {
+
+      // Check App State
+      try (java.sql.ResultSet rs =
+          stmt.executeQuery(
+              "SELECT state_key FROM adk_app_state WHERE app_name = 'app' AND state_key ="
+                  + " 'keyToRemove'")) {
+        assertThat(rs.next()).isFalse();
+      }
+
+      // Check User State
+      try (java.sql.ResultSet rs =
+          stmt.executeQuery(
+              "SELECT state_key FROM adk_user_state WHERE app_name = 'app' AND user_id = 'user'"
+                  + " AND state_key = 'keyToRemove'")) {
+        assertThat(rs.next()).isFalse();
+      }
+    }
+
+    // 4. Verify retrieval does not have keys
+    Session retrievedSession =
+        sessionService
+            .getSession(session.appName(), session.userId(), session.id(), Optional.empty())
+            .blockingGet();
+
+    assertThat(retrievedSession.state()).doesNotContainKey(State.APP_PREFIX + "keyToRemove");
+    assertThat(retrievedSession.state()).doesNotContainKey(State.USER_PREFIX + "keyToRemove");
+  }
+}

--- a/contrib/mysql-session-service/src/test/java/com/google/adk/sessions/MySqlSessionServiceUnitTest.java
+++ b/contrib/mysql-session-service/src/test/java/com/google/adk/sessions/MySqlSessionServiceUnitTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.adk.sessions;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.reactivex.rxjava3.core.Completable;
+import io.reactivex.rxjava3.core.Single;
+import java.util.concurrent.ConcurrentHashMap;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+/**
+ * Unit tests for {@link MySqlSessionService}. These tests use a mock {@link MySqlDBHelper} and do
+ * not require a running database.
+ */
+class MySqlSessionServiceUnitTest {
+
+  private MySqlDBHelper mockDbHelper;
+  private MySqlSessionService sessionService;
+
+  @BeforeEach
+  void setUp() {
+    mockDbHelper = mock(MySqlDBHelper.class);
+    sessionService = new MySqlSessionService(mockDbHelper);
+  }
+
+  @Test
+  void createSession_validInput_delegatesToDbHelper() {
+    String appName = "testApp";
+    String userId = "testUser";
+
+    when(mockDbHelper.saveSession(any(Session.class))).thenReturn(Completable.complete());
+    when(mockDbHelper.getInitialState(anyString(), anyString()))
+        .thenReturn(Single.just(new ConcurrentHashMap<>()));
+
+    sessionService.createSession(appName, userId, null, null).blockingGet();
+
+    verify(mockDbHelper).saveSession(any(Session.class));
+    verify(mockDbHelper).getInitialState(eq(appName), eq(userId));
+  }
+
+  @Test
+  void createSession_mergesGlobalState() {
+    String appName = "testApp";
+    String userId = "testUser";
+
+    // Global state
+    ConcurrentHashMap<String, Object> globalState = new ConcurrentHashMap<>();
+    globalState.put("_user_pref", "dark_mode");
+    globalState.put("shared_key", "global_value");
+
+    // Initial Session state
+    ConcurrentHashMap<String, Object> initialSessionState = new ConcurrentHashMap<>();
+    initialSessionState.put("shared_key", "session_value");
+
+    when(mockDbHelper.saveSession(any(Session.class))).thenReturn(Completable.complete());
+    when(mockDbHelper.getInitialState(anyString(), anyString()))
+        .thenReturn(Single.just(globalState));
+
+    Session session =
+        sessionService.createSession(appName, userId, initialSessionState, null).blockingGet();
+
+    // Verify global only key is present
+    assertThat(session.state()).containsEntry("_user_pref", "dark_mode");
+    // Verify session key overrides global key
+    assertThat(session.state()).containsEntry("shared_key", "session_value");
+
+    // Verify that saveSession was called WITH the merged state
+    ArgumentCaptor<Session> sessionCaptor = ArgumentCaptor.forClass(Session.class);
+    verify(mockDbHelper).saveSession(sessionCaptor.capture());
+    Session savedSession = sessionCaptor.getValue();
+    assertThat(savedSession.state()).containsEntry("_user_pref", "dark_mode");
+    assertThat(savedSession.state()).containsEntry("shared_key", "session_value");
+  }
+
+  @Test
+  void getSession_validInput_delegatesToDbHelper() {
+    when(mockDbHelper.getSession(anyString(), anyString(), anyString(), any()))
+        .thenReturn(io.reactivex.rxjava3.core.Maybe.empty());
+
+    sessionService.getSession("app", "user", "session1", java.util.Optional.empty());
+    verify(mockDbHelper).getSession("app", "user", "session1", java.util.Optional.empty());
+  }
+}

--- a/contrib/mysql-session-service/src/test/java/com/google/adk/sessions/MySqlTestSchema.java
+++ b/contrib/mysql-session-service/src/test/java/com/google/adk/sessions/MySqlTestSchema.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.adk.sessions;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Objects;
+import javax.sql.DataSource;
+
+final class MySqlTestSchema {
+
+  private MySqlTestSchema() {}
+
+  static void reset(DataSource dataSource) throws SQLException, IOException {
+    try (Connection conn = dataSource.getConnection();
+        Statement stmt = conn.createStatement()) {
+      stmt.execute("DROP TABLE IF EXISTS adk_events");
+      stmt.execute("DROP TABLE IF EXISTS adk_sessions");
+      stmt.execute("DROP TABLE IF EXISTS adk_app_state");
+      stmt.execute("DROP TABLE IF EXISTS adk_user_state");
+
+      try (InputStream schemaStream =
+          Objects.requireNonNull(
+              MySqlTestSchema.class
+                  .getClassLoader()
+                  .getResourceAsStream("mysql-session-service-schema.sql"))) {
+        String schema = new String(schemaStream.readAllBytes(), StandardCharsets.UTF_8);
+        if (conn.getMetaData().getDatabaseProductName().equals("H2")) {
+          // H2's JSON type JSON-encodes strings passed through PreparedStatement#setString,
+          // unlike MySQL. TEXT preserves the JDBC behavior exercised by these DAO tests.
+          schema = schema.replace(" JSON NOT NULL", " TEXT NOT NULL");
+        }
+        for (String sql : schema.split(";")) {
+          if (!sql.isBlank()) {
+            stmt.execute(sql);
+          }
+        }
+      }
+    }
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -32,6 +32,7 @@
     <module>contrib/spring-ai</module>
     <module>contrib/samples</module>
     <module>contrib/firestore-session-service</module>
+    <module>contrib/mysql-session-service</module>
     <module>tutorials/city-time-weather</module>
     <module>tutorials/live-audio-single-agent</module>
     <module>a2a</module>

--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,7 @@
     <module>contrib/samples</module>
     <module>contrib/planners</module>
     <module>contrib/firestore-session-service</module>
+    <module>contrib/mysql-session-service</module>
     <module>tutorials/city-time-weather</module>
     <module>tutorials/live-audio-single-agent</module>
     <module>a2a</module>


### PR DESCRIPTION
This PR introduces a MySQL implementation of the `BaseSessionService`, allowing the ADK to persist session state and history in a MySQL. This is crucial for distributed deployments and long-running agent interactions. The service automatically expects/uses session tables (schema provided in the README)

Key Changes

1. New Module: google-adk-mysql-session-service
A new contribution module located in contrib/mysql-session-service containing:

 * `MySqlSessionService`:
     * Implements the BaseSessionService interface.
     * Manages the full session lifecycle (create, get, list, delete).
     * Handles event appending with transactional integrity.
     * Uses same ObjectMapper as parent ADK library for efficient JSON serialization of session state and context.

 * `MySqlDBHelper`:
     * Encapsulates low-level JDBC operations to ensure clean separation of concerns.
     * Handles safe parameter mapping and result set extraction.
     * Optimistic Locking: Implements robust concurrency control using the updated_at column.
     * Precision Handling: Includes specific logic to truncate Java Instant nanoseconds to MySQL TIMESTAMP millisecond precision, preventing spurious ConcurrentModificationException errors caused by rounding mismatches.

2. Test Coverage
 * `MySqlSessionServiceUnitTest`: Tests service logic in isolation using Mockito to mock database interactions.
 * `MySqlDBHelperTest`: Focuses on the data access layer, verifying correct SQL generation, JSON conversion, and optimistic locking mechanics.
 * `MySqlSessionServiceIT`: An integration test suite that verifies end-to-end functionality (CRUD, history appending, concurrency) against a live MySQL instance.