### PR TITLE
Set CAPTURE_MESSAGE_CONTENT_IN_SPANS default to false

### DIFF
--- a/core/src/main/java/com/google/adk/telemetry/README.md
+++ b/core/src/main/java/com/google/adk/telemetry/README.md
@@ -151,6 +151,7 @@ The following classes are the primary places where spans are created:
 
 **ADK_CAPTURE_MESSAGE_CONTENT_IN_SPANS**: This environment variable controls
 whether LLM request/response content and tool arguments/responses are captured
-in span attributes. It defaults to `true`. Set to `false` to exclude potentially
-large or sensitive data from traces, in which case a `{}` JSON object will be
-recorded instead.
+in span attributes. It defaults to `false` per OpenTelemetry GenAI semantic
+conventions, which classify content attributes as opt-in due to privacy and data
+volume concerns. Set to `true` to include content in traces (e.g., for local
+development or debugging). When disabled, a `{}` JSON object is recorded instead.

--- a/core/src/main/java/com/google/adk/telemetry/Tracing.java
+++ b/core/src/main/java/com/google/adk/telemetry/Tracing.java
@@ -137,7 +137,7 @@ public class Tracing {
 
   private static final boolean CAPTURE_MESSAGE_CONTENT_IN_SPANS =
       Boolean.parseBoolean(
-          System.getenv().getOrDefault("ADK_CAPTURE_MESSAGE_CONTENT_IN_SPANS", "true"));
+          System.getenv().getOrDefault("ADK_CAPTURE_MESSAGE_CONTENT_IN_SPANS", "false"));
 
   private Tracing() {}
 

--- a/core/src/main/java/com/google/adk/telemetry/Tracing.java
+++ b/core/src/main/java/com/google/adk/telemetry/Tracing.java
@@ -141,7 +141,7 @@ public class Tracing {
 
   private static final boolean CAPTURE_MESSAGE_CONTENT_IN_SPANS =
       Boolean.parseBoolean(
-          System.getenv().getOrDefault("ADK_CAPTURE_MESSAGE_CONTENT_IN_SPANS", "true"));
+          System.getenv().getOrDefault("ADK_CAPTURE_MESSAGE_CONTENT_IN_SPANS", "false"));
 
   private Tracing() {}
 

--- a/core/src/test/java/com/google/adk/telemetry/ContextPropagationTest.java
+++ b/core/src/test/java/com/google/adk/telemetry/ContextPropagationTest.java
@@ -257,9 +257,7 @@ public class ContextPropagationTest {
     assertEquals("tool-name", attrs.get(AttributeKey.stringKey("gen_ai.tool.name")));
     assertEquals("tool-description", attrs.get(AttributeKey.stringKey("gen_ai.tool.description")));
     assertEquals("tool-type", attrs.get(AttributeKey.stringKey("gen_ai.tool.type")));
-    assertEquals(
-        "{\"arg1\":\"value1\"}",
-        attrs.get(AttributeKey.stringKey("gcp.vertex.agent.tool_call_args")));
+    assertEquals("{}", attrs.get(AttributeKey.stringKey("gcp.vertex.agent.tool_call_args")));
     assertEquals("{}", attrs.get(AttributeKey.stringKey("gcp.vertex.agent.llm_request")));
     assertEquals("{}", attrs.get(AttributeKey.stringKey("gcp.vertex.agent.llm_response")));
   }
@@ -304,9 +302,7 @@ public class ContextPropagationTest {
     assertEquals("tool-description", attrs.get(AttributeKey.stringKey("gen_ai.tool.description")));
     assertEquals("tool-type", attrs.get(AttributeKey.stringKey("gen_ai.tool.type")));
     assertEquals("{}", attrs.get(AttributeKey.stringKey("gcp.vertex.agent.tool_call_args")));
-    assertEquals(
-        "{\"result\":\"tool-result\"}",
-        attrs.get(AttributeKey.stringKey("gcp.vertex.agent.tool_response")));
+    assertEquals("{}", attrs.get(AttributeKey.stringKey("gcp.vertex.agent.tool_response")));
   }
 
   @Test
@@ -353,9 +349,8 @@ public class ContextPropagationTest {
     assertEquals(
         ImmutableList.of("stop"),
         attrs.get(AttributeKey.stringArrayKey("gen_ai.response.finish_reasons")));
-    assertTrue(
-        attrs.get(AttributeKey.stringKey("gcp.vertex.agent.llm_request")).contains("gemini-pro"));
-    assertTrue(attrs.get(AttributeKey.stringKey("gcp.vertex.agent.llm_response")).contains("STOP"));
+    assertEquals("{}", attrs.get(AttributeKey.stringKey("gcp.vertex.agent.llm_request")));
+    assertEquals("{}", attrs.get(AttributeKey.stringKey("gcp.vertex.agent.llm_response")));
   }
 
   @Test
