### PR TITLE
dev: Increase DevContainer 2 to 4 CPUs, and rm extension

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -9,8 +9,7 @@
     "vscode": {
       "extensions": [
         "extension-pack-for-java",
-        "redhat.vscode-xml",
-        "rangav.vscode-thunder-client"
+        "redhat.vscode-xml"
       ],
       "settings": {
         "java.jdt.download.server": "latest",
@@ -24,5 +23,8 @@
   },
   "remoteUser": "vscode",
   "forwardPorts": [8000, 8080, 8081, 8082],
-  "postCreateCommand": "git config --global credential.helper '!gh auth git-credential' && git config --global lfs.locksverify false"
+  "postCreateCommand": "git config --global credential.helper '!gh auth git-credential' && git config --global lfs.locksverify false",
+  "hostRequirements": {
+    "cpus": 4
+  }
 }


### PR DESCRIPTION
GitHub default 2 CPU machines for Codespace are unbearably slow to work on with Maven Java projects, so bump to 4 CPUs requirement.

Also remove the  "rangav.vscode-thunder-client" VSC extension (https://www.thunderclient.com) which was originally automatically added, but is not required.