### PR TITLE
fix: convert unsupported artifact MIME types to text

### DIFF
--- a/core/src/main/java/com/google/adk/tools/LoadArtifactsTool.java
+++ b/core/src/main/java/com/google/adk/tools/LoadArtifactsTool.java
@@ -22,7 +22,9 @@ import com.google.adk.JsonBaseModel;
 import com.google.adk.models.LlmRequest;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
+import com.google.genai.types.Blob;
 import com.google.genai.types.Content;
 import com.google.genai.types.FunctionDeclaration;
 import com.google.genai.types.FunctionResponse;
@@ -31,7 +33,9 @@ import com.google.genai.types.Schema;
 import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.Observable;
 import io.reactivex.rxjava3.core.Single;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -55,6 +59,12 @@ import java.util.Optional;
  */
 public final class LoadArtifactsTool extends BaseTool {
   public static final LoadArtifactsTool INSTANCE = new LoadArtifactsTool();
+  private static final ImmutableList<String> GEMINI_SUPPORTED_INLINE_MIME_PREFIXES =
+      ImmutableList.of("image/", "audio/", "video/");
+  private static final ImmutableSet<String> GEMINI_SUPPORTED_INLINE_MIME_TYPES =
+      ImmutableSet.of("application/pdf");
+  private static final ImmutableSet<String> TEXT_LIKE_MIME_TYPES =
+      ImmutableSet.of("application/csv", "application/json", "application/xml");
 
   public LoadArtifactsTool() {
     super("load_artifacts", "Loads the artifacts and adds them to the session.");
@@ -177,15 +187,75 @@ public final class LoadArtifactsTool extends BaseTool {
                         appendArtifactToLlmRequest(
                             llmRequestBuilder,
                             "Artifact " + artifactName + " is:",
+                            artifactName,
                             actualArtifact)));
   }
 
   private void appendArtifactToLlmRequest(
-      LlmRequest.Builder llmRequestBuilder, String prefix, Part artifact) {
+      LlmRequest.Builder llmRequestBuilder, String prefix, String artifactName, Part artifact) {
     llmRequestBuilder.contents(
         ImmutableList.<Content>builder()
             .addAll(llmRequestBuilder.build().contents())
-            .add(Content.fromParts(Part.fromText(prefix), artifact))
+            .add(Content.fromParts(Part.fromText(prefix), asSafePartForLlm(artifact, artifactName)))
             .build());
+  }
+
+  private static String normalizeMimeType(String mimeType) {
+    if (mimeType == null) {
+      return "";
+    }
+    int separatorIndex = mimeType.indexOf(';');
+    if (separatorIndex >= 0) {
+      mimeType = mimeType.substring(0, separatorIndex);
+    }
+    return mimeType.trim();
+  }
+
+  private static boolean isInlineMimeTypeSupported(String mimeType) {
+    String normalized = normalizeMimeType(mimeType);
+    if (normalized.isEmpty()) {
+      return false;
+    }
+    if (GEMINI_SUPPORTED_INLINE_MIME_TYPES.contains(normalized)) {
+      return true;
+    }
+    return GEMINI_SUPPORTED_INLINE_MIME_PREFIXES.stream().anyMatch(normalized::startsWith);
+  }
+
+  private static Part asSafePartForLlm(Part artifact, String artifactName) {
+    Optional<Blob> inlineData = artifact.inlineData();
+    if (inlineData.isEmpty()) {
+      return artifact;
+    }
+
+    Blob blob = inlineData.get();
+    if (isInlineMimeTypeSupported(blob.mimeType().orElse(null))) {
+      return artifact;
+    }
+
+    String mimeType = normalizeMimeType(blob.mimeType().orElse(null));
+    if (mimeType.isEmpty()) {
+      mimeType = "application/octet-stream";
+    }
+
+    Optional<byte[]> data = blob.data();
+    if (data.isEmpty()) {
+      return Part.fromText(
+          String.format(
+              "[Artifact: %s, type: %s. No inline data was provided.]", artifactName, mimeType));
+    }
+
+    if (mimeType.startsWith("text/") || TEXT_LIKE_MIME_TYPES.contains(mimeType)) {
+      return Part.fromText(new String(data.get(), StandardCharsets.UTF_8));
+    }
+
+    double sizeKb = data.get().length / 1024.0;
+    return Part.fromText(
+        String.format(
+            Locale.US,
+            "[Binary artifact: %s, type: %s, size: %.1f KB. Content cannot be displayed inline.]",
+            artifactName,
+            mimeType,
+            sizeKb));
   }
 }

