### PR TITLE
feat(live): support live for gemini-3.1-flash-live-preview model

### DIFF
--- a/core/src/main/java/com/google/adk/models/GeminiLlmConnection.java
+++ b/core/src/main/java/com/google/adk/models/GeminiLlmConnection.java
@@ -18,6 +18,7 @@ package com.google.adk.models;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
 
+import com.google.adk.utils.ModelNameUtils;
 import com.google.common.collect.ImmutableList;
 import com.google.genai.AsyncSession;
 import com.google.genai.Client;
@@ -257,6 +258,13 @@ public final class GeminiLlmConnection implements BaseLlmConnection {
 
     List<FunctionResponse> functionResponses = extractFunctionResponses(content);
     if (functionResponses.isEmpty()) {
+      Optional<LiveSendRealtimeInputParameters> realtimeInputParameters =
+          createRealtimeInputForContent(content, modelName, apiClient.vertexAI());
+      if (realtimeInputParameters.isPresent()) {
+        return Completable.fromFuture(
+            sessionFuture.thenCompose(
+                session -> session.sendRealtimeInput(realtimeInputParameters.get())));
+      }
       return sendClientContentInternal(
           LiveSendClientContentParameters.builder()
               .turns(ImmutableList.of(content))
@@ -289,7 +297,7 @@ public final class GeminiLlmConnection implements BaseLlmConnection {
         sessionFuture.thenCompose(
             session ->
                 session.sendRealtimeInput(
-                    LiveSendRealtimeInputParameters.builder().media(blob).build())));
+                    createRealtimeInputForBlob(blob, modelName, apiClient.vertexAI()))));
   }
 
   /** Helper to send client content parameters. */
