### PR TITLE
fix: resolve missing trace spans in embedded AdkWebServer

### DIFF
--- a/dev/src/main/java/com/google/adk/web/config/OpenTelemetryConfig.java
+++ b/dev/src/main/java/com/google/adk/web/config/OpenTelemetryConfig.java
@@ -60,18 +60,14 @@ public class OpenTelemetryConfig {
 
     // Check if OpenTelemetry has already been set globally (common in tests)
     try {
-      io.opentelemetry.api.GlobalOpenTelemetry.get();
-      // If we get here, it's already set, so just return a new instance without global
-      // registration
-      otelLog.debug("OpenTelemetry already registered globally, creating non-global instance.");
-      return OpenTelemetrySdk.builder().setTracerProvider(sdkTracerProvider).build();
-    } catch (IllegalStateException e) {
-      // GlobalOpenTelemetry hasn't been set yet, safe to register globally
       otelLog.debug("Registering OpenTelemetry globally.");
-      OpenTelemetrySdk otelSdk =
+      OpenTelemetrySdk sdk =
           OpenTelemetrySdk.builder().setTracerProvider(sdkTracerProvider).buildAndRegisterGlobal();
-      Runtime.getRuntime().addShutdownHook(new Thread(otelSdk::close));
-      return otelSdk;
+      Runtime.getRuntime().addShutdownHook(new Thread(sdk::close));
+      return sdk;
+    } catch (IllegalStateException e) {
+      otelLog.debug("OpenTelemetry already registered globally, returning non-global instance.");
+      return OpenTelemetrySdk.builder().setTracerProvider(sdkTracerProvider).build();
     }
   }
 }


### PR DESCRIPTION
**Please ensure you have read the [contribution guide](./CONTRIBUTING.md) before creating a pull request.**

### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

- Closes: #1175

**Problem:**
When `AdkWebServer` is embedded as a child Spring Context, `OpenTelemetry` spans generated by the core Tracing utility is dropped, leaving the `Dev UI's` Trace tab completely empty. This occurs because the `Dev UI` correctly skips `GlobalOpenTelemetry` registration to avoid polluting the parent application's telemetry, but the core engine's `Tracing` utility is hardcoded to only pull from the global registry, resulting in a fallback No-Op tracer.

**Solution:**
**Core:** Added a thread-safe `Tracing.setTracer()` method in `google-adk` to allow external frameworks to inject a custom tracer.
 **Web:** Updated `OpenTelemetryConfig` in `google-adk-dev` to automatically inject its isolated SDK tracer into the core engine upon bean creation.

### Testing Plan

**Manual End-to-End (E2E) Tests:**

1. Created a Spring Boot application EnterpriseAgentApplication configured as the parent context, launching `AdkWebServer` as a child context on port 8080.

2. Disabled external `OpenTelemetry` exports in application.properties (management.otlp.tracing.export.enabled=false) to ensure strict isolation.

3. Sent multiple prompts to the compiled agent.

4. Opened the `Trace` tab in the left-hand navigation panel.

