### PR TITLE
fix : enable service injection in A2ASendMessageExecutor for A2A runner

### DIFF
--- a/a2a/src/test/java/com/google/adk/a2a/A2ASendMessageExecutorAdvancedTest.java
+++ b/a2a/src/test/java/com/google/adk/a2a/A2ASendMessageExecutorAdvancedTest.java
@@ -1,0 +1,230 @@
+package com.google.adk.a2a;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.adk.agents.BaseAgent;
+import com.google.adk.agents.InvocationContext;
+import com.google.adk.artifacts.InMemoryArtifactService;
+import com.google.adk.events.Event;
+import com.google.adk.memory.InMemoryMemoryService;
+import com.google.adk.sessions.InMemorySessionService;
+import com.google.common.collect.ImmutableList;
+import com.google.genai.types.Content;
+import com.google.genai.types.Part;
+import io.a2a.spec.Message;
+import io.a2a.spec.TextPart;
+import io.reactivex.rxjava3.core.Flowable;
+import io.reactivex.rxjava3.core.Single;
+import java.time.Duration;
+import java.util.List;
+import java.util.UUID;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class A2ASendMessageExecutorAdvancedTest {
+
+  private InMemorySessionService sessionService;
+
+  @Test
+  public void execute_withCustomStrategy_usesStrategy() {
+    InMemorySessionService sessionService = new InMemorySessionService();
+
+    A2ASendMessageExecutor executor = new A2ASendMessageExecutor(sessionService, "test-app");
+
+    A2ASendMessageExecutor.AgentExecutionStrategy customStrategy =
+        (userId, sessionId, userContent, runConfig, invocationId) -> {
+          Event customEvent =
+              Event.builder()
+                  .id(UUID.randomUUID().toString())
+                  .invocationId(invocationId)
+                  .author("agent")
+                  .content(
+                      Content.builder()
+                          .role("model")
+                          .parts(
+                              ImmutableList.of(
+                                  Part.builder().text("Custom strategy response").build()))
+                          .build())
+                  .build();
+          return Single.just(ImmutableList.of(customEvent));
+        };
+
+    Message request =
+        new Message.Builder()
+            .messageId("msg-1")
+            .contextId("ctx-1")
+            .role(Message.Role.USER)
+            .parts(List.of(new TextPart("Test")))
+            .build();
+
+    Message response = executor.execute(request, customStrategy).blockingGet();
+
+    assertThat(response).isNotNull();
+    assertThat(response.getParts()).isNotEmpty();
+    assertThat(((TextPart) response.getParts().get(0)).getText())
+        .contains("Custom strategy response");
+  }
+
+  private A2ASendMessageExecutor createExecutorWithAgent() {
+    BaseAgent agent = createSimpleAgent();
+    sessionService = new InMemorySessionService();
+    return new A2ASendMessageExecutor(
+        agent,
+        "test-app",
+        Duration.ofSeconds(30),
+        sessionService,
+        new InMemoryArtifactService(),
+        new InMemoryMemoryService());
+  }
+
+  @Test
+  public void execute_withNullMessage_generatesDefaultContext() {
+    A2ASendMessageExecutor executor = createExecutorWithAgent();
+
+    Message response = executor.execute(null).blockingGet();
+
+    assertThat(response).isNotNull();
+    assertThat(response.getContextId()).isNotNull();
+    assertThat(response.getContextId()).isNotEmpty();
+  }
+
+  @Test
+  public void execute_withEmptyContextId_generatesNewContext() {
+    A2ASendMessageExecutor executor = createExecutorWithAgent();
+
+    Message request =
+        new Message.Builder()
+            .messageId("msg-1")
+            .role(Message.Role.USER)
+            .parts(List.of(new TextPart("Test")))
+            .build();
+
+    Message response = executor.execute(request).blockingGet();
+
+    assertThat(response).isNotNull();
+    assertThat(response.getContextId()).isNotNull();
+    assertThat(response.getContextId()).isNotEmpty();
+  }
+
+  @Test
+  public void execute_withProvidedContextId_preservesContext() {
+    A2ASendMessageExecutor executor = createExecutorWithAgent();
+
+    String contextId = "my-custom-context";
+    Message request =
+        new Message.Builder()
+            .messageId("msg-1")
+            .contextId(contextId)
+            .role(Message.Role.USER)
+            .parts(List.of(new TextPart("Test")))
+            .build();
+
+    Message response = executor.execute(request).blockingGet();
+
+    assertThat(response).isNotNull();
+    assertThat(response.getContextId()).isEqualTo(contextId);
+  }
+
+  @Test
+  public void execute_multipleRequests_maintainsSession() {
+    A2ASendMessageExecutor executor = createExecutorWithAgent();
+
+    String contextId = "persistent-context";
+
+    Message request1 =
+        new Message.Builder()
+            .messageId("msg-1")
+            .contextId(contextId)
+            .role(Message.Role.USER)
+            .parts(List.of(new TextPart("First message")))
+            .build();
+
+    Message response1 = executor.execute(request1).blockingGet();
+    assertThat(response1.getContextId()).isEqualTo(contextId);
+
+    Message request2 =
+        new Message.Builder()
+            .messageId("msg-2")
+            .contextId(contextId)
+            .role(Message.Role.USER)
+            .parts(List.of(new TextPart("Second message")))
+            .build();
+
+    Message response2 = executor.execute(request2).blockingGet();
+    assertThat(response2.getContextId()).isEqualTo(contextId);
+  }
+
+  @Test
+  public void execute_withoutRunnerConfig_throwsException() {
+    InMemorySessionService sessionService = new InMemorySessionService();
+
+    A2ASendMessageExecutor executor = new A2ASendMessageExecutor(sessionService, "test-app");
+
+    Message request =
+        new Message.Builder()
+            .messageId("msg-1")
+            .contextId("ctx-1")
+            .role(Message.Role.USER)
+            .parts(List.of(new TextPart("Test")))
+            .build();
+
+    try {
+      executor.execute(request).blockingGet();
+      assertThat(false).isTrue();
+    } catch (IllegalStateException e) {
+      assertThat(e.getMessage()).contains("Runner-based handle invoked without configured runner");
+    }
+  }
+
+  @Test
+  public void execute_errorInStrategy_returnsErrorResponse() {
+    InMemorySessionService sessionService = new InMemorySessionService();
+
+    A2ASendMessageExecutor executor = new A2ASendMessageExecutor(sessionService, "test-app");
+
+    A2ASendMessageExecutor.AgentExecutionStrategy failingStrategy =
+        (userId, sessionId, userContent, runConfig, invocationId) -> {
+          return Single.error(new RuntimeException("Strategy failed"));
+        };
+
+    Message request =
+        new Message.Builder()
+            .messageId("msg-1")
+            .contextId("ctx-1")
+            .role(Message.Role.USER)
+            .parts(List.of(new TextPart("Test")))
+            .build();
+
+    Message response = executor.execute(request, failingStrategy).blockingGet();
+
+    assertThat(response).isNotNull();
+    assertThat(response.getParts()).isNotEmpty();
+    assertThat(((TextPart) response.getParts().get(0)).getText()).contains("Error:");
+    assertThat(((TextPart) response.getParts().get(0)).getText()).contains("Strategy failed");
+  }
+
+  private BaseAgent createSimpleAgent() {
+    return new BaseAgent("test", "test agent", ImmutableList.of(), null, null) {
+      @Override
+      protected Flowable<Event> runAsyncImpl(InvocationContext ctx) {
+        return Flowable.just(
+            Event.builder()
+                .content(
+                    Content.builder()
+                        .role("model")
+                        .parts(
+                            ImmutableList.of(
+                                com.google.genai.types.Part.builder().text("Response").build()))
+                        .build())
+                .build());
+      }
+
+      @Override
+      protected Flowable<Event> runLiveImpl(InvocationContext ctx) {
+        return Flowable.empty();
+      }
+    };
+  }
+}