@@ -302,6 +310,40 @@ public final class GeminiLlmConnection implements BaseLlmConnection {
   private Completable sendToolResponseInternal(LiveSendToolResponseParameters parameters) {
     return Completable.fromFuture(
         sessionFuture.thenCompose(session -> session.sendToolResponse(parameters)));
+  }
+
+  static boolean usesGemini31FlashLiveRealtimeInput(String modelName, boolean vertexAI) {
+    return !vertexAI && ModelNameUtils.isGemini31FlashLiveModel(modelName);
+  }
+
+  static Optional<LiveSendRealtimeInputParameters> createRealtimeInputForContent(
+      Content content, String modelName, boolean vertexAI) {
+    if (!usesGemini31FlashLiveRealtimeInput(modelName, vertexAI)
+        || content.parts().isEmpty()
+        || content.parts().get().size() != 1) {
+      return Optional.empty();
+    }
+    Part part = content.parts().get().get(0);
+    if (part.text().isEmpty()) {
+      return Optional.empty();
+    }
+    return Optional.of(LiveSendRealtimeInputParameters.builder().text(part.text().get()).build());
+  }
+
+  static LiveSendRealtimeInputParameters createRealtimeInputForBlob(
+      Blob blob, String modelName, boolean vertexAI) {
+    if (!usesGemini31FlashLiveRealtimeInput(modelName, vertexAI)) {
+      return LiveSendRealtimeInputParameters.builder().media(blob).build();
+    }
+
+    String mimeType = blob.mimeType().orElse("");
+    if (mimeType.startsWith("audio/")) {
+      return LiveSendRealtimeInputParameters.builder().audio(blob).build();
+    }
+    if (mimeType.startsWith("image/")) {
+      return LiveSendRealtimeInputParameters.builder().video(blob).build();
+    }
+    return LiveSendRealtimeInputParameters.builder().media(blob).build();
   }
 
   @Override

--- a/core/src/main/java/com/google/adk/utils/ModelNameUtils.java
+++ b/core/src/main/java/com/google/adk/utils/ModelNameUtils.java
@@ -24,6 +24,7 @@ import java.util.regex.Pattern;
 /** Utility class for model names. */
 public final class ModelNameUtils {
   private static final String GEMINI_PREFIX = "gemini-";
+  private static final String GEMINI_3_1_FLASH_LIVE_PREFIX = "gemini-3.1-flash-live";
   private static final Pattern GEMINI_2_PATTERN = Pattern.compile("^gemini-2\\..*");
   private static final String GEMINI_CLASS = "com.google.adk.models.Gemini";
   private static final Pattern PATH_PATTERN =
@@ -37,6 +38,13 @@ public final class ModelNameUtils {
 
   public static boolean isGemini2Model(String modelString) {
     return matchesModelPattern(modelString, GEMINI_2_PATTERN);
+  }
+
+  public static boolean isGemini31FlashLiveModel(String modelString) {
+    if (modelString == null) {
+      return false;
+    }
+    return extractModelName(modelString).startsWith(GEMINI_3_1_FLASH_LIVE_PREFIX);
   }
 
   private static boolean matchesModelPattern(String modelString, Pattern pattern) {

--- a/core/src/test/java/com/google/adk/models/GeminiLlmConnectionTest.java
+++ b/core/src/test/java/com/google/adk/models/GeminiLlmConnectionTest.java
@@ -19,9 +19,11 @@ package com.google.adk.models;
 import static com.google.common.truth.Truth.assertThat;
 
 import com.google.common.collect.ImmutableList;
+import com.google.genai.types.Blob;
 import com.google.genai.types.Content;
 import com.google.genai.types.FunctionCall;
 import com.google.genai.types.GenerateContentResponseUsageMetadata;
+import com.google.genai.types.LiveSendRealtimeInputParameters;
 import com.google.genai.types.LiveServerContent;
 import com.google.genai.types.LiveServerMessage;
 import com.google.genai.types.LiveServerSetupComplete;
@@ -31,12 +33,99 @@ import com.google.genai.types.Part;
 import com.google.genai.types.UsageMetadata;
 import io.reactivex.rxjava3.observers.TestObserver;
 import java.util.List;
+import java.util.Optional;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
 @RunWith(JUnit4.class)
 public final class GeminiLlmConnectionTest {
+
+  @Test
+  public void usesGemini31FlashLiveRealtimeInput_withGeminiApiPreviewModel_returnsTrue() {
+    assertThat(
+            GeminiLlmConnection.usesGemini31FlashLiveRealtimeInput(
+                "gemini-3.1-flash-live-preview", false))
+        .isTrue();
+  }
+
+  @Test
+  public void usesGemini31FlashLiveRealtimeInput_withVertexAi_returnsFalse() {
+    assertThat(
+            GeminiLlmConnection.usesGemini31FlashLiveRealtimeInput(
+                "gemini-3.1-flash-live-preview", true))
+        .isFalse();
+  }
+
+  @Test
+  public void createRealtimeInputForContent_withSingleTextOnGemini31_returnsTextInput() {
+    Content content = Content.fromParts(Part.fromText("hello"));
+
+    Optional<LiveSendRealtimeInputParameters> parameters =
+        GeminiLlmConnection.createRealtimeInputForContent(
+            content, "gemini-3.1-flash-live-preview", false);
+
+    assertThat(parameters).isPresent();
+    assertThat(parameters.get().text()).hasValue("hello");
+    assertThat(parameters.get().media()).isEmpty();
+  }
+
+  @Test
+  public void createRealtimeInputForContent_withNonTextContent_returnsEmpty() {
+    Content content =
+        Content.builder()
+            .parts(
+                ImmutableList.of(
+                    Part.builder()
+                        .inlineData(
+                            Blob.builder().mimeType("image/png").data(new byte[] {1}).build())
+                        .build()))
+            .build();
+
+    Optional<LiveSendRealtimeInputParameters> parameters =
+        GeminiLlmConnection.createRealtimeInputForContent(
+            content, "gemini-3.1-flash-live-preview", false);
+
+    assertThat(parameters).isEmpty();
+  }
+
+  @Test
+  public void createRealtimeInputForBlob_withGemini31Audio_setsAudio() {
+    Blob blob = Blob.builder().mimeType("audio/pcm").data(new byte[] {1}).build();
+
+    LiveSendRealtimeInputParameters parameters =
+        GeminiLlmConnection.createRealtimeInputForBlob(
+            blob, "gemini-3.1-flash-live-preview", false);
+
+    assertThat(parameters.audio()).hasValue(blob);
+    assertThat(parameters.media()).isEmpty();
+    assertThat(parameters.video()).isEmpty();
+  }
+
+  @Test
+  public void createRealtimeInputForBlob_withGemini31Image_setsVideo() {
+    Blob blob = Blob.builder().mimeType("image/jpeg").data(new byte[] {1}).build();
+
+    LiveSendRealtimeInputParameters parameters =
+        GeminiLlmConnection.createRealtimeInputForBlob(
+            blob, "gemini-3.1-flash-live-preview", false);
+
+    assertThat(parameters.video()).hasValue(blob);
+    assertThat(parameters.media()).isEmpty();
+    assertThat(parameters.audio()).isEmpty();
+  }
+
+  @Test
+  public void createRealtimeInputForBlob_withOtherModel_keepsMedia() {
+    Blob blob = Blob.builder().mimeType("audio/pcm").data(new byte[] {1}).build();
+
+    LiveSendRealtimeInputParameters parameters =
+        GeminiLlmConnection.createRealtimeInputForBlob(blob, "gemini-2.0-flash-live-001", false);
+
+    assertThat(parameters.media()).hasValue(blob);
+    assertThat(parameters.audio()).isEmpty();
+    assertThat(parameters.video()).isEmpty();
+  }
 
   @Test
   public void convertToServerResponse_withInterruptedTrue_mapsInterruptedField() {

--- a/core/src/test/java/com/google/adk/utils/ModelNameUtilsTest.java
+++ b/core/src/test/java/com/google/adk/utils/ModelNameUtilsTest.java
@@ -138,6 +138,21 @@ public class ModelNameUtilsTest {
   }
 
   @Test
+  public void isGemini31FlashLiveModel_withPrefixOnly_returnsTrue() {
+    assertThat(ModelNameUtils.isGemini31FlashLiveModel("gemini-3.1-flash-live")).isTrue();
+  }
+
+  @Test
+  public void isGemini31FlashLiveModel_withPrefixedVariant_returnsTrue() {
+    assertThat(ModelNameUtils.isGemini31FlashLiveModel("gemini-3.1-flash-live-preview")).isTrue();
+  }
+
+  @Test
+  public void isGemini31FlashLiveModel_withOtherModel_returnsFalse() {
+    assertThat(ModelNameUtils.isGemini31FlashLiveModel("gemini-2.0-flash-live-001")).isFalse();
+  }
+
+  @Test
   public void isInstanceOfGemini_withGeminiInstance_returnsTrue() {
     assertThat(ModelNameUtils.isInstanceOfGemini(new Gemini("", ""))).isTrue();
   }


### PR DESCRIPTION
**Problem:**
adk-java does not support gemini-3.1-flash-live-preview model

**Solution:**
Ported from Python https://github.com/google/adk-python/commit/8082893619bb85d4ee0dc53fd2133d12b9434d07

### Testing Plan
Tested the bidi demo with new model and the 2.5 model

**Unit Tests:**

- [X] I have added or updated unit tests for my change.
- [X] All unit tests pass locally.

<img width="414" height="36" alt="image" src="https://github.com/user-attachments/assets/2ff7eb5a-e1d7-44bc-b0bf-a10382ab8a3a" />

**Manual End-to-End (E2E) Tests:**

bidi demo works with gemini-3.1-flash-live-preview model

### Checklist

- [x] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md) document.
- [x] My pull request contains a single commit.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [x] Any dependent changes have been merged and published in downstream modules.


