### PR TITLE
fix: Pre-merge stateDelta before onUserMessageCallback

### DIFF
--- a/core/src/main/java/com/google/adk/runner/Runner.java
+++ b/core/src/main/java/com/google/adk/runner/Runner.java
@@ -448,6 +448,12 @@ public class Runner {
               BaseAgent rootAgent = this.agent;
               String invocationId = InvocationContext.newInvocationContextId();
 
+              // Pre-merge stateDelta so onUserMessageCallback can access it.
+              // Safe: session is a copy; persistence still happens via appendNewMessageToSession.
+              if (stateDelta != null && !stateDelta.isEmpty()) {
+                stateDelta.forEach((key, value) -> session.state().put(key, value));
+              }
+
               // Create initial context
               InvocationContext initialContext =
                   newInvocationContextBuilder(session)

--- a/core/src/test/java/com/google/adk/runner/RunnerTest.java
+++ b/core/src/test/java/com/google/adk/runner/RunnerTest.java
@@ -878,6 +878,38 @@ public final class RunnerTest {
   }
 
   @Test
+  public void onUserMessageCallback_withStateDelta_seesMergedState() {
+    ArgumentCaptor<InvocationContext> contextCaptor =
+        ArgumentCaptor.forClass(InvocationContext.class);
+    when(plugin.onUserMessageCallback(contextCaptor.capture(), any())).thenReturn(Maybe.empty());
+
+    ImmutableMap<String, Object> stateDelta =
+        ImmutableMap.of("callback_key", "callback_value", "number", 123);
+
+    var unused =
+        runner
+            .runAsync(
+                "user",
+                session.id(),
+                createContent("test with state"),
+                RunConfig.builder().build(),
+                stateDelta)
+            .toList()
+            .blockingGet();
+
+    // Verify onUserMessageCallback was called
+    verify(plugin).onUserMessageCallback(any(), any());
+
+    // Verify the context passed to onUserMessageCallback has the merged state
+    InvocationContext capturedContext = contextCaptor.getValue();
+    Session sessionInCallback = capturedContext.session();
+
+    // Verify state delta was merged before onUserMessageCallback was invoked
+    assertThat(sessionInCallback.state()).containsEntry("callback_key", "callback_value");
+    assertThat(sessionInCallback.state()).containsEntry("number", 123);
+  }
+
+  @Test
   public void runAsync_ensureEventsAreAppendedInOrder() throws Exception {
     Event event1 = TestUtils.createEvent("1");
     Event event2 = TestUtils.createEvent("2");


### PR DESCRIPTION
## Summary
Fixes #1099

When `runner.runAsync(userId, sessionId, message, config, stateDelta)` is called, the `stateDelta` map was **not merged into the session before** `pluginManager.onUserMessageCallback` was executed. This caused plugins to see `null` when reading caller-provided state entries.

## Root Cause
In `Runner.runAsyncImpl`, the execution order was:
1. Create `initialContext` using the original session (no stateDelta)
2. Call `onUserMessageCallback(initialContext, message)` - plugins see **stale state**
3. Call `appendNewMessageToSession(...)` which writes stateDelta via EventActions
4. Fetch updated session and call `beforeRunCallback` - plugins see **correct state**

## Fix
Pre-merge stateDelta into the session's in-memory state **before** creating the initial context. This is safe because the session is already a copy from `getSession()`. Persistence still happens via EventActions in `appendNewMessageToSession`, making this an idempotent optimization.

---

## Workflow Comparison

### BEFORE (Bug)

```text
runAsync(userId, sessionId, message, stateDelta={transactionId: "TXN-0042"})
    |
    |-- getSession()
    |       returns session copy, state = {}
    |
    |-- initialContext = new Context(session)
    |       session.state() = {}   <-- empty
    |
    |-- onUserMessageCallback(initialContext)
    |       state.get("transactionId") = null   <-- BUG
    |
    |-- appendNewMessageToSession(..., stateDelta)
    |       writes stateDelta to session.state()
    |       persists to storage
    |
    |-- getSession()
    |       returns new copy, state = {transactionId: "TXN-0042"}
    |
    |-- beforeRunCallback(newContext)
            state.get("transactionId") = "TXN-0042"   <-- OK
```

### AFTER (Fixed)

```text
runAsync(userId, sessionId, message, stateDelta={transactionId: "TXN-0042"})
    |
    |-- getSession()
    |       returns session copy, state = {}
    |
    |-- PRE-MERGE stateDelta into session copy
    |       session.state() = {transactionId: "TXN-0042"}
    |
    |-- initialContext = new Context(session)
    |       session.state() = {transactionId: "TXN-0042"}   <-- contains stateDelta
    |
    |-- onUserMessageCallback(initialContext)
    |       state.get("transactionId") = "TXN-0042"   <-- FIXED
    |
    |-- appendNewMessageToSession(..., stateDelta)
    |       idempotent write (same values)
    |       persists to storage
    |
    |-- getSession()
    |       returns new copy, state = {transactionId: "TXN-0042"}
    |
    |-- beforeRunCallback(newContext)
            state.get("transactionId") = "TXN-0042"   <-- unchanged
```

## Changes
- **Runner.java**: Pre-merge stateDelta before creating initialContext (2-line comment + 3-line code)
- **RunnerTest.java**: Added `onUserMessageCallback_withStateDelta_seesMergedState` test

## Testing
All 56 RunnerTest tests pass, including the new test and existing `beforeRunCallback_withStateDelta_seesMergedState`.