--- a/a2a/src/test/java/com/google/adk/a2a/A2ASendMessageExecutorIntegrationTest.java
+++ b/a2a/src/test/java/com/google/adk/a2a/A2ASendMessageExecutorIntegrationTest.java
@@ -1,0 +1,103 @@
+package com.google.adk.a2a;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.adk.agents.BaseAgent;
+import com.google.adk.agents.InvocationContext;
+import com.google.adk.artifacts.InMemoryArtifactService;
+import com.google.adk.events.Event;
+import com.google.adk.memory.InMemoryMemoryService;
+import com.google.adk.sessions.InMemorySessionService;
+import com.google.common.collect.ImmutableList;
+import com.google.genai.types.Content;
+import io.a2a.spec.Message;
+import io.a2a.spec.TextPart;
+import io.reactivex.rxjava3.core.Flowable;
+import java.time.Duration;
+import java.util.List;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class A2ASendMessageExecutorIntegrationTest {
+
+  @Test
+  public void execute_withInMemoryServices_succeeds() {
+    InMemorySessionService sessionService = new InMemorySessionService();
+    BaseAgent agent = createSimpleAgent();
+
+    A2ASendMessageExecutor executor =
+        new A2ASendMessageExecutor(
+            agent,
+            "test-app",
+            Duration.ofSeconds(30),
+            sessionService,
+            new InMemoryArtifactService(),
+            new InMemoryMemoryService());
+
+    Message request =
+        new Message.Builder()
+            .messageId("msg-1")
+            .contextId("ctx-1")
+            .role(Message.Role.USER)
+            .parts(List.of(new TextPart("Hello")))
+            .build();
+
+    Message response = executor.execute(request).blockingGet();
+
+    assertThat(response).isNotNull();
+    assertThat(response.getContextId()).isEqualTo("ctx-1");
+  }
+
+  @Test
+  public void execute_createsSessionAndProcessesRequest() {
+    InMemorySessionService sessionService = new InMemorySessionService();
+    BaseAgent agent = createSimpleAgent();
+
+    A2ASendMessageExecutor executor =
+        new A2ASendMessageExecutor(
+            agent,
+            "test-app",
+            Duration.ofSeconds(30),
+            sessionService,
+            new InMemoryArtifactService(),
+            new InMemoryMemoryService());
+
+    Message request =
+        new Message.Builder()
+            .messageId("msg-1")
+            .contextId("ctx-1")
+            .role(Message.Role.USER)
+            .parts(List.of(new TextPart("Test message")))
+            .build();
+
+    Message response = executor.execute(request).blockingGet();
+
+    assertThat(response).isNotNull();
+    assertThat(response.getParts()).isNotEmpty();
+  }
+
+  private BaseAgent createSimpleAgent() {
+    return new BaseAgent("test", "test agent", ImmutableList.of(), null, null) {
+      @Override
+      protected Flowable<Event> runAsyncImpl(InvocationContext ctx) {
+        return Flowable.just(
+            Event.builder()
+                .content(
+                    Content.builder()
+                        .role("model")
+                        .parts(
+                            ImmutableList.of(
+                                com.google.genai.types.Part.builder().text("Response").build()))
+                        .build())
+                .build());
+      }
+
+      @Override
+      protected Flowable<Event> runLiveImpl(InvocationContext ctx) {
+        return Flowable.empty();
+      }
+    };
+  }
+}