--- a/core/src/test/java/com/google/adk/tools/LoadArtifactsToolTest.java
+++ b/core/src/test/java/com/google/adk/tools/LoadArtifactsToolTest.java
@@ -4,6 +4,7 @@ import static com.google.common.truth.Truth.assertThat;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.nullable;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
@@ -24,6 +25,7 @@ import com.google.genai.types.Part;
 import com.google.genai.types.Schema;
 import io.reactivex.rxjava3.core.Maybe;
 import io.reactivex.rxjava3.core.Single;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -217,5 +219,79 @@ public final class LoadArtifactsToolTest {
     verify(mockArtifactService, never())
         .loadArtifact(anyString(), anyString(), anyString(), anyString(), anyInt());
     assertThat(finalRequest.contents()).containsExactly(functionCallContent);
+  }
+
+  @Test
+  public void processLlmRequest_unsupportedTextLikeMime_convertsToText() {
+    String artifactName = "data.csv";
+    String csvContent = "col1,col2\n1,2\n";
+    LlmRequest finalRequest =
+        processLoadArtifactRequest(
+            artifactName,
+            Part.fromBytes(csvContent.getBytes(StandardCharsets.UTF_8), "application/csv"));
+
+    Part artifactPart = finalRequest.contents().get(1).parts().get().get(1);
+    assertThat(artifactPart.inlineData()).isEmpty();
+    assertThat(artifactPart.text()).hasValue(csvContent);
+  }
+
+  @Test
+  public void processLlmRequest_supportedMime_keepsInlineData() {
+    String artifactName = "file.pdf";
+    byte[] pdfBytes = "%PDF-1.4".getBytes(StandardCharsets.UTF_8);
+    LlmRequest finalRequest =
+        processLoadArtifactRequest(artifactName, Part.fromBytes(pdfBytes, "application/pdf"));
+
+    Part artifactPart = finalRequest.contents().get(1).parts().get().get(1);
+    assertThat(artifactPart.inlineData()).isPresent();
+    assertThat(artifactPart.inlineData().get().mimeType()).hasValue("application/pdf");
+    assertThat(artifactPart.inlineData().get().data().get()).isEqualTo(pdfBytes);
+  }
+
+  @Test
+  public void processLlmRequest_unsupportedBinaryMime_convertsToPlaceholder() {
+    String artifactName = "slides.pptx";
+    LlmRequest finalRequest =
+        processLoadArtifactRequest(
+            artifactName,
+            Part.fromBytes(
+                new byte[] {1, 2, 3},
+                "application/vnd.openxmlformats-officedocument.presentationml.presentation"));
+
+    Part artifactPart = finalRequest.contents().get(1).parts().get().get(1);
+    assertThat(artifactPart.inlineData()).isEmpty();
+    assertThat(artifactPart.text())
+        .hasValue(
+            "[Binary artifact: slides.pptx, type:"
+                + " application/vnd.openxmlformats-officedocument.presentationml.presentation,"
+                + " size: 0.0 KB. Content cannot be displayed inline.]");
+  }
+
+  private LlmRequest processLoadArtifactRequest(String artifactName, Part loadedArtifactPart) {
+    ImmutableList<String> availableArtifacts = ImmutableList.of(artifactName);
+    ImmutableList<String> artifactsToLoad = ImmutableList.of(artifactName);
+
+    FunctionResponse functionResponse =
+        FunctionResponse.builder()
+            .name("load_artifacts")
+            .response(ImmutableMap.of("artifact_names", artifactsToLoad))
+            .build();
+    Content functionCallContent =
+        Content.builder()
+            .role("model")
+            .parts(
+                ImmutableList.of(
+                    Part.fromFunctionResponse(
+                        functionResponse.name().get(), functionResponse.response().get())))
+            .build();
+    llmRequestBuilder.contents(ImmutableList.of(functionCallContent));
+
+    ToolContext spiedToolContext = spy(ToolContext.builder(mockInvocationContext).build());
+    doReturn(Single.just(availableArtifacts)).when(spiedToolContext).listArtifacts();
+    doReturn(Maybe.just(loadedArtifactPart)).when(spiedToolContext).loadArtifact(artifactName);
+
+    loadArtifactsTool.processLlmRequest(llmRequestBuilder, spiedToolContext).blockingAwait();
+    verify(spiedToolContext).loadArtifact(artifactName);
+    return llmRequestBuilder.build();
   }
 }


### PR DESCRIPTION
Fixes #1210

## Summary

`LoadArtifactsTool` currently appends loaded artifact parts directly into the next model request. This can produce invalid requests when an artifact is stored as inline data with a MIME type that Gemini does not support inline.

This change adds a model-safe conversion step before appending loaded artifacts:

- preserves supported inline media: `image/*`, `audio/*`, `video/*`, `application/pdf`
- converts text-like inline data to text parts: `text/*`, `application/csv`, `application/json`, `application/xml`
- replaces unsupported binary inline data with a short placeholder containing artifact name, MIME type, and size

The behavior mirrors the ADK Python fix from google/adk-python#4028 / fdc98d5c.

## Tests

- `JAVA_HOME=/opt/homebrew/Cellar/openjdk@17/17.0.18/libexec/openjdk.jdk/Contents/Home ./mvnw -pl core -Dtest=LoadArtifactsToolTest test`
