### PR TITLE
Fix NPE when Vertex AI listSessions omits sessions

### DIFF
--- a/core/src/main/java/com/google/adk/sessions/VertexAiSessionService.java
+++ b/core/src/main/java/com/google/adk/sessions/VertexAiSessionService.java
@@ -128,15 +128,17 @@ public final class VertexAiSessionService implements BaseSessionService {
         .map(
             listSessionsResponseMap ->
                 parseListSessionsResponse(listSessionsResponseMap, appName, userId))
-        .defaultIfEmpty(ListSessionsResponse.builder().build());
+        .defaultIfEmpty(ListSessionsResponse.builder().sessions(new ArrayList<>()).build());
   }
 
   private ListSessionsResponse parseListSessionsResponse(
       JsonNode listSessionsResponseMap, String appName, String userId) {
+    JsonNode sessionsNode = listSessionsResponseMap.get("sessions");
+    if (sessionsNode == null || sessionsNode.isNull() || sessionsNode.isEmpty()) {
+      return ListSessionsResponse.builder().sessions(new ArrayList<>()).build();
+    }
     List<Map<String, Object>> apiSessions =
-        objectMapper.convertValue(
-            listSessionsResponseMap.get("sessions"),
-            new TypeReference<List<Map<String, Object>>>() {});
+        objectMapper.convertValue(sessionsNode, new TypeReference<List<Map<String, Object>>>() {});
 
     List<Session> sessions = new ArrayList<>();
     for (Map<String, Object> apiSession : apiSessions) {

--- a/core/src/test/java/com/google/adk/sessions/VertexAiSessionServiceTest.java
+++ b/core/src/test/java/com/google/adk/sessions/VertexAiSessionServiceTest.java
@@ -25,6 +25,8 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import okhttp3.MediaType;
+import okhttp3.ResponseBody;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -37,6 +39,20 @@ import org.mockito.MockitoAnnotations;
 public class VertexAiSessionServiceTest {
 
   private static final ObjectMapper mapper = JsonBaseModel.getMapper();
+  private static final MediaType JSON_MEDIA_TYPE =
+      MediaType.parse("application/json; charset=utf-8");
+
+  private static ApiResponse apiResponseJson(String json) {
+    return new ApiResponse() {
+      @Override
+      public ResponseBody getResponseBody() {
+        return ResponseBody.create(JSON_MEDIA_TYPE, json);
+      }
+
+      @Override
+      public void close() {}
+    };
+  }
 
   private static final String MOCK_SESSION_STRING_1 =
       """
@@ -316,6 +332,24 @@ public class VertexAiSessionServiceTest {
   @Test
   public void listSessions_empty() {
     assertThat(vertexAiSessionService.listSessions("789", "user1").blockingGet().sessions())
+        .isEmpty();
+  }
+
+  @Test
+  public void listSessions_missingSessionsField_returnsEmpty() {
+    when(mockApiClient.request("GET", "reasoningEngines/123/sessions?filter=user_id=userX", ""))
+        .thenReturn(apiResponseJson("{}"));
+
+    assertThat(vertexAiSessionService.listSessions("123", "userX").blockingGet().sessions())
+        .isEmpty();
+  }
+
+  @Test
+  public void listSessions_nullSessionsField_returnsEmpty() {
+    when(mockApiClient.request("GET", "reasoningEngines/123/sessions?filter=user_id=userY", ""))
+        .thenReturn(apiResponseJson("{\"sessions\": null}"));
+
+    assertThat(vertexAiSessionService.listSessions("123", "userY").blockingGet().sessions())
         .isEmpty();
   }
 


### PR DESCRIPTION
Fixes a `NullPointerException` when the Vertex AI Session API listSessions response omits `sessions` or returns `sessions: null`.

Problem:
```
java.lang.NullPointerException: Cannot invoke "java.util.List.iterator()" because "apiSessions" is null
  at com.google.adk.sessions.VertexAiSessionService.parseListSessionsResponse ( com/google.adk.sessions/VertexAiSessionService.java:133 )
  at com.google.adk.sessions.VertexAiSessionService.lambda$listSessions$0 ( com/google.adk.sessions/VertexAiSessionService.java:121 )
  at io.reactivex.rxjava3.internal.operators.maybe.MaybeMap$MapMaybeObserver.onSuccess ( io/reactivex.rxjava3.internal.operators.maybe/MaybeMap.java:83 )
  at io.reactivex.rxjava3.internal.operators.single.SingleFlatMapMaybe$FlatMapMaybeObserver.onSuccess ( io/reactivex.rxjava3.internal.operators.single/SingleFlatMapMaybe.java:114 )
  at io.reactivex.rxjava3.internal.operators.maybe.MaybeJust.subscribeActual ( io/reactivex.rxjava3.internal.operators.maybe/MaybeJust.java:36 )
  at io.reactivex.rxjava3.core.Maybe.subscribe ( io/reactivex.rxjava3.core/Maybe.java:5377 )
  at io.reactivex.rxjava3.internal.operators.single.SingleFlatMapMaybe$FlatMapSingleObserver.onSuccess ( io/reactivex.rxjava3.internal.operators.single/SingleFlatMapMaybe.java:86 )
  at io.reactivex.rxjava3.internal.operators.single.SingleFromCallable.subscribeActual ( io/reactivex.rxjava3.internal.operators.single/SingleFromCallable.java:55 )
  at io.reactivex.rxjava3.core.Single.subscribe ( io/reactivex.rxjava3.core/Single.java:4855 )
  at io.reactivex.rxjava3.internal.operators.single.SingleFlatMapMaybe.subscribeActual ( io/reactivex.rxjava3.internal.operators.single/SingleFlatMapMaybe.java:38 )
  at io.reactivex.rxjava3.core.Maybe.subscribe ( io/reactivex.rxjava3.core/Maybe.java:5377 )
  at io.reactivex.rxjava3.internal.operators.maybe.MaybeMap.subscribeActual ( io/reactivex.rxjava3.internal.operators.maybe/MaybeMap.java:41 )
  at io.reactivex.rxjava3.core.Maybe.subscribe ( io/reactivex.rxjava3.core/Maybe.java:5377 )
  at io.reactivex.rxjava3.internal.operators.maybe.MaybeToSingle.subscribeActual ( io/reactivex.rxjava3.internal.operators.maybe/MaybeToSingle.java:46 )
  at io.reactivex.rxjava3.core.Single.subscribe ( io/reactivex.rxjava3.core/Single.java:4855 )
  at io.reactivex.rxjava3.core.Single.blockingGet ( io/reactivex.rxjava3.core/Single.java:3644 )
  at com.google.adk.web.controller.SessionController.listSessions ( com/google.adk.web.controller/SessionController.java:136 )
  at jakarta.servlet.http.HttpServlet.service ( jakarta/servlet.http/HttpServlet.java:564 )
  at jakarta.servlet.http.HttpServlet.service ( jakarta/servlet.http/HttpServlet.java:658 )
```


Changes:
- Treat missing/null/empty `sessions` as an empty list in `VertexAiSessionService`.
- Add regression tests for missing + null `sessions`.

Test:
- `./mvnw -pl core test`