### PR TITLE
fix(sessions): prevent VertexAiSessionService from dropping latest events under clock skew

### DIFF
--- a/core/src/main/java/com/google/adk/sessions/VertexAiSessionService.java
+++ b/core/src/main/java/com/google/adk/sessions/VertexAiSessionService.java
@@ -225,7 +225,7 @@ public final class VertexAiSessionService implements BaseSessionService {
                         if (events.isEmpty()) {
                           return sessionBuilder.build();
                         }
-                        events = filterEvents(events, updateTimestamp, config);
+                        events = filterEvents(events, config);
                         return sessionBuilder.events(events).build();
                       })
                   .toMaybe();
@@ -233,15 +233,11 @@ public final class VertexAiSessionService implements BaseSessionService {
   }
 
   private static List<Event> filterEvents(
-      List<Event> originalEvents,
-      @Nullable Instant updateTimestamp,
-      Optional<GetSessionConfig> config) {
+      List<Event> originalEvents, Optional<GetSessionConfig> config) {
+    // Do not pre-filter by session updateTime: updateTime comes from Vertex backend clock,
+    // while Event.timestamp is client-side. Comparing them can drop valid latest events.
     List<Event> events =
         originalEvents.stream()
-            .filter(
-                event ->
-                    updateTimestamp == null
-                        || Instant.ofEpochMilli(event.timestamp()).isBefore(updateTimestamp))
             .sorted(Comparator.comparing(Event::timestamp))
             .collect(toCollection(ArrayList::new));
 
@@ -253,16 +249,10 @@ public final class VertexAiSessionService implements BaseSessionService {
         }
       } else if (config.get().afterTimestamp().isPresent()) {
         Instant afterTimestamp = config.get().afterTimestamp().get();
-        int i = events.size() - 1;
-        while (i >= 0) {
-          if (Instant.ofEpochMilli(events.get(i).timestamp()).isBefore(afterTimestamp)) {
-            break;
-          }
-          i -= 1;
-        }
-        if (i >= 0) {
-          events = events.subList(i, events.size());
-        }
+        events =
+            events.stream()
+                .filter(event -> !Instant.ofEpochMilli(event.timestamp()).isBefore(afterTimestamp))
+                .collect(toCollection(ArrayList::new));
       }
     }
     return events;

--- a/core/src/test/java/com/google/adk/sessions/VertexAiSessionServiceTest.java
+++ b/core/src/test/java/com/google/adk/sessions/VertexAiSessionServiceTest.java
@@ -70,6 +70,17 @@ public class VertexAiSessionServiceTest {
       }\
       """;
 
+  private static final String MOCK_SESSION_STRING_5 =
+      """
+      {
+        "name" : "projects/test-project/locations/test-location/reasoningEngines/123/sessions/5",
+        "createTime" : "2026-04-29T11:00:05.000000Z",
+        "userId" : "skew_user",
+        "updateTime" : "2026-04-29T11:00:05.940523Z",
+        "sessionState" : {}
+      }\
+      """;
+
   private static final String MOCK_EVENT_STRING =
       """
       [
@@ -98,6 +109,36 @@ public class VertexAiSessionServiceTest {
             "interrupted" : false,
             "branch" : "",
             "longRunningToolIds" : [ "tool1" ]
+          }
+        }
+      ]
+      """;
+
+  private static final String MOCK_EVENT_STRING_5 =
+      """
+      [
+        {
+          "name" : "projects/test-project/locations/test-location/reasoningEngines/123/sessions/5/events/500",
+          "invocationId" : "500",
+          "author" : "skew_user",
+          "timestamp" : "2026-04-29T11:00:05.900000Z",
+          "content" : {
+            "role" : "user",
+            "parts" : [
+              { "text" : "before-update-time" }
+            ]
+          }
+        },
+        {
+          "name" : "projects/test-project/locations/test-location/reasoningEngines/123/sessions/5/events/501",
+          "invocationId" : "501",
+          "author" : "model",
+          "timestamp" : "2026-04-29T11:00:06.103000Z",
+          "content" : {
+            "role" : "model",
+            "parts" : [
+              { "text" : "after-update-time" }
+            ]
           }
         }
       ]
