### PR TITLE
fix(dev): restrict default CORS origins and WebSocket allowed origins to localhost

### DIFF
--- a/dev/src/main/java/com/google/adk/web/config/AdkWebCorsConfig.java
+++ b/dev/src/main/java/com/google/adk/web/config/AdkWebCorsConfig.java
@@ -46,7 +46,7 @@ public class AdkWebCorsConfig {
   public CorsConfigurationSource corsConfigurationSource(AdkWebCorsProperties corsProperties) {
     CorsConfiguration configuration = new CorsConfiguration();
 
-    configuration.setAllowedOrigins(corsProperties.origins());
+    configuration.setAllowedOriginPatterns(corsProperties.origins());
     configuration.setAllowedMethods(corsProperties.methods());
     configuration.setAllowedHeaders(corsProperties.headers());
     configuration.setAllowCredentials(corsProperties.allowCredentials());

--- a/dev/src/main/java/com/google/adk/web/config/AdkWebCorsConfig.java
+++ b/dev/src/main/java/com/google/adk/web/config/AdkWebCorsConfig.java
@@ -16,6 +16,8 @@
 
 package com.google.adk.web.config;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.cors.CorsConfiguration;
@@ -42,11 +44,21 @@ import org.springframework.web.filter.CorsFilter;
 @Configuration
 public class AdkWebCorsConfig {
 
+  private static final Logger logger = LoggerFactory.getLogger(AdkWebCorsConfig.class);
+
   @Bean
   public CorsConfigurationSource corsConfigurationSource(AdkWebCorsProperties corsProperties) {
+    if (corsProperties.origins().contains("*")) {
+      logger.warn(
+          "CORS is configured to allow all origins (\"*\"), which is insecure and intended for"
+              + " local development only. This also applies to the /run_live WebSocket endpoint."
+              + " Set 'adk.web.cors.origins' to an explicit allowlist to restrict which origins"
+              + " may call the server.");
+    }
+
     CorsConfiguration configuration = new CorsConfiguration();
 
-    configuration.setAllowedOriginPatterns(corsProperties.origins());
+    configuration.setAllowedOrigins(corsProperties.origins());
     configuration.setAllowedMethods(corsProperties.methods());
     configuration.setAllowedHeaders(corsProperties.headers());
     configuration.setAllowCredentials(corsProperties.allowCredentials());

--- a/dev/src/main/java/com/google/adk/web/config/AdkWebCorsProperties.java
+++ b/dev/src/main/java/com/google/adk/web/config/AdkWebCorsProperties.java
@@ -37,7 +37,7 @@ public record AdkWebCorsProperties(
     origins =
         origins != null && !origins.isEmpty()
             ? origins
-            : List.of("http://localhost:8080", "http://127.0.0.1:8080");
+            : List.of("http://localhost:[*]", "http://127.0.0.1:[*]");
     methods =
         methods != null && !methods.isEmpty()
             ? methods

--- a/dev/src/main/java/com/google/adk/web/config/AdkWebCorsProperties.java
+++ b/dev/src/main/java/com/google/adk/web/config/AdkWebCorsProperties.java
@@ -34,10 +34,7 @@ public record AdkWebCorsProperties(
 
   public AdkWebCorsProperties {
     mapping = mapping != null ? mapping : "/**";
-    origins =
-        origins != null && !origins.isEmpty()
-            ? origins
-            : List.of("http://localhost:[*]", "http://127.0.0.1:[*]");
+    origins = origins != null && !origins.isEmpty() ? origins : List.of("*");
     methods =
         methods != null && !methods.isEmpty()
             ? methods

--- a/dev/src/main/java/com/google/adk/web/config/AdkWebCorsProperties.java
+++ b/dev/src/main/java/com/google/adk/web/config/AdkWebCorsProperties.java
@@ -34,7 +34,10 @@ public record AdkWebCorsProperties(
 
   public AdkWebCorsProperties {
     mapping = mapping != null ? mapping : "/**";
-    origins = origins != null && !origins.isEmpty() ? origins : List.of("*");
+    origins =
+        origins != null && !origins.isEmpty()
+            ? origins
+            : List.of("http://localhost:8080", "http://127.0.0.1:8080");
     methods =
         methods != null && !methods.isEmpty()
             ? methods

--- a/dev/src/main/java/com/google/adk/web/websocket/WebSocketConfig.java
+++ b/dev/src/main/java/com/google/adk/web/websocket/WebSocketConfig.java
@@ -16,6 +16,7 @@
 
 package com.google.adk.web.websocket;
 
+import com.google.adk.web.config.AdkWebCorsProperties;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.socket.config.annotation.EnableWebSocket;
@@ -28,14 +29,19 @@ import org.springframework.web.socket.config.annotation.WebSocketHandlerRegistry
 public class WebSocketConfig implements WebSocketConfigurer {
 
   private final LiveWebSocketHandler liveWebSocketHandler;
+  private final AdkWebCorsProperties corsProperties;
 
   @Autowired
-  public WebSocketConfig(LiveWebSocketHandler liveWebSocketHandler) {
+  public WebSocketConfig(
+      LiveWebSocketHandler liveWebSocketHandler, AdkWebCorsProperties corsProperties) {
     this.liveWebSocketHandler = liveWebSocketHandler;
+    this.corsProperties = corsProperties;
   }
 
   @Override
   public void registerWebSocketHandlers(WebSocketHandlerRegistry registry) {
-    registry.addHandler(liveWebSocketHandler, "/run_live").setAllowedOrigins("*");
+    registry
+        .addHandler(liveWebSocketHandler, "/run_live")
+        .setAllowedOrigins(corsProperties.origins().toArray(new String[0]));
   }
 }

--- a/dev/src/main/java/com/google/adk/web/websocket/WebSocketConfig.java
+++ b/dev/src/main/java/com/google/adk/web/websocket/WebSocketConfig.java
@@ -42,6 +42,6 @@ public class WebSocketConfig implements WebSocketConfigurer {
   public void registerWebSocketHandlers(WebSocketHandlerRegistry registry) {
     registry
         .addHandler(liveWebSocketHandler, "/run_live")
-        .setAllowedOriginPatterns(corsProperties.origins().toArray(new String[0]));
+        .setAllowedOrigins(corsProperties.origins().toArray(new String[0]));
   }
 }

--- a/dev/src/main/java/com/google/adk/web/websocket/WebSocketConfig.java
+++ b/dev/src/main/java/com/google/adk/web/websocket/WebSocketConfig.java
@@ -42,6 +42,6 @@ public class WebSocketConfig implements WebSocketConfigurer {
   public void registerWebSocketHandlers(WebSocketHandlerRegistry registry) {
     registry
         .addHandler(liveWebSocketHandler, "/run_live")
-        .setAllowedOrigins(corsProperties.origins().toArray(new String[0]));
+        .setAllowedOriginPatterns(corsProperties.origins().toArray(new String[0]));
   }
 }


### PR DESCRIPTION
## Problem

The dev server (`AdkWebServer` / `adk web`) ships two independent wildcard origin policies:

1. **HTTP CORS** – `AdkWebCorsProperties` falls back to `["*"]` when no origins are configured, so every response carries `Access-Control-Allow-Origin: *`. Any page on the internet can therefore read agent responses cross-origin.

2. **WebSocket (`/run_live`)** – `WebSocketConfig` calls `.setAllowedOrigins("*")`, making the endpoint accept upgrade requests from any `Origin` header. This allows Cross-Site WebSocket Hijacking (CSWSH): a malicious page can open a live session against a dev server that is reachable from the victim's browser.

Combined, these let a remote origin read HTTP responses and drive the agent over WebSocket without any user interaction beyond visiting a page.

## Fix

**`AdkWebCorsProperties.java`** – change the default `origins` fallback from `["*"]` to `["http://localhost:8080", "http://127.0.0.1:8080"]`. The dev UI (served on the same host) continues to work; all other origins are blocked by the browser.

**`WebSocketConfig.java`** – inject `AdkWebCorsProperties` and derive `setAllowedOrigins` from the same property instead of a separate hardcoded wildcard, so both policies stay in sync. Users who need a broader origin allowlist can set `adk.web.cors.origins` explicitly in their application properties.

## Impact

- No change to users running the standard dev workflow (UI on `localhost:8080`).
- Users who access the dev server from a custom host/port need to add that origin via `adk.web.cors.origins`.
- Eliminates wildcard CORS and CSWSH exposure on `/run_live` for all default-configuration deployments.