--- a/a2a/src/test/java/com/google/adk/a2a/A2ASendMessageExecutorTest.java
+++ b/a2a/src/test/java/com/google/adk/a2a/A2ASendMessageExecutorTest.java
@@ -1,0 +1,62 @@
+package com.google.adk.a2a;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.adk.agents.BaseAgent;
+import com.google.adk.agents.InvocationContext;
+import com.google.adk.artifacts.InMemoryArtifactService;
+import com.google.adk.events.Event;
+import com.google.adk.memory.InMemoryMemoryService;
+import com.google.adk.sessions.InMemorySessionService;
+import com.google.common.collect.ImmutableList;
+import io.reactivex.rxjava3.core.Flowable;
+import java.time.Duration;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class A2ASendMessageExecutorTest {
+
+  @Test
+  public void constructor_simple_acceptsSessionService() {
+    InMemorySessionService sessionService = new InMemorySessionService();
+
+    A2ASendMessageExecutor executor = new A2ASendMessageExecutor(sessionService, "test-app");
+
+    assertThat(executor).isNotNull();
+  }
+
+  @Test
+  public void constructor_withAgent_acceptsAllServices() {
+    BaseAgent agent = createSimpleAgent();
+    InMemorySessionService sessionService = new InMemorySessionService();
+    InMemoryArtifactService artifactService = new InMemoryArtifactService();
+    InMemoryMemoryService memoryService = new InMemoryMemoryService();
+
+    A2ASendMessageExecutor executor =
+        new A2ASendMessageExecutor(
+            agent,
+            "test-app",
+            Duration.ofSeconds(30),
+            sessionService,
+            artifactService,
+            memoryService);
+
+    assertThat(executor).isNotNull();
+  }
+
+  private BaseAgent createSimpleAgent() {
+    return new BaseAgent("test", "test agent", ImmutableList.of(), null, null) {
+      @Override
+      protected Flowable<Event> runAsyncImpl(InvocationContext ctx) {
+        return Flowable.empty();
+      }
+
+      @Override
+      protected Flowable<Event> runLiveImpl(InvocationContext ctx) {
+        return Flowable.empty();
+      }
+    };
+  }
+}

