### PR TITLE
fix: add media/image support in Spring AI MessageConverter

### DIFF
--- a/contrib/spring-ai/src/main/java/com/google/adk/models/springai/MessageConverter.java
+++ b/contrib/spring-ai/src/main/java/com/google/adk/models/springai/MessageConverter.java
@@ -221,8 +221,7 @@ public class MessageConverter {
           } catch (Exception e) {
             // Log warning but continue processing other parts
             // In production, consider proper logging framework
-            System.err.println(
-                "Warning: Failed to parse media mime type: " + blob.mimeType().get());
+            System.err.println("Warning: Failed to process media part: " + e.getMessage());
           }
         }
       } else if (part.fileData().isPresent()) {
@@ -235,19 +234,14 @@ public class MessageConverter {
             URI uri = URI.create(fileData.fileUri().get());
             mediaList.add(new Media(mimeType, uri));
           } catch (Exception e) {
-            System.err.println(
-                "Warning: Failed to parse media mime type: " + fileData.mimeType().get());
+            System.err.println("Warning: Failed to process media part: " + e.getMessage());
           }
         }
       }
     }
 
     List<Message> messages = new ArrayList<>();
-    // Create UserMessage with text
-    // TODO: Media attachments support - UserMessage constructors with media are private in Spring
-    // AI 1.1.0
-    // For now, only text content is supported
-    messages.add(new UserMessage(textBuilder.toString()));
+    messages.add(UserMessage.builder().text(textBuilder.toString()).media(mediaList).build());
     messages.addAll(toolResponseMessages);
 
     return messages;

--- a/contrib/spring-ai/src/test/java/com/google/adk/models/springai/MessageConverterTest.java
+++ b/contrib/spring-ai/src/test/java/com/google/adk/models/springai/MessageConverterTest.java
@@ -60,7 +60,9 @@ class MessageConverterTest {
     assertThat(prompt.getInstructions()).hasSize(1);
     Message message = prompt.getInstructions().get(0);
     assertThat(message).isInstanceOf(UserMessage.class);
-    assertThat(((UserMessage) message).getText()).isEqualTo("Hello, how are you?");
+    UserMessage userMessage = (UserMessage) message;
+    assertThat(userMessage.getText()).isEqualTo("Hello, how are you?");
+    assertThat(userMessage.getMedia()).isEmpty();
   }
 
   @Test
