### PR TITLE
fix: Allow -latest model aliases in GoogleSearchTool

### DIFF
--- a/core/src/main/java/com/google/adk/tools/GoogleSearchTool.java
+++ b/core/src/main/java/com/google/adk/tools/GoogleSearchTool.java
@@ -62,7 +62,7 @@ public final class GoogleSearchTool extends BaseTool {
     updatedToolsBuilder.addAll(existingTools);
 
     String model = llmRequestBuilder.build().model().orElse(null);
-    if (model != null && (model.startsWith("gemini-2") || model.startsWith("gemini-3"))) {
+    if (isSupportedModel(model)) {
 
       updatedToolsBuilder.add(Tool.builder().googleSearch(GoogleSearch.builder().build()).build());
       configBuilder.tools(updatedToolsBuilder.build());
@@ -73,5 +73,14 @@ public final class GoogleSearchTool extends BaseTool {
 
     llmRequestBuilder.config(configBuilder.build());
     return Completable.complete();
+  }
+
+  private boolean isSupportedModel(String model) {
+    if (model == null || !model.startsWith("gemini-")) {
+      return false;
+    }
+    return model.startsWith("gemini-2")
+        || model.startsWith("gemini-3")
+        || model.endsWith("-latest");
   }
 }

--- a/core/src/test/java/com/google/adk/tools/BaseToolTest.java
+++ b/core/src/test/java/com/google/adk/tools/BaseToolTest.java
@@ -167,6 +167,33 @@ public final class BaseToolTest {
   }
 
   @Test
+  public void processLlmRequestWithLatestAliasAddsToolToConfig() {
+    final GoogleSearchTool googleSearchTool = new GoogleSearchTool();
+    LlmRequest.Builder builder =
+        LlmRequest.builder().model("gemini-flash-latest").build().toBuilder();
+    Completable result = googleSearchTool.processLlmRequest(builder, null);
+    result.test().assertComplete();
+    assertThat(builder.build().config().get().tools().get())
+        .contains(Tool.builder().googleSearch(GoogleSearch.builder().build()).build());
+  }
+
+  @Test
+  public void processLlmRequestWithUnsupportedModelReturnsError() {
+    final GoogleSearchTool googleSearchTool = new GoogleSearchTool();
+    LlmRequest.Builder builder = LlmRequest.builder().model("text-bison-001").build().toBuilder();
+    Completable result = googleSearchTool.processLlmRequest(builder, null);
+    result.test().assertError(IllegalArgumentException.class);
+  }
+
+  @Test
+  public void processLlmRequest_WithNullModel_ReturnsError() {
+    final GoogleSearchTool googleSearchTool = new GoogleSearchTool();
+    LlmRequest.Builder builder = LlmRequest.builder().build().toBuilder();
+    Completable result = googleSearchTool.processLlmRequest(builder, null);
+    result.test().assertError(IllegalArgumentException.class);
+  }
+
+  @Test
   public void processLlmRequestWithUrlContextToolAddsToolToConfig() {
     FunctionDeclaration functionDeclaration =
         FunctionDeclaration.builder().name("test_function").build();


### PR DESCRIPTION
**Please ensure you have read the [contribution guide](./CONTRIBUTING.md) before creating a pull request.**

### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

- Closes: #1203

**2. Or, if no issue exists, describe the change:**

_If applicable, please follow the issue templates to provide as much detail as
possible._

**Problem:**
The GoogleSearchTool checks model.startsWith("gemini-2") || model.startsWith("gemini-3"), which rejects all -latest model aliases (gemini-flash-latest, gemini-pro-latest, gemini-flash-lite-latest).

**Solution:**
Introduced the `isSupportedModel` helper method to allow model names ending with `-latest` in addition to existing models.

### Testing Plan

Added unit tests to ensure missing models return the expected `IllegalArgumentException` and that `-latest` aliases are correctly accepted.

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.


The following test cases were added to BaseToolTest:

`processLlmRequestWithLatestAliasAddsToolToConfig`: Verifies that models ending in -latest are accepted and configured correctly.

`processLlmRequestWithUnsupportedModelReturnsError`: Verifies rejection of invalid model strings.

`processLlmRequest_WithNullModel_ReturnsError`: Verifies that a null model input does not crash and throws an IllegalArgumentException as expected.

### Checklist

- [x] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md) document.
- [x] My pull request contains a single commit.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [x] Any dependent changes have been merged and published in downstream modules.