--- a/a2a/webservice/pom.xml
+++ b/a2a/webservice/pom.xml
@@ -35,6 +35,17 @@
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.13.2</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>
@@ -46,6 +57,18 @@
         <configuration>
           <release>${java.version}</release>
         </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>3.5.2</version>
+        <dependencies>
+          <dependency>
+            <groupId>org.apache.maven.surefire</groupId>
+            <artifactId>surefire-junit47</artifactId>
+            <version>3.5.2</version>
+          </dependency>
+        </dependencies>
       </plugin>
       <plugin>
         <groupId>org.springframework.boot</groupId>

--- a/a2a/webservice/src/test/java/com/google/adk/webservice/A2ARemoteConfigurationCustomServicesTest.java
+++ b/a2a/webservice/src/test/java/com/google/adk/webservice/A2ARemoteConfigurationCustomServicesTest.java
@@ -1,0 +1,65 @@
+package com.google.adk.webservice;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
+
+import com.google.adk.a2a.A2ASendMessageExecutor;
+import com.google.adk.artifacts.BaseArtifactService;
+import com.google.adk.artifacts.InMemoryArtifactService;
+import com.google.adk.memory.BaseMemoryService;
+import com.google.adk.memory.InMemoryMemoryService;
+import com.google.adk.sessions.BaseSessionService;
+import com.google.adk.sessions.InMemorySessionService;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringRunner;
+
+@RunWith(SpringRunner.class)
+@ContextConfiguration(
+    classes = {
+      A2ARemoteConfiguration.class,
+      TestAgentConfig.class,
+      A2ARemoteConfigurationCustomServicesTest.WithCustomServicesTestConfig.class
+    })
+public class A2ARemoteConfigurationCustomServicesTest {
+
+  @TestConfiguration
+  static class WithCustomServicesTestConfig {
+    private static final BaseSessionService CUSTOM_SESSION_SERVICE = new InMemorySessionService();
+    private static final BaseArtifactService CUSTOM_ARTIFACT_SERVICE =
+        new InMemoryArtifactService();
+    private static final BaseMemoryService CUSTOM_MEMORY_SERVICE = new InMemoryMemoryService();
+
+    @Bean
+    public BaseSessionService customSessionService() {
+      return CUSTOM_SESSION_SERVICE;
+    }
+
+    @Bean
+    public BaseArtifactService customArtifactService() {
+      return CUSTOM_ARTIFACT_SERVICE;
+    }
+
+    @Bean
+    public BaseMemoryService customMemoryService() {
+      return CUSTOM_MEMORY_SERVICE;
+    }
+  }
+
+  @Autowired private A2ASendMessageExecutor executor;
+  @Autowired private BaseSessionService sessionService;
+  @Autowired private BaseArtifactService artifactService;
+  @Autowired private BaseMemoryService memoryService;
+
+  @Test
+  public void beanCreation_withCustomServices_autowires() {
+    assertNotNull(executor);
+    assertSame(WithCustomServicesTestConfig.CUSTOM_SESSION_SERVICE, sessionService);
+    assertSame(WithCustomServicesTestConfig.CUSTOM_ARTIFACT_SERVICE, artifactService);
+    assertSame(WithCustomServicesTestConfig.CUSTOM_MEMORY_SERVICE, memoryService);
+  }
+}

