### PR TITLE
fix: parallel tool calls execute sequentially despite PARALLEL mode (#735)

### DIFF
--- a/core/src/main/java/com/google/adk/flows/llmflows/Functions.java
+++ b/core/src/main/java/com/google/adk/flows/llmflows/Functions.java
@@ -48,6 +48,7 @@ import io.reactivex.rxjava3.core.Observable;
 import io.reactivex.rxjava3.core.Single;
 import io.reactivex.rxjava3.disposables.Disposable;
 import io.reactivex.rxjava3.functions.Function;
+import io.reactivex.rxjava3.schedulers.Schedulers;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -591,8 +592,9 @@ public final class Functions {
 
   private static Maybe<Map<String, Object>> callTool(
       BaseTool tool, Map<String, Object> args, ToolContext toolContext) {
-    return tool.runAsync(args, toolContext)
+    return Single.defer(() -> tool.runAsync(args, toolContext))
         .toMaybe()
+        .subscribeOn(Schedulers.io())
         .doOnError(t -> Span.current().recordException(t))
         .onErrorResumeNext(
             e ->

--- a/core/src/test/java/com/google/adk/flows/llmflows/FunctionsTest.java
+++ b/core/src/test/java/com/google/adk/flows/llmflows/FunctionsTest.java
@@ -27,12 +27,18 @@ import com.google.adk.agents.RunConfig;
 import com.google.adk.agents.RunConfig.ToolExecutionMode;
 import com.google.adk.events.Event;
 import com.google.adk.testing.TestUtils;
+import com.google.adk.tools.BaseTool;
+import com.google.adk.tools.ToolContext;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.genai.types.Content;
 import com.google.genai.types.FunctionCall;
+import com.google.genai.types.FunctionDeclaration;
 import com.google.genai.types.FunctionResponse;
 import com.google.genai.types.Part;
+import io.reactivex.rxjava3.core.Single;
+import java.util.Map;
+import java.util.Optional;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -388,5 +394,138 @@ public final class FunctionsTest {
             .build();
     ImmutableList<FunctionCall> result = Functions.getAskUserConfirmationFunctionCalls(event);
     assertThat(result).containsExactly(confirmationCall1, confirmationCall2);
+  }
+
+  /**
+   * A tool that blocks for a specified duration, simulating a slow I/O operation. Uses
+   * Single.fromCallable to ensure the sleep is deferred until subscription time.
+   */
+  private static class SlowTool extends BaseTool {
+    private final String toolName;
+    private final long sleepMillis;
+
+    SlowTool(String name, long sleepMillis) {
+      super(name, "A slow tool for testing parallel execution");
+      this.toolName = name;
+      this.sleepMillis = sleepMillis;
+    }
+
+    @Override
+    public Optional<FunctionDeclaration> declaration() {
+      return Optional.of(FunctionDeclaration.builder().name(toolName).build());
+    }
+
+    @Override
+    public Single<Map<String, Object>> runAsync(Map<String, Object> args, ToolContext toolContext) {
+      return Single.fromCallable(
+          () -> {
+            Thread.sleep(sleepMillis);
+            return ImmutableMap.<String, Object>of("tool", toolName, "status", "done");
+          });
+    }
+  }
+
+  @Test
+  public void handleFunctionCalls_parallelMode_shouldExecuteConcurrently() {
+    long sleepTime = 1000;
+    SlowTool slowTool1 = new SlowTool("slow_tool_1", sleepTime);
+    SlowTool slowTool2 = new SlowTool("slow_tool_2", sleepTime);
+
+    InvocationContext invocationContext =
+        createInvocationContext(
+            createRootAgent(),
+            RunConfig.builder().setToolExecutionMode(ToolExecutionMode.PARALLEL).build());
+
+    Event event =
+        createEvent("event").toBuilder()
+            .content(
+                Content.fromParts(
+                    Part.builder()
+                        .functionCall(
+                            FunctionCall.builder()
+                                .id("call_1")
+                                .name("slow_tool_1")
+                                .args(ImmutableMap.of())
+                                .build())
+                        .build(),
+                    Part.builder()
+                        .functionCall(
+                            FunctionCall.builder()
+                                .id("call_2")
+                                .name("slow_tool_2")
+                                .args(ImmutableMap.of())
+                                .build())
+                        .build()))
+            .build();
+
+    long startTime = System.currentTimeMillis();
+    Event result =
+        Functions.handleFunctionCalls(
+                invocationContext,
+                event,
+                ImmutableMap.of("slow_tool_1", slowTool1, "slow_tool_2", slowTool2))
+            .blockingGet();
+    long duration = System.currentTimeMillis() - startTime;
+
+    // If parallel, duration should be ~1000ms, not ~2000ms.
+    assertThat(duration).isAtLeast(sleepTime);
+    assertThat(duration).isLessThan((long) (1.5 * sleepTime));
+
+    // Verify results are returned in correct order (concatMapEager preserves order).
+    assertThat(result).isNotNull();
+    assertThat(result.content().get().parts().get()).hasSize(2);
+    assertThat(result.content().get().parts().get().get(0).functionResponse().get().name())
+        .hasValue("slow_tool_1");
+    assertThat(result.content().get().parts().get().get(1).functionResponse().get().name())
+        .hasValue("slow_tool_2");
+  }
+
+  @Test
+  public void handleFunctionCalls_sequentialMode_shouldExecuteSerially() {
+    long sleepTime = 1000;
+    SlowTool slowTool1 = new SlowTool("slow_tool_1", sleepTime);
+    SlowTool slowTool2 = new SlowTool("slow_tool_2", sleepTime);
+
+    InvocationContext invocationContext =
+        createInvocationContext(
+            createRootAgent(),
+            RunConfig.builder().setToolExecutionMode(ToolExecutionMode.SEQUENTIAL).build());
+
+    Event event =
+        createEvent("event").toBuilder()
+            .content(
+                Content.fromParts(
+                    Part.builder()
+                        .functionCall(
+                            FunctionCall.builder()
+                                .id("call_1")
+                                .name("slow_tool_1")
+                                .args(ImmutableMap.of())
+                                .build())
+                        .build(),
+                    Part.builder()
+                        .functionCall(
+                            FunctionCall.builder()
+                                .id("call_2")
+                                .name("slow_tool_2")
+                                .args(ImmutableMap.of())
+                                .build())
+                        .build()))
+            .build();
+
+    long startTime = System.currentTimeMillis();
+    Event result =
+        Functions.handleFunctionCalls(
+                invocationContext,
+                event,
+                ImmutableMap.of("slow_tool_1", slowTool1, "slow_tool_2", slowTool2))
+            .blockingGet();
+    long duration = System.currentTimeMillis() - startTime;
+
+    // Sequential: duration should be >= 2 * sleepTime.
+    assertThat(duration).isAtLeast(2 * sleepTime);
+
+    assertThat(result).isNotNull();
+    assertThat(result.content().get().parts().get()).hasSize(2);
   }
 }


### PR DESCRIPTION
## Problem

Fixes #735

When an LLM returns multiple tool calls simultaneously (parallel function calling), ADK Java executes them **sequentially** despite `ToolExecutionMode.PARALLEL` being set. Two tools each taking 1 second complete in ~2 seconds instead of ~1 second.

## Root Cause

The bug is in `Functions.callTool()`. For `FunctionTool` (the most common tool type), `runAsync()` calls `func.invoke()` via Java reflection — a **synchronous**, blocking call that completes before returning a `Single`:

```java
// FunctionTool.runAsync() calls this:
private Maybe<...> call(...) throws ... {
    Object result = func.invoke(instance, arguments);  // blocks here — HTTP/DB call
    return Maybe.just(result);                         // value already computed
}
```

The original `callTool()` was:

```java
// BEFORE (broken)
return tool.runAsync(args, toolContext)   // func.invoke() runs NOW, blocks calling thread
    .toMaybe()
    // subscribeOn here would be too late — computation already done
    .doOnError(...)
    .onErrorResumeNext(...);
```

`handleFunctionCalls` uses `concatMapEager` for PARALLEL mode, which _eagerly subscribes_ to all inner Observables. However, if the subscription itself is synchronous and blocking, `concatMapEager` cannot dispatch to a new thread — it is stuck waiting for the first subscription to complete before starting the next.

**Why `subscribeOn(Schedulers.io())` alone (without `Single.defer`) does not fix it:**

`subscribeOn` only shifts the _subscription signal_ to an IO thread, not the method call that produces the `Single`. By the time `.subscribeOn()` is reached in the chain, `func.invoke()` has already finished on the calling thread.

```
Calling thread:
  tool.runAsync()           ← func.invoke() runs synchronously here (~1000ms)
      ↓ returns Single.just(alreadyComputedValue)
  .toMaybe()
  .subscribeOn(IO)          ← too late, value was computed before this
```

**Contrast with `ParallelAgent`** ([ParallelAgent.java#L148](https://github.com/google/adk-java/blob/main/core/src/main/java/com/google/adk/agents/ParallelAgent.java#L148)), which correctly uses `.subscribeOn(scheduler)` because `subAgent.runAsync()` returns a lazy `Flowable` — the work has not started yet when it is returned.

## Fix

Wrap `tool.runAsync()` in `Single.defer()` to make it **lazy**, then apply `subscribeOn(Schedulers.io())`:

```java
// AFTER (fixed)
return Single.defer(() -> tool.runAsync(args, toolContext))  // deferred — not called yet
    .toMaybe()
    .subscribeOn(Schedulers.io())    // subscription (+ runAsync call) happens on IO thread
    .doOnError(...)
    .onErrorResumeNext(...);
```

`Single.defer()` packages `tool.runAsync()` as a lambda that only executes at subscription time. `subscribeOn(Schedulers.io())` then causes that subscription — including `func.invoke()` — to happen on an IO thread. `concatMapEager` eagerly dispatches all tool subscriptions, each to its own IO thread, achieving true parallelism while preserving result order.

## Execution Flow: Before vs After

**Scenario:** LLM returns two parallel tool calls — `get_weather(city=Beijing)` and `search_hotels(city=Shanghai)` — each taking ~1000ms.

### Before (sequential despite PARALLEL mode)

```
Calling thread ─────────────────────────────────────────────────────────────►

concatMapEager subscribes to Observable1
│
├─ Maybe.defer(lambda) executes on calling thread
│  └─ callTool() -> tool.runAsync()
│        └─ func.invoke("get_weather") ████████████ 1000ms (HTTP call) ████
│              returns Single.just({"temperature":"25C"})  <- already computed
│  .toMaybe().subscribeOn(IO)  <- pointless, value already exists
│
│  <- thread released; concatMapEager can now subscribe to Observable2
│
├─ Maybe.defer(lambda) executes on calling thread
│  └─ callTool() -> tool.runAsync()
│        └─ func.invoke("search_hotels") █████████ 1000ms (HTTP call) ████
│              returns Single.just({"hotel":"Hilton"})
│
└─ merge results -> total ~2000ms  ✗
```

### After (true parallel)

```
Calling thread ──────────►    IO-thread-1 ──────────────────────────────►
                               ┌─ Single.defer lambda executes
concatMapEager subscribes      │  └─ tool.runAsync() -> func.invoke("get_weather")
to Observable1                 │            ████████████ 1000ms ████
│                              └─ emits {"temperature":"25C"}
├─ callTool() returns
│  Single.defer(...).subscribeOn(IO) ──────┘  (non-blocking!)
│
concatMapEager subscribes      IO-thread-2 ──────────────────────────────►
to Observable2                 ┌─ Single.defer lambda executes
│                              │  └─ tool.runAsync() -> func.invoke("search_hotels")
├─ callTool() returns          │            ████████████ 1000ms ████
│  Single.defer(...).subscribeOn(IO) ──────┘  (non-blocking!)
│
│       <- ~1000ms: both IO threads finish ──────────────────────────────┤
└─ concatMapEager emits in original order: [weather_result, hotel_result]
   total ~1000ms  ✓
```

## Changes

### `Functions.java`
- Added `import io.reactivex.rxjava3.schedulers.Schedulers`
- Wrapped `tool.runAsync(args, toolContext)` in `Single.defer()` and added `.subscribeOn(Schedulers.io())` in `callTool()`

### `FunctionsTest.java`
- Added `SlowTool` inner class — a `BaseTool` that sleeps for a configurable duration using `Single.fromCallable`
- `handleFunctionCalls_parallelMode_shouldExecuteConcurrently`: two 1000ms tools complete in <1500ms under PARALLEL mode
- `handleFunctionCalls_sequentialMode_shouldExecuteSerially`: two 1000ms tools take ≥2000ms under SEQUENTIAL mode (serial contract unchanged)

## Testing

```
Tests run: 16, Failures: 0, Errors: 0, Skipped: 0
```
