### PR TITLE
fix(firestore): Remove hardcoded dependency version

### DIFF
--- a/contrib/firestore-session-service/pom.xml
+++ b/contrib/firestore-session-service/pom.xml
@@ -14,7 +14,9 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
@@ -49,7 +51,6 @@
         <dependency>
             <groupId>com.google.cloud</groupId>
             <artifactId>google-cloud-firestore</artifactId>
-            <version>3.30.3</version>
         </dependency>
         <dependency>
             <groupId>com.google.truth</groupId>


### PR DESCRIPTION
The  `google-cloud-firestore` version will be derived from the parent BOM. 

Removes the explicit `3.30.3` tag from the `google-cloud-firestore` dependency in the session service. 

The version is now derived from the parent BOM (dependency management) to ensure compatibility.

Tested the build and test everything looked good.