### PR TITLE
chore: ensure A2A example instructions work

### DIFF
--- a/contrib/samples/a2a_server/pom.xml
+++ b/contrib/samples/a2a_server/pom.xml
@@ -23,12 +23,13 @@
     <a2a.sdk.version>0.3.0.Beta1</a2a.sdk.version>
     <quarkus.platform.version>3.30.6</quarkus.platform.version>
     <flogger.version>0.8</flogger.version>
+    <quarkus.native.builder-image>graalvm</quarkus.native.builder-image>
   </properties>
 
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>io.quarkus</groupId>
+                <groupId>io.quarkus.platform</groupId>
                 <artifactId>quarkus-bom</artifactId>
                 <version>${quarkus.platform.version}</version>
                 <type>pom</type>

--- a/contrib/samples/a2a_server/src/main/java/com/google/adk/samples/a2aagent/AgentExecutorProducer.java
+++ b/contrib/samples/a2a_server/src/main/java/com/google/adk/samples/a2aagent/AgentExecutorProducer.java
@@ -1,6 +1,7 @@
 package com.google.adk.samples.a2aagent;
 
 import com.google.adk.a2a.executor.AgentExecutorConfig;
+import com.google.adk.artifacts.InMemoryArtifactService;
 import com.google.adk.samples.a2aagent.agent.Agent;
 import com.google.adk.sessions.InMemorySessionService;
 import io.a2a.server.agentexecution.AgentExecutor;
@@ -18,10 +19,12 @@ public class AgentExecutorProducer {
   @Produces
   public AgentExecutor agentExecutor() {
     InMemorySessionService sessionService = new InMemorySessionService();
+    InMemoryArtifactService artifactService = new InMemoryArtifactService();
     return new com.google.adk.a2a.executor.AgentExecutor.Builder()
         .agent(Agent.ROOT_AGENT)
         .appName(appName)
         .sessionService(sessionService)
+        .artifactService(artifactService)
         .agentExecutorConfig(AgentExecutorConfig.builder().build())
         .build();
   }


### PR DESCRIPTION
add `InMemoryArtifactService` to `AgentExecutor` and update `pom.xml` dependencies

- Set `artifactService` in `AgentExecutorProducer` with `InMemoryArtifactService`
- Update `pom.xml` to specify `quarkus.native.builder-image` and fix groupId for `quarkus-bom`

