### PR TITLE
LangChain4j - Make modelName optional if providing ChatModel or StreamingChatModel

### DIFF
--- a/contrib/langchain4j/src/main/java/com/google/adk/models/langchain4j/LangChain4j.java
+++ b/contrib/langchain4j/src/main/java/com/google/adk/models/langchain4j/LangChain4j.java
@@ -75,6 +75,7 @@ import java.util.Base64;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.UUID;
 import org.jspecify.annotations.Nullable;
 
@@ -96,6 +97,7 @@ public abstract class LangChain4j extends BaseLlm {
 
   public abstract ObjectMapper objectMapper();
 
+  @Nullable
   public abstract String modelName();
 
   @Nullable
@@ -122,7 +124,32 @@ public abstract class LangChain4j extends BaseLlm {
 
     public abstract Builder modelName(String modelName);
 
-    public abstract LangChain4j build();
+    abstract @Nullable ChatModel chatModel();
+
+    abstract @Nullable StreamingChatModel streamingChatModel();
+
+    abstract @Nullable String modelName();
+
+    abstract LangChain4j autoBuild();
+
+    public LangChain4j build() {
+      if (Objects.isNull(modelName())) {
+        // Try to extract modelName from chatModel or streamingChatModel
+        if (!Objects.isNull(chatModel())
+            && !Objects.isNull(chatModel().defaultRequestParameters())) {
+          modelName(chatModel().defaultRequestParameters().modelName());
+        } else if (!Objects.isNull(streamingChatModel())
+            && !Objects.isNull(streamingChatModel().defaultRequestParameters())) {
+          modelName(streamingChatModel().defaultRequestParameters().modelName());
+        }
+      }
+      // Up to this step, if modelName still null - Fail fast
+      if (modelName() == null) {
+        throw new IllegalStateException(
+            "modelName is required. Either set it explicitly via modelName() or provide a ChatModel/StreamingChatModel");
+      }
+      return autoBuild();
+    }
   }
 
   public LangChain4j(ChatModel chatModel) {

--- a/contrib/langchain4j/src/main/java/com/google/adk/models/langchain4j/LangChain4j.java
+++ b/contrib/langchain4j/src/main/java/com/google/adk/models/langchain4j/LangChain4j.java
@@ -76,6 +76,7 @@ import java.util.Base64;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.UUID;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
@@ -100,6 +101,7 @@ public abstract class LangChain4j extends BaseLlm {
 
   public abstract ObjectMapper objectMapper();
 
+  @Nullable
   public abstract String modelName();
 
   @Nullable
@@ -126,7 +128,32 @@ public abstract class LangChain4j extends BaseLlm {
 
     public abstract Builder modelName(String modelName);
 
-    public abstract LangChain4j build();
+    abstract @Nullable ChatModel chatModel();
+
+    abstract @Nullable StreamingChatModel streamingChatModel();
+
+    abstract @Nullable String modelName();
+
+    abstract LangChain4j autoBuild();
+
+    public LangChain4j build() {
+      if (Objects.isNull(modelName())) {
+        // Try to extract modelName from chatModel or streamingChatModel
+        if (!Objects.isNull(chatModel())
+            && !Objects.isNull(chatModel().defaultRequestParameters())) {
+          modelName(chatModel().defaultRequestParameters().modelName());
+        } else if (!Objects.isNull(streamingChatModel())
+            && !Objects.isNull(streamingChatModel().defaultRequestParameters())) {
+          modelName(streamingChatModel().defaultRequestParameters().modelName());
+        }
+      }
+      // Up to this step, if modelName still null - Fail fast
+      if (modelName() == null) {
+        throw new IllegalStateException(
+            "modelName is required. Either set it explicitly via modelName() or provide a ChatModel/StreamingChatModel");
+      }
+      return autoBuild();
+    }
   }
 
   public LangChain4j(ChatModel chatModel) {

--- a/contrib/langchain4j/src/test/java/com/google/adk/models/langchain4j/LangChain4jTest.java
+++ b/contrib/langchain4j/src/test/java/com/google/adk/models/langchain4j/LangChain4jTest.java
@@ -31,6 +31,7 @@ import dev.langchain4j.model.TokenCountEstimator;
 import dev.langchain4j.model.chat.ChatModel;
 import dev.langchain4j.model.chat.StreamingChatModel;
 import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.request.ChatRequestParameters;
 import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
 import dev.langchain4j.model.chat.request.json.JsonStringSchema;
 import dev.langchain4j.model.chat.response.ChatResponse;
@@ -992,5 +993,53 @@ class LangChain4jTest {
     assertThat(response).isNotNull();
     assertThat(response.content()).isPresent();
     assertThat(response.content().get().parts().orElse(List.of())).isEmpty();
+  }
+
+  @Test
+  @DisplayName("Should auto-detect model name from ChatModel when not explicitly set")
+  void testBuilderAutoDetectsModelNameFromChatModel() {
+    // Given
+    final ChatRequestParameters params = mock(ChatRequestParameters.class);
+    when(params.modelName()).thenReturn("auto-detected-model");
+    when(chatModel.defaultRequestParameters()).thenReturn(params);
+
+    // When
+    final LangChain4j lc4j = LangChain4j.builder().chatModel(chatModel).build();
+
+    // Then
+    assertThat(lc4j.modelName()).isEqualTo("auto-detected-model");
+    assertThat(lc4j.model()).isEqualTo("auto-detected-model");
+  }
+
+  @Test
+  @DisplayName("Should auto-detect model name from StreamingChatModel when not explicitly set")
+  void testBuilderAutoDetectsModelNameFromStreamingChatModel() {
+    // Given
+    final ChatRequestParameters params = mock(ChatRequestParameters.class);
+    when(params.modelName()).thenReturn("auto-detected-streaming-model");
+    when(streamingChatModel.defaultRequestParameters()).thenReturn(params);
+
+    // When
+    final LangChain4j lc4j = LangChain4j.builder().streamingChatModel(streamingChatModel).build();
+
+    // Then
+    assertThat(lc4j.modelName()).isEqualTo("auto-detected-streaming-model");
+    assertThat(lc4j.model()).isEqualTo("auto-detected-streaming-model");
+  }
+
+  @Test
+  @DisplayName("Should prefer explicit model name over auto-detected one")
+  void testBuilderPrefersExplicitModelName() {
+    // Given
+    final ChatRequestParameters params = mock(ChatRequestParameters.class);
+    when(params.modelName()).thenReturn("auto-detected-model");
+    when(chatModel.defaultRequestParameters()).thenReturn(params);
+
+    // When
+    final LangChain4j lc4j =
+        LangChain4j.builder().chatModel(chatModel).modelName("explicit-model").build();
+
+    // Then
+    assertThat(lc4j.modelName()).isEqualTo("explicit-model");
   }
 }

--- a/contrib/langchain4j/src/test/java/com/google/adk/models/langchain4j/LangChain4jTest.java
+++ b/contrib/langchain4j/src/test/java/com/google/adk/models/langchain4j/LangChain4jTest.java
@@ -31,6 +31,7 @@ import dev.langchain4j.model.TokenCountEstimator;
 import dev.langchain4j.model.chat.ChatModel;
 import dev.langchain4j.model.chat.StreamingChatModel;
 import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.request.ChatRequestParameters;
 import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
 import dev.langchain4j.model.chat.request.json.JsonStringSchema;
 import dev.langchain4j.model.chat.response.ChatResponse;
@@ -1144,5 +1145,53 @@ class LangChain4jTest {
         (dev.langchain4j.data.message.TextContent) userMessage.contents().get(0);
 
     assertThat(textContent.text()).isEqualTo(textPayload);
+  }
+
+  @Test
+  @DisplayName("Should auto-detect model name from ChatModel when not explicitly set")
+  void testBuilderAutoDetectsModelNameFromChatModel() {
+    // Given
+    final ChatRequestParameters params = mock(ChatRequestParameters.class);
+    when(params.modelName()).thenReturn("auto-detected-model");
+    when(chatModel.defaultRequestParameters()).thenReturn(params);
+
+    // When
+    final LangChain4j lc4j = LangChain4j.builder().chatModel(chatModel).build();
+
+    // Then
+    assertThat(lc4j.modelName()).isEqualTo("auto-detected-model");
+    assertThat(lc4j.model()).isEqualTo("auto-detected-model");
+  }
+
+  @Test
+  @DisplayName("Should auto-detect model name from StreamingChatModel when not explicitly set")
+  void testBuilderAutoDetectsModelNameFromStreamingChatModel() {
+    // Given
+    final ChatRequestParameters params = mock(ChatRequestParameters.class);
+    when(params.modelName()).thenReturn("auto-detected-streaming-model");
+    when(streamingChatModel.defaultRequestParameters()).thenReturn(params);
+
+    // When
+    final LangChain4j lc4j = LangChain4j.builder().streamingChatModel(streamingChatModel).build();
+
+    // Then
+    assertThat(lc4j.modelName()).isEqualTo("auto-detected-streaming-model");
+    assertThat(lc4j.model()).isEqualTo("auto-detected-streaming-model");
+  }
+
+  @Test
+  @DisplayName("Should prefer explicit model name over auto-detected one")
+  void testBuilderPrefersExplicitModelName() {
+    // Given
+    final ChatRequestParameters params = mock(ChatRequestParameters.class);
+    when(params.modelName()).thenReturn("auto-detected-model");
+    when(chatModel.defaultRequestParameters()).thenReturn(params);
+
+    // When
+    final LangChain4j lc4j =
+        LangChain4j.builder().chatModel(chatModel).modelName("explicit-model").build();
+
+    // Then
+    assertThat(lc4j.modelName()).isEqualTo("explicit-model");
   }
 }


### PR DESCRIPTION
**Please ensure you have read the [contribution guide](./CONTRIBUTING.md) before creating a pull request.**

### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

- Closes: #1124 

**2. Or, if no issue exists, describe the change:**

N/A

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

**Command**

```bash
mvn test -pl contrib/langchain4j -am
```

```
[INFO] Results:
[INFO] 
[WARNING] Tests run: 27, Failures: 0, Errors: 0, Skipped: 6
[INFO] 
[INFO] 
[INFO] --- jacoco:0.8.12:report (report) @ google-adk-langchain4j ---
[INFO] Loading execution data file /Users/tpcoder/Documents/Working/OSS Contribution/adk-java/contrib/langchain4j/target/jacoco.exec
[INFO] Analyzed bundle 'Agent Development Kit - LangChain4j' with 6 classes
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary for Google Agent Development Kit Maven Parent POM 1.0.1-SNAPSHOT:
[INFO] 
[INFO] Google Agent Development Kit Maven Parent POM ...... SUCCESS [  0.064 s]
[INFO] Agent Development Kit .............................. SUCCESS [ 22.594 s]
[INFO] Agent Development Kit - LangChain4j ................ SUCCESS [  2.265 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  25.493 s
[INFO] Finished at: 2026-04-09T08:02:22+07:00
[INFO] ------------------------------------------------------------------------
```

**Manual End-to-End (E2E) Tests:**

I created a sample project to verify session interaction

```java
public class MultiProviderAgent {

  /**
   * Creates a science teacher agent powered by Anthropic Claude.
   */
  public static LlmAgent createClaudeAgent() {
    AnthropicChatModel claudeModel =
        AnthropicChatModel.builder()
            .apiKey(System.getenv("ANTHROPIC_API_KEY"))
            .modelName("claude-sonnet-4-6")
            .build();

    LangChain4j adkModel = LangChain4j.builder()
        .chatModel(claudeModel)
        .build();
    
    return LlmAgent.builder()
        .name("claude-science-agent")
        .description("A science teacher powered by Claude")
        .model(adkModel)
        .instruction(
            """
                You are a science teacher.
                Explain concepts clearly and concisely in 2-3 sentences.
                """)
        .build();
  }

  /**
   * Creates a history teacher agent powered by Google Gemini.
   */
  public static LlmAgent createGeminiAgent() {
    GoogleAiGeminiChatModel geminiModel =
        GoogleAiGeminiChatModel.builder()
            .apiKey(System.getenv("GOOGLE_API_KEY"))
            .modelName("gemini-2.5-flash")
            .build();

    LangChain4j adkModel = LangChain4j.builder()
        .chatModel(geminiModel)
        .build();

    return LlmAgent.builder()
        .name("gemini-history-agent")
        .description("A history teacher powered by Gemini")
        .model(adkModel)
        .instruction(
            """
                You are a history teacher.
                Provide accurate and engaging historical facts in 2-3 sentences.
                """)
        .build();
  }

  private MultiProviderAgent() {
  }
}
```

And triggered by this

```java
  public static void main(String[] args) {
    LlmAgent claudeAgent = MultiProviderAgent.createClaudeAgent();
    LlmAgent geminiAgent = MultiProviderAgent.createGeminiAgent();

    askAgent(claudeAgent, "What is quantum entanglement?");
    askAgent(geminiAgent, "What caused the fall of the Roman Empire?");
  }
```

**E2E Result**

```
--- claude-science-agent ---
Q: What is quantum entanglement?
A: Quantum entanglement is a phenomenon where two or more particles become linked in such a way that the quantum state of one particle instantly influences the state of the other, no matter how far apart they are. When you measure a property of one entangled particle, you immediately know the corresponding property of its partner. Einstein famously called this "spooky action at a distance," and while it seems mysterious, it has been repeatedly confirmed by experiments and is even being used in emerging technologies like quantum computing and cryptography.

--- gemini-history-agent ---
Q: What caused the fall of the Roman Empire?
A: The fall of the Western Roman Empire in 476 CE was not a single event but a complex process driven by multiple factors. Relentless barbarian invasions, like those by the Goths and Vandals, severely strained Rome's vast borders and military resources. Simultaneously, internal issues such as political instability, economic decline, and social upheaval eroded the empire's foundations from within.

Process finished with exit code 0
```

### Checklist

- [x] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md) document.
- [x] My pull request contains a single commit.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [x] Any dependent changes have been merged and published in downstream modules.

### Additional context

The LangChain4j builder now auto-detects modelName from the underlying ChatModel or StreamingChatModel via
  defaultRequestParameters().modelName(), making it optional when the model already exposes it. Explicit modelName() still takes precedence for backward compatibility. If model name cannot be resolved from any source, the builder fails fast with a clear IllegalStateException.
