### PR TITLE
Ensure all properties are copied when converting to a2a

### DIFF
--- a/a2a/src/main/java/com/google/adk/a2a/converters/PartConverter.java
+++ b/a2a/src/main/java/com/google/adk/a2a/converters/PartConverter.java
@@ -132,21 +132,28 @@ public final class PartConverter {
     if (data.containsKey("name") && data.containsKey("args")
         || A2A_DATA_PART_METADATA_TYPE_FUNCTION_CALL.equals(metadataType)) {
       String functionName = String.valueOf(data.getOrDefault("name", ""));
+      String functionId = String.valueOf(data.getOrDefault("id", ""));
       Map<String, Object> args = coerceToMap(data.get("args"));
       return Optional.of(
           com.google.genai.types.Part.builder()
-              .functionCall(FunctionCall.builder().name(functionName).args(args).build())
+              .functionCall(
+                  FunctionCall.builder().name(functionName).id(functionId).args(args).build())
               .build());
     }
 
     if (data.containsKey("name") && data.containsKey("response")
         || A2A_DATA_PART_METADATA_TYPE_FUNCTION_RESPONSE.equals(metadataType)) {
       String functionName = String.valueOf(data.getOrDefault("name", ""));
+      String functionId = String.valueOf(data.getOrDefault("id", ""));
       Map<String, Object> response = coerceToMap(data.get("response"));
       return Optional.of(
           com.google.genai.types.Part.builder()
               .functionResponse(
-                  FunctionResponse.builder().name(functionName).response(response).build())
+                  FunctionResponse.builder()
+                      .name(functionName)
+                      .id(functionId)
+                      .response(response)
+                      .build())
               .build());
     }
 
@@ -167,6 +174,7 @@ public final class PartConverter {
   private static Optional<DataPart> createDataPartFromFunctionCall(FunctionCall functionCall) {
     Map<String, Object> data = new HashMap<>();
     data.put("name", functionCall.name().orElse(""));
+    data.put("id", functionCall.id().orElse(""));
     data.put("args", functionCall.args().orElse(Map.of()));
 
     Map<String, Object> metadata =
@@ -185,6 +193,7 @@ public final class PartConverter {
       FunctionResponse functionResponse) {
     Map<String, Object> data = new HashMap<>();
     data.put("name", functionResponse.name().orElse(""));
+    data.put("id", functionResponse.id().orElse(""));
     data.put("response", functionResponse.response().orElse(Map.of()));
 
     Map<String, Object> metadata =

--- a/a2a/src/test/java/com/google/adk/a2a/EventConverterTest.java
+++ b/a2a/src/test/java/com/google/adk/a2a/EventConverterTest.java
@@ -43,7 +43,12 @@ public final class EventConverterTest {
 
     Part functionCallPart =
         Part.builder()
-            .functionCall(FunctionCall.builder().name("roll_die").args(Map.of("sides", 6)).build())
+            .functionCall(
+                FunctionCall.builder()
+                    .name("roll_die")
+                    .id("adk-call-1")
+                    .args(Map.of("sides", 6))
+                    .build())
             .build();
     Event callEvent =
         Event.builder()
@@ -59,7 +64,11 @@ public final class EventConverterTest {
     Part functionResponsePart =
         Part.builder()
             .functionResponse(
-                FunctionResponse.builder().name("roll_die").response(Map.of("result", 3)).build())
+                FunctionResponse.builder()
+                    .name("roll_die")
+                    .id("adk-call-1")
+                    .response(Map.of("result", 3))
+                    .build())
             .build();
     Event responseEvent =
         Event.builder()
@@ -106,11 +115,14 @@ public final class EventConverterTest {
     assertThat(callDataPart.getMetadata().get(PartConverter.A2A_DATA_PART_METADATA_TYPE_KEY))
         .isEqualTo(PartConverter.A2A_DATA_PART_METADATA_TYPE_FUNCTION_CALL);
     assertThat(callDataPart.getData()).containsEntry("name", "roll_die");
+    assertThat(callDataPart.getData()).containsEntry("id", "adk-call-1");
     assertThat(callDataPart.getData()).containsEntry("args", Map.of("sides", 6));
 
     DataPart responseDataPart = (DataPart) message.getParts().get(2);
     assertThat(responseDataPart.getMetadata().get(PartConverter.A2A_DATA_PART_METADATA_TYPE_KEY))
         .isEqualTo(PartConverter.A2A_DATA_PART_METADATA_TYPE_FUNCTION_RESPONSE);
+    assertThat(responseDataPart.getData()).containsEntry("name", "roll_die");
+    assertThat(responseDataPart.getData()).containsEntry("id", "adk-call-1");
     assertThat(responseDataPart.getData()).containsEntry("response", Map.of("result", 3));
   }
 


### PR DESCRIPTION
Python and Go implementations of ADK both copy function call and response properties by copying the entire struct automatically. Java does this a property at a time and so was missing the "id" property of the ADK event. Providing these allows downstream agents to properly associate multiple tool calls and responses to the same tool name.

Updated EventConverterTest to verify the new field and also verified function name in the response object.