@@ -379,7 +374,7 @@ public class ContextPropagationTest {
         "test-invocation-id", attrs.get(AttributeKey.stringKey("gcp.vertex.agent.invocation_id")));
     assertEquals("event-1", attrs.get(AttributeKey.stringKey("gcp.vertex.agent.event_id")));
     assertEquals("test-session", attrs.get(AttributeKey.stringKey("gcp.vertex.agent.session_id")));
-    assertTrue(attrs.get(AttributeKey.stringKey("gcp.vertex.agent.data")).contains("hello"));
+    assertEquals("{}", attrs.get(AttributeKey.stringKey("gcp.vertex.agent.data")));
   }
 
   // Agent that emits one event on a computation thread.

--- a/core/src/test/java/com/google/adk/telemetry/ContextPropagationTest.java
+++ b/core/src/test/java/com/google/adk/telemetry/ContextPropagationTest.java
@@ -257,9 +257,7 @@ public class ContextPropagationTest {
     assertEquals("tool-name", attrs.get(AttributeKey.stringKey("gen_ai.tool.name")));
     assertEquals("tool-description", attrs.get(AttributeKey.stringKey("gen_ai.tool.description")));
     assertEquals("tool-type", attrs.get(AttributeKey.stringKey("gen_ai.tool.type")));
-    assertEquals(
-        "{\"arg1\":\"value1\"}",
-        attrs.get(AttributeKey.stringKey("gcp.vertex.agent.tool_call_args")));
+    assertEquals("{}", attrs.get(AttributeKey.stringKey("gcp.vertex.agent.tool_call_args")));
     assertEquals("{}", attrs.get(AttributeKey.stringKey("gcp.vertex.agent.llm_request")));
     assertEquals("{}", attrs.get(AttributeKey.stringKey("gcp.vertex.agent.llm_response")));
   }
@@ -304,9 +302,7 @@ public class ContextPropagationTest {
     assertEquals("tool-description", attrs.get(AttributeKey.stringKey("gen_ai.tool.description")));
     assertEquals("tool-type", attrs.get(AttributeKey.stringKey("gen_ai.tool.type")));
     assertEquals("{}", attrs.get(AttributeKey.stringKey("gcp.vertex.agent.tool_call_args")));
-    assertEquals(
-        "{\"result\":\"tool-result\"}",
-        attrs.get(AttributeKey.stringKey("gcp.vertex.agent.tool_response")));
+    assertEquals("{}", attrs.get(AttributeKey.stringKey("gcp.vertex.agent.tool_response")));
   }
 
   @Test
@@ -353,9 +349,8 @@ public class ContextPropagationTest {
     assertEquals(
         ImmutableList.of("stop"),
         attrs.get(AttributeKey.stringArrayKey("gen_ai.response.finish_reasons")));
-    assertTrue(
-        attrs.get(AttributeKey.stringKey("gcp.vertex.agent.llm_request")).contains("gemini-pro"));
-    assertTrue(attrs.get(AttributeKey.stringKey("gcp.vertex.agent.llm_response")).contains("STOP"));
+    assertEquals("{}", attrs.get(AttributeKey.stringKey("gcp.vertex.agent.llm_request")));
+    assertEquals("{}", attrs.get(AttributeKey.stringKey("gcp.vertex.agent.llm_response")));
   }
 
   @Test
@@ -419,7 +414,7 @@ public class ContextPropagationTest {
         "test-invocation-id", attrs.get(AttributeKey.stringKey("gcp.vertex.agent.invocation_id")));
     assertEquals("event-1", attrs.get(AttributeKey.stringKey("gcp.vertex.agent.event_id")));
     assertEquals("test-session", attrs.get(AttributeKey.stringKey("gcp.vertex.agent.session_id")));
-    assertTrue(attrs.get(AttributeKey.stringKey("gcp.vertex.agent.data")).contains("hello"));
+    assertEquals("{}", attrs.get(AttributeKey.stringKey("gcp.vertex.agent.data")));
   }
 
   // Agent that emits one event on a computation thread.


### PR DESCRIPTION
### Link to Issue or Description of Change
- Closes: #1143 

**Problem:**
LLM request/response content and tool arguments/responses will no longer be captured in OpenTelemetry spans unless explicitly opted in.

ADK should provide a privacy-first default to avoid UGC being accidently extracted, aligning with OTEL conventions.

**Solution:**
Tracing.java — The default value of the ADK_CAPTURE_MESSAGE_CONTENT_IN_SPANS environment variable should default from true → false.

Note that this will diverge from the `adk-python` behaviour, but IMO for the better.

https://github.com/google/adk-python/blame/b8e8f6b90290e48e134f48bbe7e2b800276e7269/src/google/adk/telemetry/tracing.py#L484