### PR TITLE
fix(tools): convert unsupported artifact MIME types to text in LoadArtifactsTool

### DIFF
--- a/core/src/main/java/com/google/adk/tools/LoadArtifactsTool.java
+++ b/core/src/main/java/com/google/adk/tools/LoadArtifactsTool.java
@@ -22,7 +22,9 @@ import com.google.adk.JsonBaseModel;
 import com.google.adk.models.LlmRequest;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
+import com.google.genai.types.Blob;
 import com.google.genai.types.Content;
 import com.google.genai.types.FunctionDeclaration;
 import com.google.genai.types.FunctionResponse;
@@ -31,7 +33,9 @@ import com.google.genai.types.Schema;
 import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.Observable;
 import io.reactivex.rxjava3.core.Single;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -55,6 +59,12 @@ import java.util.Optional;
  */
 public final class LoadArtifactsTool extends BaseTool {
   public static final LoadArtifactsTool INSTANCE = new LoadArtifactsTool();
+  private static final ImmutableList<String> GEMINI_SUPPORTED_INLINE_MIME_PREFIXES =
+      ImmutableList.of("image/", "audio/", "video/");
+  private static final ImmutableSet<String> GEMINI_SUPPORTED_INLINE_MIME_TYPES =
+      ImmutableSet.of("application/pdf");
+  private static final ImmutableSet<String> TEXT_LIKE_MIME_TYPES =
+      ImmutableSet.of("application/csv", "application/json", "application/xml");
 
   public LoadArtifactsTool() {
     super("load_artifacts", "Loads the artifacts and adds them to the session.");
@@ -177,15 +187,75 @@ public final class LoadArtifactsTool extends BaseTool {
                         appendArtifactToLlmRequest(
                             llmRequestBuilder,
                             "Artifact " + artifactName + " is:",
+                            artifactName,
                             actualArtifact)));
   }
 
   private void appendArtifactToLlmRequest(
-      LlmRequest.Builder llmRequestBuilder, String prefix, Part artifact) {
+      LlmRequest.Builder llmRequestBuilder, String prefix, String artifactName, Part artifact) {
     llmRequestBuilder.contents(
         ImmutableList.<Content>builder()
             .addAll(llmRequestBuilder.build().contents())
-            .add(Content.fromParts(Part.fromText(prefix), artifact))
+            .add(Content.fromParts(Part.fromText(prefix), asSafePartForLlm(artifact, artifactName)))
             .build());
+  }
+
+  private static String normalizeMimeType(String mimeType) {
+    if (mimeType == null) {
+      return "";
+    }
+    int separatorIndex = mimeType.indexOf(';');
+    if (separatorIndex >= 0) {
+      mimeType = mimeType.substring(0, separatorIndex);
+    }
+    return mimeType.trim();
+  }
+
+  private static boolean isInlineMimeTypeSupported(String mimeType) {
+    String normalized = normalizeMimeType(mimeType);
+    if (normalized.isEmpty()) {
+      return false;
+    }
+    if (GEMINI_SUPPORTED_INLINE_MIME_TYPES.contains(normalized)) {
+      return true;
+    }
+    return GEMINI_SUPPORTED_INLINE_MIME_PREFIXES.stream().anyMatch(normalized::startsWith);
+  }
+
+  private static Part asSafePartForLlm(Part artifact, String artifactName) {
+    Optional<Blob> inlineData = artifact.inlineData();
+    if (inlineData.isEmpty()) {
+      return artifact;
+    }
+
+    Blob blob = inlineData.get();
+    if (isInlineMimeTypeSupported(blob.mimeType().orElse(null))) {
+      return artifact;
+    }
+
+    String mimeType = normalizeMimeType(blob.mimeType().orElse(null));
+    if (mimeType.isEmpty()) {
+      mimeType = "application/octet-stream";
+    }
+
+    Optional<byte[]> data = blob.data();
+    if (data.isEmpty()) {
+      return Part.fromText(
+          String.format(
+              "[Artifact: %s, type: %s. No inline data was provided.]", artifactName, mimeType));
+    }
+
+    if (mimeType.startsWith("text/") || TEXT_LIKE_MIME_TYPES.contains(mimeType)) {
+      return Part.fromText(new String(data.get(), StandardCharsets.UTF_8));
+    }
+
+    double sizeKb = data.get().length / 1024.0;
+    return Part.fromText(
+        String.format(
+            Locale.US,
+            "[Binary artifact: %s, type: %s, size: %.1f KB. Content cannot be displayed inline.]",
+            artifactName,
+            mimeType,
+            sizeKb));
   }
 }

