### PR TITLE
fix(core): avoid NPE when Agent description is missing

### DIFF
--- a/core/src/main/java/com/google/adk/tools/AgentTool.java
+++ b/core/src/main/java/com/google/adk/tools/AgentTool.java
@@ -31,6 +31,7 @@ import com.google.adk.runner.InMemoryRunner;
 import com.google.adk.runner.Runner;
 import com.google.adk.sessions.State;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.genai.types.Content;
@@ -131,8 +132,14 @@ public class AgentTool extends BaseTool {
 
   @Override
   public Optional<FunctionDeclaration> declaration() {
+
+    // The genai FunctionDeclaration builder uses Optional.of() internally, which NPEs on a null
+    // description. Coerce null to an empty string. This matches the Python, Go, and Kotlin ports,
+    // which send an empty description when the agent has none.
+    String desc = Strings.nullToEmpty(this.description());
+
     FunctionDeclaration.Builder builder =
-        FunctionDeclaration.builder().description(this.description()).name(this.name());
+        FunctionDeclaration.builder().description(desc).name(this.name());
 
     Optional<Schema> agentInputSchema = getInputSchema(agent);
 

--- a/core/src/test/java/com/google/adk/tools/AgentToolTest.java
+++ b/core/src/test/java/com/google/adk/tools/AgentToolTest.java
@@ -43,6 +43,7 @@ import com.google.genai.types.Schema;
 import io.reactivex.rxjava3.core.Flowable;
 import io.reactivex.rxjava3.core.Maybe;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.junit.Before;
 import org.junit.Test;
@@ -881,5 +882,22 @@ public final class AgentToolTest {
                 .sessionService(sessionService)
                 .build())
         .build();
+  }
+
+  @Test
+  public void declaration_withNullDescription_usesEmptyDescription() {
+    // Create an agent with a name but NO description
+    LlmAgent testAgent =
+        LlmAgent.builder()
+            .name("TestAgent")
+            // .description() is intentionally left out
+            .build();
+
+    AgentTool tool = AgentTool.create(testAgent);
+    Optional<FunctionDeclaration> declaration = tool.declaration();
+    assertThat(declaration).isPresent();
+    assertThat(declaration.get().name()).hasValue("TestAgent");
+    // Matches the Python, Go, and Kotlin ports: a missing description becomes an empty string.
+    assertThat(declaration.get().description()).hasValue("");
   }
 }


### PR DESCRIPTION
Prevents a NullPointerException in the google-genai library when an Agent is defined without a description. Includes a regression test.

**Please ensure you have read the [contribution guide](./CONTRIBUTING.md) before creating a pull request.**

### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

- Closes: _N/A_
- Related: _N/A_

**2. Or, if no issue exists, describe the change:**

_If applicable, please follow the issue templates to provide as much detail as
possible._

**Problem:**
_Calling AgentTool.declaration() triggers a NullPointerException when an Agent is defined without an explicit description. The crash occurs because the underlying google-genai library's generated FunctionDeclaration builder uses Optional.of() for the description field, which is not null-safe._

**Solution:**
_Coerce a null description to an empty string in AgentTool.declaration() using Guava's Strings.nullToEmpty(), so the google-genai builder always receives a non-null value. This matches the Python, Go, and Kotlin ports, which send an empty description when an agent has none._

### Testing Plan

_Please describe the tests that you ran to verify your changes. This is required
for all PRs that are not small documentation or typo fixes._

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

**Summary of passed java test results:**
_Passed AgentToolTest.declaration_withNullDescription_usesEmptyDescription, which verifies that a null description no longer triggers an NPE and results in an empty description._

**Manual End-to-End (E2E) Tests:**

_Verified by running a sample agentic workflow where the Agent class lacked a description field. Previously, this resulted in a crash during tool registration; it now initializes and executes correctly._

### Checklist

- [x] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md) document.
- [x] My pull request contains a single commit.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [x] Any dependent changes have been merged and published in downstream modules.

### Additional context
Stack Trace:
java.lang.NullPointerException
at java.base/java.util.Objects.requireNonNull(Objects.java:220)
at java.base/java.util.Optional.of(Optional.java:113)
at com.google.genai.types.AutoValue_FunctionDeclaration$Builder.description(AutoValue_FunctionDeclaration.java:160)
at com.google.adk.tools.AgentTool.declaration(AgentTool.java:135)

_Note on Root Cause:
While this PR ensures stability within adk-java, the underlying issue appears to be in the google-genai library. The generated AutoValue_FunctionDeclaration.Builder uses Optional.of() for the description field, which enforces a non-null constraint. A more robust upstream fix would involve the generator using Optional.ofNullable(). This local fix is necessary to prevent crashes in the meantime._

