### PR TITLE
refactor: Fixes #947 Update Spring Boot version , Spring AI version, organize imports

### DIFF
--- a/contrib/spring-ai/pom.xml
+++ b/contrib/spring-ai/pom.xml
@@ -29,7 +29,7 @@
     <description>Spring AI integration for the Agent Development Kit.</description>
 
     <properties>
-        <spring-ai.version>1.1.0</spring-ai.version>
+        <spring-ai.version>2.0.0-M2</spring-ai.version>
         <testcontainers.version>1.21.3</testcontainers.version>
     </properties>
 

--- a/dev/pom.xml
+++ b/dev/pom.xml
@@ -64,6 +64,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-webmvc-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>com.google.truth</groupId>
       <artifactId>truth</artifactId>
       <scope>test</scope>

--- a/dev/src/test/java/com/google/adk/web/AdkWebServerTest.java
+++ b/dev/src/test/java/com/google/adk/web/AdkWebServerTest.java
@@ -26,8 +26,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 

--- a/dev/src/test/java/com/google/adk/web/AdkWebServerUITest.java
+++ b/dev/src/test/java/com/google/adk/web/AdkWebServerUITest.java
@@ -24,8 +24,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.test.web.servlet.MockMvc;
 
 /**

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
     <maven.checkstyle.plugin.version>3.6.0</maven.checkstyle.plugin.version>
 
     <auto-value.version>1.11.1</auto-value.version>
-    <spring-boot.version>3.4.1</spring-boot.version>
+    <spring-boot.version>4.0.2</spring-boot.version>
     <!-- otel.version capped at 1.51.0 to avoid conflicts with google
          cloud libraries. Once they update their otel dependencies we
          can consider updating ours here as well -->
@@ -56,7 +56,7 @@
     <junit.version>5.11.4</junit.version>
     <mockito.version>5.20.0</mockito.version>
     <java-websocket.version>1.6.0</java-websocket.version>
-    <jackson.version>2.19.0</jackson.version>
+    <jackson.version>2.20.2</jackson.version>
     <okhttp.version>5.3.2</okhttp.version>
     <docker-java.version>3.7.0</docker-java.version>
     <graphviz.version>0.18.1</graphviz.version>
@@ -78,6 +78,13 @@
   <dependencyManagement>
     <dependencies>
       <!-- BOMs for dependency management -->
+      <dependency>
+        <groupId>com.fasterxml.jackson</groupId>
+        <artifactId>jackson-bom</artifactId>
+        <version>${jackson.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>libraries-bom</artifactId>
@@ -162,36 +169,36 @@
         <artifactId>error_prone_annotations</artifactId>
         <version>${errorprone.version}</version>
       </dependency>
-      <dependency>
-        <groupId>com.fasterxml.jackson.core</groupId>
-        <artifactId>jackson-core</artifactId>
-        <version>${jackson.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>com.fasterxml.jackson.core</groupId>
-        <artifactId>jackson-annotations</artifactId>
-        <version>${jackson.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>com.fasterxml.jackson.core</groupId>
-        <artifactId>jackson-databind</artifactId>
-        <version>${jackson.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>com.fasterxml.jackson.datatype</groupId>
-        <artifactId>jackson-datatype-jdk8</artifactId>
-        <version>${jackson.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>com.fasterxml.jackson.datatype</groupId>
-        <artifactId>jackson-datatype-jsr310</artifactId>
-        <version>${jackson.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>com.fasterxml.jackson.dataformat</groupId>
-        <artifactId>jackson-dataformat-yaml</artifactId>
-        <version>${jackson.version}</version>
-      </dependency>
+<!--      <dependency>-->
+<!--        <groupId>com.fasterxml.jackson.core</groupId>-->
+<!--        <artifactId>jackson-core</artifactId>-->
+<!--        <version>${jackson.version}</version>-->
+<!--      </dependency>-->
+<!--      <dependency>-->
+<!--        <groupId>com.fasterxml.jackson.core</groupId>-->
+<!--        <artifactId>jackson-annotations</artifactId>-->
+<!--        <version>${jackson.version}</version>-->
+<!--      </dependency>-->
+<!--      <dependency>-->
+<!--        <groupId>com.fasterxml.jackson.core</groupId>-->
+<!--        <artifactId>jackson-databind</artifactId>-->
+<!--        <version>${jackson.version}</version>-->
+<!--      </dependency>-->
+<!--      <dependency>-->
+<!--        <groupId>com.fasterxml.jackson.datatype</groupId>-->
+<!--        <artifactId>jackson-datatype-jdk8</artifactId>-->
+<!--        <version>${jackson.version}</version>-->
+<!--      </dependency>-->
+<!--      <dependency>-->
+<!--        <groupId>com.fasterxml.jackson.datatype</groupId>-->
+<!--        <artifactId>jackson-datatype-jsr310</artifactId>-->
+<!--        <version>${jackson.version}</version>-->
+<!--      </dependency>-->
+<!--      <dependency>-->
+<!--        <groupId>com.fasterxml.jackson.dataformat</groupId>-->
+<!--        <artifactId>jackson-dataformat-yaml</artifactId>-->
+<!--        <version>${jackson.version}</version>-->
+<!--      </dependency>-->
       <dependency>
         <groupId>com.google.protobuf</groupId>
         <artifactId>protobuf-java</artifactId>


### PR DESCRIPTION
Update Spring Boot version to 4.0.2, update Spring AI to 2.0.0-M2, organize corresponding imports.

Note: Jackson has a minor update from 2.19.0 to 2.20.0.
Spring Boot 4.x uses Jackson 3, however with switching to the jackson-bom the major version remains the same

Updated modules:
/dev
/contrib/spring-ai