### PR TITLE
Remove ADK dependency for langchain4j module

### DIFF
--- a/contrib/langchain4j/pom.xml
+++ b/contrib/langchain4j/pom.xml
@@ -59,11 +59,6 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.google.adk</groupId>
-            <artifactId>google-adk-dev</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
             <groupId>com.google.genai</groupId>
             <artifactId>google-genai</artifactId>
         </dependency>


### PR DESCRIPTION
The langchain4j module in the "contrib" directory depends on adk-dev, although it doesn't seem to need anything in that module. This, in turn, pulls in tons of stuff for applications that use it, including logback and Spring Boot, which I'd like to not have to include in my project. This PR just takes the dependency out.
