### PR TITLE
Extract timestamp as double for InMemorySessionService events

### DIFF
--- a/core/src/main/java/com/google/adk/sessions/InMemorySessionService.java
+++ b/core/src/main/java/com/google/adk/sessions/InMemorySessionService.java
@@ -154,17 +154,11 @@ public final class InMemorySessionService implements BaseSessionService {
     if (config.numRecentEvents().isEmpty() && config.afterTimestamp().isPresent()) {
       Instant threshold = config.afterTimestamp().get();
 
-      eventsInCopy.removeIf(
-          event -> getEventTimestampEpochSeconds(event) < threshold.getEpochSecond());
+      eventsInCopy.removeIf(event -> getInstantFromEvent(event).isBefore(threshold));
     }
 
     // Merge state into the potentially filtered copy and return
     return Maybe.just(mergeWithGlobalState(appName, userId, sessionCopy));
-  }
-
-  // Helper to get event timestamp as epoch seconds
-  private long getEventTimestampEpochSeconds(Event event) {
-    return event.timestamp() / 1000L;
   }
 
   @Override
@@ -294,10 +288,7 @@ public final class InMemorySessionService implements BaseSessionService {
   /** Converts an event's timestamp to an Instant. Adapt based on actual Event structure. */
   // TODO: have Event.timestamp() return Instant directly
   private Instant getInstantFromEvent(Event event) {
-    double epochSeconds = getEventTimestampEpochSeconds(event);
-    long seconds = (long) epochSeconds;
-    long nanos = (long) ((epochSeconds % 1.0) * 1_000_000_000L);
-    return Instant.ofEpochSecond(seconds, nanos);
+    return Instant.ofEpochMilli(event.timestamp());
   }
 
   /**

--- a/core/src/test/java/com/google/adk/sessions/InMemorySessionServiceTest.java
+++ b/core/src/test/java/com/google/adk/sessions/InMemorySessionServiceTest.java
@@ -20,6 +20,7 @@ import static com.google.common.truth.Truth.assertThat;
 import com.google.adk.events.Event;
 import com.google.adk.events.EventActions;
 import io.reactivex.rxjava3.core.Single;
+import java.time.Instant;
 import java.util.HashMap;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
@@ -212,6 +213,24 @@ public final class InMemorySessionServiceTest {
     assertThat(retrievedSessionRemove.state()).doesNotContainKey("_app_appKey");
     assertThat(retrievedSessionRemove.state()).doesNotContainKey("_user_userKey");
     assertThat(retrievedSessionRemove.state()).doesNotContainKey("temp:tempKey");
+  }
+
+  @Test
+  public void appendEvent_updatesSessionTimestampWithFractionalSeconds() {
+    InMemorySessionService sessionService = new InMemorySessionService();
+    Session session =
+        sessionService.createSession("app", "user", new HashMap<>(), "session1").blockingGet();
+
+    // Add an event with a timestamp that contains a fractional second
+    Event eventAdd = Event.builder().timestamp(5500).build();
+    var unused = sessionService.appendEvent(session, eventAdd).blockingGet();
+
+    // Verify the last modified timestamp contains a fractional second
+    Session retrievedSession =
+        sessionService
+            .getSession(session.appName(), session.userId(), session.id(), Optional.empty())
+            .blockingGet();
+    assertThat(retrievedSession.lastUpdateTime()).isEqualTo(Instant.ofEpochSecond(5, 500000000L));
   }
 
   @Test


### PR DESCRIPTION
InMemorySessionService sets a Session's last modified time based on the last appended event's timestamp. The timestamp in an event is recorded in millis while the Session's timestamp is an Instant. During the transformation, Events perform this converstion using division. Before this change, the timestamp was truncated to the second, yet the code was trying to extract nanos which were always 0. This fixes that bug with a simple type change. I've also added a test to prevent regressions.