--- a/a2a/webservice/src/test/java/com/google/adk/webservice/A2ARemoteConfigurationTest.java
+++ b/a2a/webservice/src/test/java/com/google/adk/webservice/A2ARemoteConfigurationTest.java
@@ -1,0 +1,35 @@
+package com.google.adk.webservice;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import com.google.adk.a2a.A2ASendMessageExecutor;
+import com.google.adk.artifacts.BaseArtifactService;
+import com.google.adk.artifacts.InMemoryArtifactService;
+import com.google.adk.memory.BaseMemoryService;
+import com.google.adk.memory.InMemoryMemoryService;
+import com.google.adk.sessions.BaseSessionService;
+import com.google.adk.sessions.InMemorySessionService;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringRunner;
+
+@RunWith(SpringRunner.class)
+@ContextConfiguration(classes = {A2ARemoteConfiguration.class, TestAgentConfig.class})
+public class A2ARemoteConfigurationTest {
+
+  @Autowired private A2ASendMessageExecutor executor;
+  @Autowired private BaseSessionService sessionService;
+  @Autowired private BaseArtifactService artifactService;
+  @Autowired private BaseMemoryService memoryService;
+
+  @Test
+  public void beanCreation_withoutCustomServices_usesDefaults() {
+    assertNotNull(executor);
+    assertTrue(sessionService instanceof InMemorySessionService);
+    assertTrue(artifactService instanceof InMemoryArtifactService);
+    assertTrue(memoryService instanceof InMemoryMemoryService);
+  }
+}

--- a/a2a/webservice/src/test/java/com/google/adk/webservice/TestAgentConfig.java
+++ b/a2a/webservice/src/test/java/com/google/adk/webservice/TestAgentConfig.java
@@ -1,0 +1,27 @@
+package com.google.adk.webservice;
+
+import com.google.adk.agents.BaseAgent;
+import com.google.adk.agents.InvocationContext;
+import com.google.adk.events.Event;
+import com.google.common.collect.ImmutableList;
+import io.reactivex.rxjava3.core.Flowable;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+
+@TestConfiguration
+public class TestAgentConfig {
+  @Bean
+  public BaseAgent testAgent() {
+    return new BaseAgent("test", "test agent", ImmutableList.of(), null, null) {
+      @Override
+      protected Flowable<Event> runAsyncImpl(InvocationContext ctx) {
+        return Flowable.empty();
+      }
+
+      @Override
+      protected Flowable<Event> runLiveImpl(InvocationContext ctx) {
+        return Flowable.empty();
+      }
+    };
+  }
+}


### PR DESCRIPTION
Fixes #677

This PR updates A2ASendMessageExecutor and A2ARemoteConfiguration to support dependency injection for session, artifact, and memory services.
This enables consumers to plug in persistent service implementations instead of relying on hard-coded in-memory defaults.

**Key changes**

Updated A2ASendMessageExecutor to accept BaseSessionService, BaseArtifactService, and BaseMemoryService via constructor injection

Updated A2ARemoteConfiguration to autowire service beans, with fallback to in-memory implementations when custom beans are not provided

Added unit and integration tests covering service injection scenarios and Spring configuration behavior

**Testing**

Unit tests for A2ASendMessageExecutor
Integration tests validating injected service behavior
Spring configuration tests for custom service wiring


## Tasks
- [x] Update A2ASendMessageExecutor to accept injected services 
- [x] Modify A2ARemoteConfiguration to autowire service beans 
- [x] Add unit tests for A2ASendMessageExecutor
- [x] Add integration tests for service injection
- [x] Add Spring configuration tests for custom services
- [x] Address code review feedback