### PR TITLE
Ensure all property types are translated when converting function calls to a2a

### DIFF
--- a/a2a/src/main/java/com/google/adk/a2a/converters/PartConverter.java
+++ b/a2a/src/main/java/com/google/adk/a2a/converters/PartConverter.java
@@ -137,7 +137,7 @@ public final class PartConverter {
       return Optional.of(
           com.google.genai.types.Part.builder()
               .functionCall(
-                FunctionCall.builder().name(functionName).id(functionId).args(args).build())
+                FunctionCall.builder().name(functionName).id(functionId).id(functionId).args(args).build())
               .build());
     }
 
@@ -150,7 +150,7 @@ public final class PartConverter {
           com.google.genai.types.Part.builder()
               .functionResponse(
                   FunctionResponse.builder()
-                      .name(functionName)
+                      .name(functionName).id(functionId)
                       .id(functionId)
                       .response(response)
                       .build())

--- a/a2a/src/test/java/com/google/adk/a2a/EventConverterTest.java
+++ b/a2a/src/test/java/com/google/adk/a2a/EventConverterTest.java
@@ -45,7 +45,7 @@ public final class EventConverterTest {
         Part.builder()
             .functionCall(
                 FunctionCall.builder()
-                    .name("roll_die")
+                    .name("roll_die").id("adk-call-1")
                     .id("adk-call-1")
                     .args(Map.of("sides", 6))
                     .build())
@@ -65,7 +65,7 @@ public final class EventConverterTest {
         Part.builder()
             .functionResponse(
                 FunctionResponse.builder()
-                    .name("roll_die")
+                    .name("roll_die").id("adk-call-1")
                     .id("adk-call-1")
                     .response(Map.of("result", 3))
                     .build())


### PR DESCRIPTION
Python and Go implementations of ADK both copy function call and response properties by copying the entire struct automatically. Java does this a property at a time and so was missing the "id" property of the ADK event.  Providing these allows downstream agents to properly associate multiple tool calls and responses to the same tool name.