@@ -443,5 +445,182 @@ class MessageConverterTest {
     Message secondMessage = prompt.getInstructions().get(1);
     assertThat(secondMessage).isInstanceOf(UserMessage.class);
     assertThat(((UserMessage) secondMessage).getText()).isEqualTo("Hello world");
+  }
+
+  @Test
+  void testUserMessageWithInlineMediaData() {
+    // Test conversion of ADK Content with inline media (image bytes) to Spring AI UserMessage
+    byte[] imageData = "fake-image-data".getBytes();
+    String mimeType = "image/png";
+
+    Content userContent =
+        Content.builder()
+            .role("user")
+            .parts(
+                List.of(
+                    Part.fromText("What's in this image?"),
+                    Part.builder()
+                        .inlineData(
+                            com.google.genai.types.Blob.builder()
+                                .mimeType(mimeType)
+                                .data(imageData)
+                                .build())
+                        .build()))
+            .build();
+
+    LlmRequest request = LlmRequest.builder().contents(List.of(userContent)).build();
+
+    Prompt prompt = messageConverter.toLlmPrompt(request);
+
+    assertThat(prompt.getInstructions()).hasSize(1);
+    Message message = prompt.getInstructions().get(0);
+    assertThat(message).isInstanceOf(UserMessage.class);
+
+    UserMessage userMessage = (UserMessage) message;
+    assertThat(userMessage.getText()).isEqualTo("What's in this image?");
+    assertThat(userMessage.getMedia()).hasSize(1);
+    org.springframework.ai.content.Media media = userMessage.getMedia().get(0);
+    assertThat(media.getMimeType().toString()).isEqualTo(mimeType);
+    assertThat(media.getData()).isInstanceOf(byte[].class);
+    byte[] actualData = (byte[]) media.getData();
+    assertThat(actualData).isEqualTo(imageData);
+  }
+
+  @Test
+  void testUserMessageWithFileMediaData() {
+    // Test conversion of ADK Content with file-based media (URI) to Spring AI UserMessage
+    String fileUri = "gs://bucket/image.jpg";
+    String mimeType = "image/jpeg";
+
+    Content userContent =
+        Content.builder()
+            .role("user")
+            .parts(
+                List.of(
+                    Part.fromText("Analyze this image"),
+                    Part.builder()
+                        .fileData(
+                            com.google.genai.types.FileData.builder()
+                                .mimeType(mimeType)
+                                .fileUri(fileUri)
+                                .build())
+                        .build()))
+            .build();
+
+    LlmRequest request = LlmRequest.builder().contents(List.of(userContent)).build();
+
+    Prompt prompt = messageConverter.toLlmPrompt(request);
+
+    assertThat(prompt.getInstructions()).hasSize(1);
+    Message message = prompt.getInstructions().get(0);
+    assertThat(message).isInstanceOf(UserMessage.class);
+
+    UserMessage userMessage = (UserMessage) message;
+    assertThat(userMessage.getText()).isEqualTo("Analyze this image");
+    assertThat(userMessage.getMedia()).hasSize(1);
+    org.springframework.ai.content.Media media = userMessage.getMedia().get(0);
+    assertThat(media.getMimeType().toString()).isEqualTo(mimeType);
+    assertThat(media.getData()).isInstanceOf(String.class);
+    String actualUri = (String) media.getData();
+    assertThat(actualUri).isEqualTo(fileUri);
+  }
+
+  @Test
+  void testUserMessageWithMultipleMediaAttachments() {
+    // Test conversion with multiple media attachments
+    byte[] image1 = "image1-data".getBytes();
+    byte[] image2 = "image2-data".getBytes();
+
+    Content userContent =
+        Content.builder()
+            .role("user")
+            .parts(
+                List.of(
+                    Part.fromText("Compare these images"),
+                    Part.builder()
+                        .inlineData(
+                            com.google.genai.types.Blob.builder()
+                                .mimeType("image/png")
+                                .data(image1)
+                                .build())
+                        .build(),
+                    Part.builder()
+                        .inlineData(
+                            com.google.genai.types.Blob.builder()
+                                .mimeType("image/jpeg")
+                                .data(image2)
+                                .build())
+                        .build()))
+            .build();
+
+    LlmRequest request = LlmRequest.builder().contents(List.of(userContent)).build();
+
+    Prompt prompt = messageConverter.toLlmPrompt(request);
+
+    assertThat(prompt.getInstructions()).hasSize(1);
+    UserMessage userMessage = (UserMessage) prompt.getInstructions().get(0);
+    assertThat(userMessage.getText()).isEqualTo("Compare these images");
+    assertThat(userMessage.getMedia()).hasSize(2);
+  }
+
+  @Test
+  void testUserMessageWithInvalidMimeTypeGracefullySkipsMediaPart() {
+    // Test that an invalid MIME type string causes the media part to be skipped gracefully
+    byte[] imageData = "fake-image-data".getBytes();
+
+    Content userContent =
+        Content.builder()
+            .role("user")
+            .parts(
+                List.of(
+                    Part.fromText("What's in this image?"),
+                    Part.builder()
+                        .inlineData(
+                            com.google.genai.types.Blob.builder()
+                                .mimeType("invalid/mime/type!!!") // invalid MIME type
+                                .data(imageData)
+                                .build())
+                        .build()))
+            .build();
+
+    LlmRequest request = LlmRequest.builder().contents(List.of(userContent)).build();
+
+    // Should not throw — invalid MIME type is silently skipped
+    Prompt prompt = messageConverter.toLlmPrompt(request);
+
+    assertThat(prompt.getInstructions()).hasSize(1);
+    UserMessage userMessage = (UserMessage) prompt.getInstructions().get(0);
+    assertThat(userMessage.getText()).isEqualTo("What's in this image?");
+    // Media part is skipped due to invalid MIME type
+    assertThat(userMessage.getMedia()).isEmpty();
+  }
+
+  @Test
+  void testUserMessageWithMediaOnly() {
+    // Test conversion with media but no text
+    byte[] imageData = "image-only".getBytes();
+
+    Content userContent =
+        Content.builder()
+            .role("user")
+            .parts(
+                List.of(
+                    Part.builder()
+                        .inlineData(
+                            com.google.genai.types.Blob.builder()
+                                .mimeType("image/png")
+                                .data(imageData)
+                                .build())
+                        .build()))
+            .build();
+
+    LlmRequest request = LlmRequest.builder().contents(List.of(userContent)).build();
+
+    Prompt prompt = messageConverter.toLlmPrompt(request);
+
+    assertThat(prompt.getInstructions()).hasSize(1);
+    UserMessage userMessage = (UserMessage) prompt.getInstructions().get(0);
+    assertThat(userMessage.getText()).isEmpty();
+    assertThat(userMessage.getMedia()).hasSize(1);
   }
 }


### PR DESCRIPTION
Previously, MessageConverter only transferred text content from ADK to Spring AI, ignoring image and media attachments. This caused vision model requests to fail even though Spring AI's underlying models (like GPT-4o) support image inputs.

Updated MessageConverter to properly handle image/media parts by constructing UserMessage with Media attachments.

Fixes #705