### PR TITLE
fix: Make LlmResponse constructor protected for external subclassing

### DIFF
--- a/core/src/main/java/com/google/adk/models/LlmResponse.java
+++ b/core/src/main/java/com/google/adk/models/LlmResponse.java
@@ -41,7 +41,8 @@ import org.jspecify.annotations.Nullable;
 @JsonDeserialize(builder = LlmResponse.Builder.class)
 public abstract class LlmResponse extends JsonBaseModel {
 
-  LlmResponse() {}
+  /** Protected to allow custom LLM integrations to subclass this type outside the package. */
+  protected LlmResponse() {}
 
   /**
    * Returns the content of the first candidate in the response, if available.

--- a/core/src/test/java/com/google/adk/models/external/ExternalLlmResponseSubclassTest.java
+++ b/core/src/test/java/com/google/adk/models/external/ExternalLlmResponseSubclassTest.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.adk.models.external;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.adk.models.LlmResponse;
+import com.google.genai.types.Content;
+import com.google.genai.types.CustomMetadata;
+import com.google.genai.types.FinishReason;
+import com.google.genai.types.GenerateContentResponseUsageMetadata;
+import com.google.genai.types.GroundingMetadata;
+import com.google.genai.types.Transcription;
+import java.util.List;
+import java.util.Optional;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public final class ExternalLlmResponseSubclassTest {
+
+  @Test
+  public void subclassOutsidePackage_canInstantiate() {
+    LlmResponse response = new ExternalLlmResponse();
+
+    assertThat(response.content()).isEmpty();
+  }
+
+  private static final class ExternalLlmResponse extends LlmResponse {
+
+    @Override
+    public Optional<Content> content() {
+      return Optional.empty();
+    }
+
+    @Override
+    public Optional<GroundingMetadata> groundingMetadata() {
+      return Optional.empty();
+    }
+
+    @Override
+    public Optional<List<CustomMetadata>> customMetadata() {
+      return Optional.empty();
+    }
+
+    @Override
+    public Optional<Boolean> partial() {
+      return Optional.empty();
+    }
+
+    @Override
+    public Optional<Boolean> turnComplete() {
+      return Optional.empty();
+    }
+
+    @Override
+    public Optional<FinishReason> errorCode() {
+      return Optional.empty();
+    }
+
+    @Override
+    public Optional<FinishReason> finishReason() {
+      return Optional.empty();
+    }
+
+    @Override
+    public Optional<Double> avgLogprobs() {
+      return Optional.empty();
+    }
+
+    @Override
+    public Optional<String> errorMessage() {
+      return Optional.empty();
+    }
+
+    @Override
+    public Optional<Boolean> interrupted() {
+      return Optional.empty();
+    }
+
+    @Override
+    public Optional<GenerateContentResponseUsageMetadata> usageMetadata() {
+      return Optional.empty();
+    }
+
+    @Override
+    public Optional<String> modelVersion() {
+      return Optional.empty();
+    }
+
+    @Override
+    public Optional<Transcription> inputTranscription() {
+      return Optional.empty();
+    }
+
+    @Override
+    public Optional<Transcription> outputTranscription() {
+      return Optional.empty();
+    }
+
+    @Override
+    public Builder toBuilder() {
+      return LlmResponse.builder();
+    }
+  }
+}


### PR DESCRIPTION
**Please ensure you have read the [contribution guide](./CONTRIBUTING.md) before creating a pull request.**

### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

- Closes: #1134

**Problem:**
The `LlmResponse` constructor uses package-private (default) visibility, which prevents users from subclassing `LlmResponse` outside of the `com.google.adk.models` package. This blocks custom LLM integrations (e.g., connecting LM Studio or other local models) that need to extend `LlmResponse`.

**Solution:**
Change the `LlmResponse` constructor from package-private to `protected`. This is the minimal change needed. It allows subclassing from external packages while still preventing arbitrary instantiation (unlike `public`). The `@AutoValue`-generated subclass in the same package is unaffected.

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

Added `ExternalLlmResponseSubclassTest` in the `com.google.adk.models.external` package (outside `com.google.adk.models`) to verify that an external subclass of `LlmResponse` can be instantiated.

```
./mvnw -pl core -Dtest=ExternalLlmResponseSubclassTest test
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0 — BUILD SUCCESS
```

### Checklist

- [x] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md) document.
- [x] My pull request contains a single commit.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have manually tested my changes end-to-end.
- [x] Any dependent changes have been merged and published in downstream modules.