### PR TITLE
Fix null Event ID in adk_request_confirmation events

### DIFF
--- a/core/src/main/java/com/google/adk/flows/llmflows/Functions.java
+++ b/core/src/main/java/com/google/adk/flows/llmflows/Functions.java
@@ -682,6 +682,7 @@ public final class Functions {
 
     return Optional.of(
         Event.builder()
+            .id(Event.generateEventId())
             .invocationId(invocationContext.invocationId())
             .author(invocationContext.agent().name())
             .branch(invocationContext.branch().orElse(null))

--- a/core/src/test/java/com/google/adk/flows/llmflows/FunctionsTest.java
+++ b/core/src/test/java/com/google/adk/flows/llmflows/FunctionsTest.java
@@ -26,6 +26,8 @@ import com.google.adk.agents.InvocationContext;
 import com.google.adk.agents.RunConfig;
 import com.google.adk.agents.RunConfig.ToolExecutionMode;
 import com.google.adk.events.Event;
+import com.google.adk.events.EventActions;
+import com.google.adk.events.ToolConfirmation;
 import com.google.adk.testing.TestUtils;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -33,6 +35,8 @@ import com.google.genai.types.Content;
 import com.google.genai.types.FunctionCall;
 import com.google.genai.types.FunctionResponse;
 import com.google.genai.types.Part;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -388,5 +392,53 @@ public final class FunctionsTest {
             .build();
     ImmutableList<FunctionCall> result = Functions.getAskUserConfirmationFunctionCalls(event);
     assertThat(result).containsExactly(confirmationCall1, confirmationCall2);
+  }
+
+  @Test
+  public void generateRequestConfirmationEvent_generatesNonNullEventId() {
+    InvocationContext invocationContext = createInvocationContext(createRootAgent());
+    String functionCallId = "function_call_123";
+
+    // Create a function call event with a function call that has an ID
+    Event functionCallEvent =
+        Event.builder()
+            .id("event1")
+            .invocationId(invocationContext.invocationId())
+            .author(invocationContext.agent().name())
+            .content(
+                Content.fromParts(
+                    Part.builder()
+                        .functionCall(
+                            FunctionCall.builder()
+                                .id(functionCallId)
+                                .name("some_tool")
+                                .args(ImmutableMap.of())
+                                .build())
+                        .build()))
+            .build();
+
+    // Create a function response event with requestedToolConfirmations
+    ConcurrentHashMap<String, ToolConfirmation> toolConfirmations = new ConcurrentHashMap<>();
+    toolConfirmations.put(functionCallId, ToolConfirmation.builder().build());
+
+    EventActions actionsWithConfirmation =
+        EventActions.builder().requestedToolConfirmations(toolConfirmations).build();
+
+    Event functionResponseEvent =
+        Event.builder()
+            .id("event2")
+            .invocationId(invocationContext.invocationId())
+            .author(invocationContext.agent().name())
+            .content(Content.fromParts(Part.fromText("response")))
+            .actions(actionsWithConfirmation)
+            .build();
+
+    Optional<Event> result =
+        Functions.generateRequestConfirmationEvent(
+            invocationContext, functionCallEvent, functionResponseEvent);
+
+    assertThat(result).isPresent();
+    assertThat(result.get().id()).isNotNull();
+    assertThat(result.get().id()).isNotEmpty();
   }
 }


### PR DESCRIPTION
Fixes #871

Events generated for tool confirmation requests (adk_request_confirmation) were being created with null IDs because the generateRequestConfirmationEvent() method was missing the .id(Event.generateEventId()) call in the Event builder.

This commit:
- Adds .id(Event.generateEventId()) to generateRequestConfirmationEvent() in Functions.java to ensure all confirmation request events have non-null UUIDs
- Adds regression test generateRequestConfirmationEvent_generatesNonNullEventId() to FunctionsTest.java to verify the fix