### PR TITLE
fix: Resolve IllegalArgumentException for text MIME types in LangChain4j adapter

### DIFF
--- a/contrib/langchain4j/src/main/java/com/google/adk/models/langchain4j/LangChain4j.java
+++ b/contrib/langchain4j/src/main/java/com/google/adk/models/langchain4j/LangChain4j.java
@@ -70,6 +70,7 @@ import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
 import dev.langchain4j.model.output.TokenUsage;
 import io.reactivex.rxjava3.core.BackpressureStrategy;
 import io.reactivex.rxjava3.core.Flowable;
+import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Base64;
 import java.util.HashMap;
@@ -77,10 +78,13 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @AutoValue
 public abstract class LangChain4j extends BaseLlm {
 
+  private static final Logger logger = LoggerFactory.getLogger(LangChain4j.class);
   private static final TypeReference<Map<String, Object>> MAP_TYPE_REFERENCE =
       new TypeReference<>() {};
 
@@ -388,13 +392,12 @@ public abstract class LangChain4j extends BaseLlm {
                       .mimeType(mimeType)
                       .build());
         } else if (mimeType.startsWith("text/")
-            || "application/json".equals(mimeType)
-            || mimeType.endsWith("+json")
-            || mimeType.endsWith("+xml")) {
+            || mimeType.startsWith("application/json")
+            || mimeType.contains("+json")
+            || mimeType.contains("+xml")) {
           // TODO are there missing text based mime types?
           // TODO should we assume UTF_8?
-          lc4jContents.add(
-              TextContent.from(new String(bytes, java.nio.charset.StandardCharsets.UTF_8)));
+          lc4jContent = TextContent.from(new String(bytes, extractCharset(mimeType)));
         }
 
         if (lc4jContent != null) {
@@ -417,6 +420,22 @@ public abstract class LangChain4j extends BaseLlm {
           .toList();
     } else {
       return List.of(UserMessage.from(lc4jContents));
+    }
+  }
+
+  private Charset extractCharset(String mimeType) {
+    String charSetString = "charset=";
+    if (mimeType == null || !mimeType.toLowerCase().contains(charSetString)) {
+      return java.nio.charset.StandardCharsets.UTF_8;
+    }
+    try {
+      String[] parts = mimeType.toLowerCase().split(charSetString);
+      String charsetName = parts[1].split(";")[0].trim().replace("\"", "").replace("'", "");
+      return java.nio.charset.Charset.forName(charsetName);
+    } catch (IllegalArgumentException e) {
+      logger.warn(
+          "Invalid charset extracted from mimeType: '{}'. Falling back to UTF-8.", mimeType);
+      return java.nio.charset.StandardCharsets.UTF_8;
     }
   }
 

--- a/contrib/langchain4j/src/test/java/com/google/adk/models/langchain4j/LangChain4jTest.java
+++ b/contrib/langchain4j/src/test/java/com/google/adk/models/langchain4j/LangChain4jTest.java
@@ -993,4 +993,156 @@ class LangChain4jTest {
     assertThat(response.content()).isPresent();
     assertThat(response.content().get().parts().orElse(List.of())).isEmpty();
   }