--- a/core/src/test/java/com/google/adk/tools/LoadArtifactsToolTest.java
+++ b/core/src/test/java/com/google/adk/tools/LoadArtifactsToolTest.java
@@ -4,6 +4,7 @@ import static com.google.common.truth.Truth.assertThat;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.nullable;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
@@ -17,6 +18,7 @@ import com.google.adk.models.LlmRequest;
 import com.google.adk.sessions.Session;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.genai.types.Blob;
 import com.google.genai.types.Content;
 import com.google.genai.types.FunctionDeclaration;
 import com.google.genai.types.FunctionResponse;
@@ -24,6 +26,7 @@ import com.google.genai.types.Part;
 import com.google.genai.types.Schema;
 import io.reactivex.rxjava3.core.Maybe;
 import io.reactivex.rxjava3.core.Single;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -217,5 +220,138 @@ public final class LoadArtifactsToolTest {
     verify(mockArtifactService, never())
         .loadArtifact(anyString(), anyString(), anyString(), anyString(), anyInt());
     assertThat(finalRequest.contents()).containsExactly(functionCallContent);
+  }
+
+  @Test
+  public void processLlmRequest_unsupportedTextLikeMime_convertsToText() {
+    String artifactName = "data.csv";
+    String csvContent = "col1,col2\n1,2\n";
+    Part artifactPart =
+        processLoadArtifactRequest(
+            artifactName,
+            Part.fromBytes(
+                csvContent.getBytes(StandardCharsets.UTF_8), "application/csv; charset=utf-8"));
+
+    assertThat(artifactPart.inlineData()).isEmpty();
+    assertThat(artifactPart.text()).hasValue(csvContent);
+  }
+
+  @Test
+  public void processLlmRequest_supportedMime_keepsInlineData() {
+    String artifactName = "file.pdf";
+    byte[] pdfBytes = "%PDF-1.4".getBytes(StandardCharsets.UTF_8);
+    Part artifactPart =
+        processLoadArtifactRequest(artifactName, Part.fromBytes(pdfBytes, "application/pdf"));
+
+    assertThat(artifactPart.inlineData()).isPresent();
+    assertThat(artifactPart.inlineData().get().mimeType()).hasValue("application/pdf");
+    assertThat(artifactPart.inlineData().get().data().get()).isEqualTo(pdfBytes);
+  }
+
+  @Test
+  public void processLlmRequest_unsupportedBinaryMime_convertsToPlaceholder() {
+    String artifactName = "slides.pptx";
+    Part artifactPart =
+        processLoadArtifactRequest(
+            artifactName,
+            Part.fromBytes(
+                new byte[] {1, 2, 3},
+                "application/vnd.openxmlformats-officedocument.presentationml.presentation"));
+
+    assertThat(artifactPart.inlineData()).isEmpty();
+    assertThat(artifactPart.text())
+        .hasValue(
+            "[Binary artifact: slides.pptx, type:"
+                + " application/vnd.openxmlformats-officedocument.presentationml.presentation,"
+                + " size: 0.0 KB. Content cannot be displayed inline.]");
+  }
+
+  @Test
+  public void processLlmRequest_unsupportedMimeWithoutInlineData_convertsToNoDataPlaceholder() {
+    String artifactName = "empty.bin";
+    Part artifactPart =
+        processLoadArtifactRequest(
+            artifactName,
+            Part.builder()
+                .inlineData(Blob.builder().mimeType("application/octet-stream").build())
+                .build());
+
+    assertThat(artifactPart.inlineData()).isEmpty();
+    assertThat(artifactPart.text())
+        .hasValue(
+            "[Artifact: empty.bin, type: application/octet-stream."
+                + " No inline data was provided.]");
+  }
+
+  @Test
+  public void processLlmRequest_emptyMime_defaultsToOctetStream() {
+    String artifactName = "unknown";
+    Part artifactPart =
+        processLoadArtifactRequest(
+            artifactName,
+            Part.fromBytes(new byte[] {(byte) 0xDE, (byte) 0xAD, (byte) 0xBE, (byte) 0xEF}, ""));
+
+    assertThat(artifactPart.inlineData()).isEmpty();
+    assertThat(artifactPart.text())
+        .hasValue(
+            "[Binary artifact: unknown, type: application/octet-stream,"
+                + " size: 0.0 KB. Content cannot be displayed inline.]");
+  }
+
+  @Test
+  public void processLlmRequest_nullMime_defaultsToOctetStream() {
+    String artifactName = "mystery";
+    Part artifactPart =
+        processLoadArtifactRequest(
+            artifactName,
+            Part.builder()
+                .inlineData(
+                    Blob.builder()
+                        .data(new byte[] {(byte) 0xDE, (byte) 0xAD, (byte) 0xBE, (byte) 0xEF})
+                        .build())
+                .build());
+
+    assertThat(artifactPart.inlineData()).isEmpty();
+    assertThat(artifactPart.text())
+        .hasValue(
+            "[Binary artifact: mystery, type: application/octet-stream,"
+                + " size: 0.0 KB. Content cannot be displayed inline.]");
+  }
+
+  private Part processLoadArtifactRequest(String artifactName, Part loadedArtifactPart) {
+    ImmutableList<String> availableArtifacts = ImmutableList.of(artifactName);
+    ImmutableList<String> artifactsToLoad = ImmutableList.of(artifactName);
+
+    FunctionResponse functionResponse =
+        FunctionResponse.builder()
+            .name("load_artifacts")
+            .response(ImmutableMap.of("artifact_names", artifactsToLoad))
+            .build();
+    Content functionCallContent =
+        Content.builder()
+            .role("model")
+            .parts(
+                ImmutableList.of(
+                    Part.fromFunctionResponse(
+                        functionResponse.name().get(), functionResponse.response().get())))
+            .build();
+    llmRequestBuilder.contents(ImmutableList.of(functionCallContent));
+
+    ToolContext spiedToolContext = spy(ToolContext.builder(mockInvocationContext).build());
+    doReturn(Single.just(availableArtifacts)).when(spiedToolContext).listArtifacts();
+    doReturn(Maybe.just(loadedArtifactPart)).when(spiedToolContext).loadArtifact(artifactName);
+
+    loadArtifactsTool.processLlmRequest(llmRequestBuilder, spiedToolContext).blockingAwait();
+    verify(spiedToolContext).loadArtifact(artifactName);
+
+    LlmRequest finalRequest = llmRequestBuilder.build();
+    assertThat(finalRequest.contents()).hasSize(2);
+    Content appendedContent = finalRequest.contents().get(1);
+    assertThat(appendedContent.role()).hasValue("user");
+    assertThat(appendedContent.parts()).isPresent();
+    assertThat(appendedContent.parts().get()).hasSize(2);
+    assertThat(appendedContent.parts().get().get(0).text())
+        .hasValue("Artifact " + artifactName + " is:");
+    return appendedContent.parts().get().get(1);
   }
 }


