### PR TITLE
fix: upgrade Mockito and JaCoCo for Java 25 compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
     <google.genai.version>1.44.0</google.genai.version>
     <protobuf.version>4.33.5</protobuf.version>
     <junit.version>5.11.4</junit.version>
-    <mockito.version>5.20.0</mockito.version>
+    <mockito.version>5.23.0</mockito.version>
     <java-websocket.version>1.6.0</java-websocket.version>
     <jackson.version>2.20.2</jackson.version>
     <okhttp.version>5.3.2</okhttp.version>
@@ -454,7 +454,7 @@
       <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
-        <version>0.8.12</version>
+        <version>0.8.14</version>
         <executions>
           <execution>
             <goals>


### PR DESCRIPTION
## Summary

- Upgrade Mockito `5.20.0` → `5.23.0`
- Upgrade JaCoCo `0.8.12` → `0.8.14`

## Problem

Both Mockito and JaCoCo bundle an ASM library that does not recognize Java 25 class file format (major version 69). Running `mvn test` on Java 25 fails with:

```
Caused by: java.lang.IllegalArgumentException: Unsupported class file major version 69
```

This happens because Java 25 was released in September 2025, after these versions were published. ASM 9.7 (bundled in the old versions) supports up to Java 24; Java 25 requires ASM 9.8+.

## Fix

Upgraded to versions released after Java 25 GA:
- Mockito 5.23.0 bundles ByteBuddy/ASM with Java 25 support
- JaCoCo 0.8.14 bundles ASM with Java 25 support

## Test plan

- [x] `mvn test -pl core` passes cleanly on Java 25
- [x] Full `mvn test` passes (1247 tests, 0 failures — the only error is `LangChain4jIntegrationTest` which requires live API credentials and was failing before this change)