+
+  @Test
+  @DisplayName("Should parse text/plain inlineData as TextContent without exception")
+  void testGenerateContentWithTextPlainInlineData() {
+    final String textPayload = "Hello, plain text.";
+    final Blob textBlob =
+        Blob.builder()
+            .mimeType("text/plain")
+            .data(textPayload.getBytes(java.nio.charset.StandardCharsets.UTF_8))
+            .build();
+    final Part textPart = Part.builder().inlineData(textBlob).build();
+
+    final LlmRequest llmRequest =
+        LlmRequest.builder().contents(List.of(Content.fromParts(textPart))).build();
+
+    final ChatResponse chatResponse = mock(ChatResponse.class);
+    final AiMessage aiMessage = AiMessage.from("Acknowledged.");
+    when(chatResponse.aiMessage()).thenReturn(aiMessage);
+    when(chatModel.chat(any(ChatRequest.class))).thenReturn(chatResponse);
+
+    langChain4j.generateContent(llmRequest, false).blockingFirst();
+
+    final ArgumentCaptor<ChatRequest> requestCaptor = ArgumentCaptor.forClass(ChatRequest.class);
+    verify(chatModel).chat(requestCaptor.capture());
+    final ChatRequest capturedRequest = requestCaptor.getValue();
+
+    assertThat(capturedRequest.messages()).hasSize(1);
+    assertThat(capturedRequest.messages().get(0)).isInstanceOf(UserMessage.class);
+    final UserMessage userMessage = (UserMessage) capturedRequest.messages().get(0);
+
+    assertThat(userMessage.contents()).hasSize(1);
+    assertThat(userMessage.contents().get(0))
+        .isInstanceOf(dev.langchain4j.data.message.TextContent.class);
+
+    final dev.langchain4j.data.message.TextContent textContent =
+        (dev.langchain4j.data.message.TextContent) userMessage.contents().get(0);
+    assertThat(textContent.text()).isEqualTo(textPayload);
+  }
+
+  @Test
+  @DisplayName("Should parse application/json inlineData as TextContent without exception")
+  void testGenerateContentWithApplicationJsonInlineData() {
+    final String jsonPayload = "{\"key\":\"value\"}";
+    final Blob jsonBlob =
+        Blob.builder()
+            .mimeType("application/json")
+            .data(jsonPayload.getBytes(java.nio.charset.StandardCharsets.UTF_8))
+            .build();
+    final Part jsonPart = Part.builder().inlineData(jsonBlob).build();
+
+    final LlmRequest llmRequest =
+        LlmRequest.builder().contents(List.of(Content.fromParts(jsonPart))).build();
+
+    final ChatResponse chatResponse = mock(ChatResponse.class);
+    final AiMessage aiMessage = AiMessage.from("Parsed JSON.");
+    when(chatResponse.aiMessage()).thenReturn(aiMessage);
+    when(chatModel.chat(any(ChatRequest.class))).thenReturn(chatResponse);
+
+    langChain4j.generateContent(llmRequest, false).blockingFirst();
+
+    final ArgumentCaptor<ChatRequest> requestCaptor = ArgumentCaptor.forClass(ChatRequest.class);
+    verify(chatModel).chat(requestCaptor.capture());
+    final ChatRequest capturedRequest = requestCaptor.getValue();
+
+    final UserMessage userMessage = (UserMessage) capturedRequest.messages().get(0);
+    final dev.langchain4j.data.message.TextContent textContent =
+        (dev.langchain4j.data.message.TextContent) userMessage.contents().get(0);
+    assertThat(textContent.text()).isEqualTo(jsonPayload);
+  }
+
+  @Test
+  @DisplayName(
+      "Should throw IllegalArgumentException for genuinely unsupported inlineData mime types")
+  void testGenerateContentWithUnsupportedMimeType() {
+    final Blob unsupportedBlob =
+        Blob.builder().mimeType("application/x-yaml").data(new byte[] {1, 2, 3, 4}).build();
+    final Part unsupportedPart = Part.builder().inlineData(unsupportedBlob).build();
+
+    final LlmRequest llmRequest =
+        LlmRequest.builder().contents(List.of(Content.fromParts(unsupportedPart))).build();
+
+    assertThatThrownBy(() -> langChain4j.generateContent(llmRequest, false).blockingFirst())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Unknown or unhandled mime type: application/x-yaml");
+  }
+
+  @Test
+  @DisplayName("Should extract and apply explicit charset from mimeType (e.g., UTF-16)")
+  void testGenerateContentWithExplicitCharset() {
+    final String textPayload = "Hello, this is strictly UTF-16 encoded text.";
+
+    final byte[] utf16Bytes = textPayload.getBytes(java.nio.charset.StandardCharsets.UTF_16);
+
+    final Blob textBlob =
+        Blob.builder().mimeType("text/plain; charset=utf-16").data(utf16Bytes).build();
+    final Part textPart = Part.builder().inlineData(textBlob).build();
+
+    final LlmRequest llmRequest =
+        LlmRequest.builder().contents(List.of(Content.fromParts(textPart))).build();
+
+    final ChatResponse chatResponse = mock(ChatResponse.class);
+    final AiMessage aiMessage = AiMessage.from("Acknowledged.");
+    when(chatResponse.aiMessage()).thenReturn(aiMessage);
+    when(chatModel.chat(any(ChatRequest.class))).thenReturn(chatResponse);
+
+    langChain4j.generateContent(llmRequest, false).blockingFirst();
+
+    final ArgumentCaptor<ChatRequest> requestCaptor = ArgumentCaptor.forClass(ChatRequest.class);
+    verify(chatModel).chat(requestCaptor.capture());
+    final ChatRequest capturedRequest = requestCaptor.getValue();
+
+    final UserMessage userMessage = (UserMessage) capturedRequest.messages().get(0);
+    final dev.langchain4j.data.message.TextContent textContent =
+        (dev.langchain4j.data.message.TextContent) userMessage.contents().get(0);
+
+    assertThat(textContent.text()).isEqualTo(textPayload);
+  }
+
+  @Test
+  @DisplayName("Should safely fallback to UTF-8 if provided charset is malformed or unsupported")
+  void testGenerateContentWithMalformedCharsetFallback() {
+    final String textPayload = "{\"status\": \"fallback to UTF-8 successful\"}";
+
+    final byte[] utf8Bytes = textPayload.getBytes(java.nio.charset.StandardCharsets.UTF_8);
+
+    final Blob jsonBlob =
+        Blob.builder()
+            .mimeType("application/json; charset=not-a-real-charset-12345")
+            .data(utf8Bytes)
+            .build();
+    final Part jsonPart = Part.builder().inlineData(jsonBlob).build();
+
+    final LlmRequest llmRequest =
+        LlmRequest.builder().contents(List.of(Content.fromParts(jsonPart))).build();
+
+    final ChatResponse chatResponse = mock(ChatResponse.class);
+    final AiMessage aiMessage = AiMessage.from("Fallback verified.");
+    when(chatResponse.aiMessage()).thenReturn(aiMessage);
+    when(chatModel.chat(any(ChatRequest.class))).thenReturn(chatResponse);
+
+    langChain4j.generateContent(llmRequest, false).blockingFirst();
+
+    final ArgumentCaptor<ChatRequest> requestCaptor = ArgumentCaptor.forClass(ChatRequest.class);
+    verify(chatModel).chat(requestCaptor.capture());
+    final ChatRequest capturedRequest = requestCaptor.getValue();
+
+    final UserMessage userMessage = (UserMessage) capturedRequest.messages().get(0);
+    final dev.langchain4j.data.message.TextContent textContent =
+        (dev.langchain4j.data.message.TextContent) userMessage.contents().get(0);
+
+    assertThat(textContent.text()).isEqualTo(textPayload);
+  }
 }