@@ -154,8 +195,9 @@ public class VertexAiSessionServiceTest {
             ImmutableMap.of(
                 "1", MOCK_SESSION_STRING_1,
                 "2", MOCK_SESSION_STRING_2,
-                "3", MOCK_SESSION_STRING_3));
-    eventMap = new HashMap<>(ImmutableMap.of("1", MOCK_EVENT_STRING));
+                "3", MOCK_SESSION_STRING_3,
+                "5", MOCK_SESSION_STRING_5));
+    eventMap = new HashMap<>(ImmutableMap.of("1", MOCK_EVENT_STRING, "5", MOCK_EVENT_STRING_5));
 
     MockitoAnnotations.openMocks(this);
     vertexAiSessionService =
@@ -350,6 +392,44 @@ public class VertexAiSessionServiceTest {
                 .blockingGet()
                 .events())
         .isEmpty();
+  }
+
+  @Test
+  public void getSession_clockSkewWithUpdateTime_doesNotDropRecentEvents() {
+    Session session =
+        vertexAiSessionService.getSession("123", "skew_user", "5", Optional.empty()).blockingGet();
+
+    assertThat(session.events()).hasSize(2);
+    ImmutableList<String> eventIds =
+        session.events().stream().map(Event::id).collect(toImmutableList());
+    assertThat(eventIds).containsExactly("500", "501").inOrder();
+  }
+
+  @Test
+  public void getSession_afterTimestamp_filtersAtOrAfterThreshold() {
+    Instant threshold = Instant.parse("2026-04-29T11:00:06.103000Z");
+    GetSessionConfig config = GetSessionConfig.builder().afterTimestamp(threshold).build();
+
+    Session session =
+        vertexAiSessionService
+            .getSession("123", "skew_user", "5", Optional.of(config))
+            .blockingGet();
+
+    assertThat(session.events()).hasSize(1);
+    assertThat(session.events().get(0).id()).isEqualTo("501");
+  }
+
+  @Test
+  public void getSession_numRecentEvents_returnsLatestEvents() {
+    GetSessionConfig config = GetSessionConfig.builder().numRecentEvents(1).build();
+
+    Session session =
+        vertexAiSessionService
+            .getSession("123", "skew_user", "5", Optional.of(config))
+            .blockingGet();
+
+    assertThat(session.events()).hasSize(1);
+    assertThat(session.events().get(0).id()).isEqualTo("501");
   }
 
   @Test


### PR DESCRIPTION
## Summary
- Fix `VertexAiSessionService.getSession()` to stop pre-filtering events against session `updateTime`.
- Preserve all events returned by `listEvents()` and only apply explicit `GetSessionConfig` filters.
- Add regression coverage for clock-skew behavior where event timestamps can be newer than server `updateTime`.

## Why
Issue #1173 reports that `getSession()` can silently drop the most recent event(s) (notably in HITL resume flows) because it compared:
- server-side session `updateTime`
- client-side `Event.timestamp()`

Those clocks can drift, so valid latest events were filtered out.

## What changed
- In `core/src/main/java/com/google/adk/sessions/VertexAiSessionService.java`:
  - Removed the `updateTime`-based pre-filter in `filterEvents(...)`.
  - Kept deterministic sorting by event timestamp.
  - Kept config-based filtering:
    - `numRecentEvents`
    - `afterTimestamp` (inclusive behavior via `!isBefore`).

- In `core/src/test/java/com/google/adk/sessions/VertexAiSessionServiceTest.java`:
  - Added `getSession_clockSkewWithUpdateTime_doesNotDropRecentEvents`
  - Added `getSession_afterTimestamp_filtersAtOrAfterThreshold`
  - Added `getSession_numRecentEvents_returnsLatestEvents`
  - Added dedicated mock session/event fixtures reproducing skew (`event.timestamp > session.updateTime`).

## Validation
-  `./mvnw -pl core -Dtest=VertexAiSessionServiceTest test`
-  `./mvnw test` fails due to existing unrelated test/build issues outside the files changed in this PR.

## Issue
Closes #1173