### PR TITLE
fix: Merging of events in rearrangeEventsForAsyncFunctionResponsesInHistory

### DIFF
--- a/core/src/main/java/com/google/adk/flows/llmflows/Contents.java
+++ b/core/src/main/java/com/google/adk/flows/llmflows/Contents.java
@@ -564,8 +564,7 @@ public final class Contents implements RequestProcessor {
     for (int i = 0; i < events.size(); i++) {
       Event event = events.get(i);
 
-      // Skip response events that will be processed via responseEventsBuffer
-      if (processedResponseIndices.contains(i)) {
+      if (!event.functionResponses().isEmpty()) {
         continue;
       }
 

--- a/core/src/test/java/com/google/adk/flows/llmflows/ContentsTest.java
+++ b/core/src/test/java/com/google/adk/flows/llmflows/ContentsTest.java
@@ -203,9 +203,11 @@ public final class ContentsTest {
   public void rearrangeHistory_multipleFRsForSameFC_returnsMergedFR() {
     Event fcEvent = createFunctionCallEvent("fc1", "tool1", "call1");
     Event frEvent1 =
-        createFunctionResponseEvent("fr1", "tool1", "call1", ImmutableMap.of("status", "running"));
+        createFunctionResponseEvent("fr1", "tool1", "call1", ImmutableMap.of("status", "pending"));
     Event frEvent2 =
-        createFunctionResponseEvent("fr2", "tool1", "call1", ImmutableMap.of("status", "done"));
+        createFunctionResponseEvent("fr2", "tool1", "call1", ImmutableMap.of("status", "running"));
+    Event frEvent3 =
+        createFunctionResponseEvent("fr3", "tool1", "call1", ImmutableMap.of("status", "done"));
     ImmutableList<Event> inputEvents =
         ImmutableList.of(
             createUserEvent("u1", "Query"),
@@ -213,17 +215,75 @@ public final class ContentsTest {
             createUserEvent("u2", "Wait"),
             frEvent1,
             createUserEvent("u3", "Done?"),
-            frEvent2);
+            frEvent2,
+            frEvent3,
+            createUserEvent("u4", "Follow up query"));
 
     List<Content> result = runContentsProcessor(inputEvents);
 
-    assertThat(result).hasSize(3); // u1, fc1, merged_fr
+    assertThat(result).hasSize(6); // u1, fc1, merged_fr, u2, u3, u4
     assertThat(result.get(0)).isEqualTo(inputEvents.get(0).content().get());
-    assertThat(result.get(1)).isEqualTo(inputEvents.get(1).content().get()); // Check merged event
+    assertThat(result.get(1)).isEqualTo(inputEvents.get(1).content().get()); // Check fcEvent
     Content mergedContent = result.get(2);
     assertThat(mergedContent.parts().get()).hasSize(1);
     assertThat(mergedContent.parts().get().get(0).functionResponse().get().response().get())
-        .containsExactly("status", "done"); // Last FR wins
+        .containsExactly("status", "done"); // Last FR wins (frEvent3)
+    assertThat(result.get(3)).isEqualTo(inputEvents.get(2).content().get()); // u2
+    assertThat(result.get(4)).isEqualTo(inputEvents.get(4).content().get()); // u3
+    assertThat(result.get(5)).isEqualTo(inputEvents.get(7).content().get()); // u4
+  }
+
+  @Test
+  public void rearrangeHistory_multipleFRsForMultipleFC_returnsMergedFR() {
+    Event fcEvent1 = createFunctionCallEvent("fc1", "tool1", "call1");
+    Event fcEvent2 = createFunctionCallEvent("fc2", "tool1", "call2");
+
+    Event frEvent1 =
+        createFunctionResponseEvent("fr1", "tool1", "call1", ImmutableMap.of("status", "pending"));
+    Event frEvent2 =
+        createFunctionResponseEvent("fr2", "tool1", "call1", ImmutableMap.of("status", "done"));
+
+    Event frEvent3 =
+        createFunctionResponseEvent("fr3", "tool1", "call2", ImmutableMap.of("status", "pending"));
+    Event frEvent4 =
+        createFunctionResponseEvent("fr4", "tool1", "call2", ImmutableMap.of("status", "done"));
+
+    ImmutableList<Event> inputEvents =
+        ImmutableList.of(
+            createUserEvent("u1", "I"),
+            fcEvent1,
+            createUserEvent("u2", "am"),
+            frEvent1,
+            createUserEvent("u3", "waiting"),
+            frEvent2,
+            createUserEvent("u4", "for"),
+            fcEvent2,
+            createUserEvent("u5", "you"),
+            frEvent3,
+            createUserEvent("u6", "to"),
+            frEvent4,
+            createUserEvent("u7", "Follow up query"));
+
+    List<Content> result = runContentsProcessor(inputEvents);
+
+    assertThat(result).hasSize(11); // u1, fc1, frEvent2, u2, u3, u4, fc2, frEvent4, u5, u6, u7
+    assertThat(result.get(0)).isEqualTo(inputEvents.get(0).content().get()); // u1
+    assertThat(result.get(1)).isEqualTo(inputEvents.get(1).content().get()); // fc1
+    Content mergedContent = result.get(2);
+    assertThat(mergedContent.parts().get()).hasSize(1);
+    assertThat(mergedContent.parts().get().get(0).functionResponse().get().response().get())
+        .containsExactly("status", "done"); // Last FR wins (frEvent2)
+    assertThat(result.get(3)).isEqualTo(inputEvents.get(2).content().get()); // u2
+    assertThat(result.get(4)).isEqualTo(inputEvents.get(4).content().get()); // u3
+    assertThat(result.get(5)).isEqualTo(inputEvents.get(6).content().get()); // u4
+    assertThat(result.get(6)).isEqualTo(inputEvents.get(7).content().get()); // fc2
+    Content mergedContent2 = result.get(7);
+    assertThat(mergedContent2.parts().get()).hasSize(1);
+    assertThat(mergedContent2.parts().get().get(0).functionResponse().get().response().get())
+        .containsExactly("status", "done"); // Last FR wins (frEvent4)
+    assertThat(result.get(8)).isEqualTo(inputEvents.get(8).content().get()); // u5
+    assertThat(result.get(9)).isEqualTo(inputEvents.get(10).content().get()); // u6
+    assertThat(result.get(10)).isEqualTo(inputEvents.get(12).content().get()); // u7
   }
 
   @Test


### PR DESCRIPTION
**Problem** 

When using long running tools https://google.github.io/adk-docs/tools-custom/function-tools/#long-run-tool (or boolean confirmation), if a follow up prompt is provided to the agent after a "confirmed" tool is executed. The `rearrangeEventsForAsyncFunctionResponsesInHistory` function will incorrectly merge function calls and responses in the event history.

This results in events being not in order, and multiple function response for the same function call, and results in failures in subsequent invocation of the agent when using non-Gemini models.

```
Role 'tool' must be a response to a preceding message with 'tool_calls'
```

**Example**
Input:
[user prompt 1, FC1, user prompt 2, FR1A, user prompt 3, model response 1, FR1B, user prompt 4]

Actual Output:
[user prompt 1, FC1, FR1B, user prompt 2, FR1A, user prompt 3, model response 1, user prompt 4]

My Expected Output:
[user prompt 1, FC1, FR1B, user prompt 4] (dropping all events between the FC and corresponding FR)

Looking at how we handle the merging of events when the function response is the latest event `rearrangeEventsForLatestFunctionResponse`, we seem to drop events between the FC and corresponding FR, perhaps the logic should be smarter to conditionally keep some the intermediate events.

adk-python Output
[user prompt 1, FC1, FR1B, model response 1, user prompt 4]

`adk-python` seems to keep some of the intermediate model responses where the model asks user for confirmation, but providing this to subsequent agent calls doesn't seem very useful if function has already been executed and we have the result.
<img width="998" height="733" alt="Screenshot 2026-01-19 at 12 35 26 pm" src="https://github.com/user-attachments/assets/76bd0fe7-e363-4581-8809-619745f54093" />

**Change**
When processing each event, it will skip to the corresponding function response and thus ignoring events in between. Added some tests to handle when there are multiple function calls.