### PR DESCRIPTION
**Please ensure you have read the [contribution guide](./CONTRIBUTING.md) before creating a pull request.**

### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

- Closes: #1184

**Problem:**
When `LangChain4j.toUserOrToolResultMessage()` processes `inlineData` parts with text-based MIME types, it instantiates a `TextContent` object but adds it directly to the master list rather than assigning it to the local `lc4jContent` reference. this is causing the false validation for this condition `if (lc4jContent == null)` and throwing an unexpected `IllegalArgumentException`. Additionally, the existing string matching was too strict `.equals()`, causing valid payloads to fail if a charset parameter was appended like this `application/json; charset=utf-8`

**Solution:**
Modified the text MIME type matching logic to use `.startsWith()` and `.contains()` to gracefully tolerate appended parameters like boundaries or charsets.

Implemented a private `extractCharset()` helper method to dynamically read the provided character set and safely falling back to `UTF-8` if no charset provided or malformed.

Updated the control flow to assign the generated `TextContent` directly to the `lc4jContent` variable,

### Testing Plan

_Please describe the tests that you ran to verify your changes. This is required
for all PRs that are not small documentation or typo fixes._

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

Added the following methods to `LangChain4jTest.java` which all execute and pass successfully:

`testGenerateContentWithTextPlainInlineData` - Verifies standard text parsing.

`testGenerateContentWithApplicationJsonInlineData` - Verifies JSON payload parsing.

`testGenerateContentWithUnsupportedMimeType` - Verifies the unsupported types still correctly throws IllegalArgumentException for truly unhandled types.

`testGenerateContentWithExplicitCharset` - Verifies the dynamic extraction of custom charsets.

`testGenerateContentWithMalformedCharsetFallback` - Verifies safe fallback to UTF-8 when provided with unsupported charset parameters.