### PR DESCRIPTION
### Link to Issue or Description of Change

- Closes: #1213

**Problem:**

`LoadArtifactsTool` appends loaded artifact parts directly into the next model request. When the inline MIME is not accepted by Gemini, the follow-up request fails with `Unsupported MIME Type` instead of continuing with usable context. Same class of issue as adk-python #4028 (fixed by commit `fdc98d5c`).

**Solution:**

Before appending a loaded artifact, classify its MIME type and fall back to a model-safe part:

- keep inline media supported by Gemini unchanged: `image/*`, `audio/*`, `video/*`, `application/pdf`
- convert text-like inline data to text: `text/*`, `application/csv`, `application/json`, `application/xml`
- replace unsupported binary inline data with a short placeholder that includes the artifact name, MIME type, and size

MIME normalization strips the `;charset=...` parameter, so `application/csv; charset=utf-8` is handled the same as `application/csv`.

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

Added five cases covering the fallback paths:

- `processLlmRequest_unsupportedTextLikeMime_convertsToText`
- `processLlmRequest_supportedMime_keepsInlineData`
- `processLlmRequest_unsupportedBinaryMime_convertsToPlaceholder`
- `processLlmRequest_unsupportedMimeWithoutInlineData_convertsToNoDataPlaceholder`
- `processLlmRequest_emptyMime_defaultsToOctetStream`

```
$ ./mvnw -pl core test -Dtest=LoadArtifactsToolTest -DfailIfNoTests=false
[INFO] Tests run: 12, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```

12/12 pass.

**Manual End-to-End (E2E) Tests:**

Adapted `contrib/samples/helloworld` locally (not part of this PR) as a temporary driver: saved a `weather.csv` artifact with `application/csv` inline MIME and asked the agent to describe it against the live Gemini API. The agent loaded the artifact, the fallback converted the inline csv to a text part, and the model produced an accurate description:

```
Saved weather.csv as version 0 with MIME application/csv.
=== E2E: LoadArtifactsTool with application/csv (unsupported inline MIME) ===
Function Call: load_artifacts(artifact_names=[weather.csv])
Function Response: load_artifacts -> {artifact_names=[weather.csv]}
The weather.csv artifact is a CSV file containing weather data. It has two
columns: "city" and "temperature". The file contains temperature readings for
three cities: Seoul (12 degrees), Tokyo (18 degrees), and Singapore (30 degrees).
=== Done ===
```

Without the fallback, this request fails with `Unsupported MIME Type` before the model can respond.

### Checklist

- [x] I have read the CONTRIBUTING.md document.
- [x] My pull request contains a single commit.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [x] Any dependent changes have been merged and published in downstream modules.

### Additional context

Ports the behavior introduced in adk-python by commit `fdc98d5c` (Close #4028). Follows the "Alignment with adk-python" section of CONTRIBUTING.md.
