### PR TITLE
fix: Fix RxJava tracing context propagation

### DIFF
--- a/core/src/main/java/com/google/adk/agents/BaseAgent.java
+++ b/core/src/main/java/com/google/adk/agents/BaseAgent.java
@@ -323,11 +323,12 @@ public abstract class BaseAgent {
   private Flowable<Event> run(
       InvocationContext parentContext,
       Function<InvocationContext, Flowable<Event>> runImplementation) {
-    Context otelContext = Context.current();
     return Flowable.using(
-        () ->
-            Instrumentation.recordAgentInvocation(
-                createInvocationContext(parentContext), this, otelContext),
+        () -> {
+          Context otelContext = Context.current();
+          return Instrumentation.recordAgentInvocation(
+              createInvocationContext(parentContext), this, otelContext);
+        },
         agentInvocation -> {
           InvocationContext invocationContext = agentInvocation.getCtx();
           Flowable<Event> mainAndAfterEvents =

--- a/core/src/main/java/com/google/adk/flows/llmflows/BaseLlmFlow.java
+++ b/core/src/main/java/com/google/adk/flows/llmflows/BaseLlmFlow.java
@@ -218,74 +218,87 @@ public abstract class BaseLlmFlow implements BaseFlow {
       Event eventForCallbackUsage) {
     LlmRequest.Builder llmRequestBuilder = llmRequest.toBuilder();
 
-    return handleBeforeModelCallback(context, llmRequestBuilder, eventForCallbackUsage)
-        .toFlowable()
-        .concatMap(
-            llmResp ->
-                postprocess(
-                    context,
-                    eventForCallbackUsage,
-                    llmRequestBuilder.build(),
-                    llmResp,
-                    spanContext))
-        .switchIfEmpty(
-            Flowable.defer(
-                () -> {
-                  LlmAgent agent = (LlmAgent) context.agent();
-                  BaseLlm llm =
-                      agent.resolvedModel().model().isPresent()
-                          ? agent.resolvedModel().model().get()
-                          : LlmRegistry.getLlm(agent.resolvedModel().modelName().get());
-                  LlmRequest finalLlmRequest = llmRequestBuilder.build();
+    return Flowable.defer(
+        () -> {
+          Span span =
+              Tracing.getTracer().spanBuilder("call_llm").setParent(spanContext).startSpan();
+          Context callLlmContext = spanContext.with(span);
 
-                  Span span =
-                      Tracing.getTracer()
-                          .spanBuilder("call_llm")
-                          .setParent(spanContext)
-                          .startSpan();
-                  Context callLlmContext = spanContext.with(span);
-
-                  Flowable<Event> flowable =
-                      llm.generateContent(
-                              finalLlmRequest,
-                              context.runConfig().streamingMode() == StreamingMode.SSE)
-                          .onErrorResumeNext(
-                              exception ->
-                                  handleOnModelErrorCallback(
-                                          context,
-                                          llmRequestBuilder,
-                                          eventForCallbackUsage,
-                                          exception)
-                                      .switchIfEmpty(Single.error(exception))
-                                      .toFlowable())
-                          .doOnError(
-                              error -> {
-                                span.setStatus(StatusCode.ERROR, error.getMessage());
-                                span.recordException(error);
-                              })
+          return Tracing.traceFlowable(
+                  callLlmContext,
+                  span,
+                  () ->
+                      handleBeforeModelCallback(context, llmRequestBuilder, eventForCallbackUsage)
+                          .toFlowable()
                           .concatMap(
-                              llmResp ->
-                                  handleAfterModelCallback(context, llmResp, eventForCallbackUsage)
-                                      .toFlowable())
-                          .flatMap(
                               llmResp ->
                                   postprocess(
                                           context,
                                           eventForCallbackUsage,
-                                          finalLlmRequest,
+                                          llmRequestBuilder.build(),
                                           llmResp,
                                           callLlmContext)
                                       .doOnSubscribe(
-                                          s ->
+                                          subscription ->
                                               traceCallLlm(
                                                   span,
                                                   context,
                                                   eventForCallbackUsage.id(),
-                                                  finalLlmRequest,
-                                                  llmResp)));
+                                                  llmRequestBuilder.build(),
+                                                  llmResp)))
+                          .switchIfEmpty(
+                              Flowable.defer(
+                                  () -> {
+                                    LlmAgent agent = (LlmAgent) context.agent();
+                                    BaseLlm llm =
+                                        agent.resolvedModel().model().isPresent()
+                                            ? agent.resolvedModel().model().get()
+                                            : LlmRegistry.getLlm(
+                                                agent.resolvedModel().modelName().get());
+                                    LlmRequest finalLlmRequest = llmRequestBuilder.build();
 
-                  return Tracing.traceFlowable(callLlmContext, span, () -> flowable);
-                }));
+                                    return llm.generateContent(
+                                            finalLlmRequest,
+                                            context.runConfig().streamingMode()
+                                                == StreamingMode.SSE)
+                                        .onErrorResumeNext(
+                                            exception ->
+                                                handleOnModelErrorCallback(
+                                                        context,
+                                                        llmRequestBuilder,
+                                                        eventForCallbackUsage,
+                                                        exception)
+                                                    .switchIfEmpty(Single.error(exception))
+                                                    .toFlowable())
+                                        .doOnError(
+                                            error -> {
+                                              span.setStatus(StatusCode.ERROR, error.getMessage());
+                                              span.recordException(error);
+                                            })
+                                        .concatMap(
+                                            llmResp ->
+                                                handleAfterModelCallback(
+                                                        context, llmResp, eventForCallbackUsage)
+                                                    .toFlowable())
+                                        .flatMap(
+                                            llmResp ->
+                                                postprocess(
+                                                        context,
+                                                        eventForCallbackUsage,
+                                                        finalLlmRequest,
+                                                        llmResp,
+                                                        callLlmContext)
+                                                    .doOnSubscribe(
+                                                        subscription ->
+                                                            traceCallLlm(
+                                                                span,
+                                                                context,
+                                                                eventForCallbackUsage.id(),
+                                                                finalLlmRequest,
+                                                                llmResp)));
+                                  })))
+              .compose(Tracing.withContext(spanContext));
+        });
   }
 
   /**
@@ -667,10 +680,12 @@ public abstract class BaseLlmFlow implements BaseFlow {
                                     "Agent not found: " + event.actions().transferToAgent().get());
                               }
                               Flowable<Event> nextAgentEvents =
-                                  nextAgent
-                                      .get()
-                                      .runLive(invocationContext)
-                                      .compose(Tracing.withContext(spanContext));
+                                  Flowable.defer(
+                                      () -> {
+                                        try (Scope scope = spanContext.makeCurrent()) {
+                                          return nextAgent.get().runLive(invocationContext);
+                                        }
+                                      });
                               events = Flowable.concat(events, nextAgentEvents);
                             }
                             return events;
@@ -693,11 +708,12 @@ public abstract class BaseLlmFlow implements BaseFlow {
                           });
 
               return Tracing.traceFlowable(
-                  callLlmContext,
-                  span,
-                  () ->
-                      receiveFlow.takeWhile(
-                          event -> !event.actions().endInvocation().orElse(false)));
+                      callLlmContext,
+                      span,
+                      () ->
+                          receiveFlow.takeWhile(
+                              event -> !event.actions().endInvocation().orElse(false)))
+                  .compose(Tracing.withContext(spanContext));
             }));
   }
 

--- a/core/src/main/java/com/google/adk/runner/Runner.java
+++ b/core/src/main/java/com/google/adk/runner/Runner.java
@@ -485,9 +485,9 @@ public class Runner {
     Preconditions.checkNotNull(session, "session cannot be null");
     Preconditions.checkNotNull(newMessage, "newMessage cannot be null");
     Preconditions.checkNotNull(runConfig, "runConfig cannot be null");
-    Context capturedContext = Context.current();
     return Flowable.defer(
             () -> {
+              Context capturedContext = Context.current();
               BaseAgent rootAgent = this.agent;
               String invocationId = InvocationContext.newInvocationContextId();
 

--- a/core/src/main/java/com/google/adk/telemetry/Tracing.java
+++ b/core/src/main/java/com/google/adk/telemetry/Tracing.java
@@ -560,7 +560,8 @@ public class Tracing {
       return Flowable.defer(
           () -> {
             TracingLifecycle lifecycle = new TracingLifecycle();
-            Flowable<T> pipeline = upstream.doOnSubscribe(s -> lifecycle.start());
+            lifecycle.start();
+            Flowable<T> pipeline = upstream;
             if (onSuccessConsumer != null) {
               pipeline = pipeline.doOnNext(t -> onSuccessConsumer.accept(lifecycle.span, t));
             }
@@ -573,7 +574,8 @@ public class Tracing {
       return Single.defer(
           () -> {
             TracingLifecycle lifecycle = new TracingLifecycle();
-            Single<T> pipeline = upstream.doOnSubscribe(s -> lifecycle.start());
+            lifecycle.start();
+            Single<T> pipeline = upstream;
             if (onSuccessConsumer != null) {
               pipeline = pipeline.doOnSuccess(t -> onSuccessConsumer.accept(lifecycle.span, t));
             }
@@ -586,7 +588,8 @@ public class Tracing {
       return Maybe.defer(
           () -> {
             TracingLifecycle lifecycle = new TracingLifecycle();
-            Maybe<T> pipeline = upstream.doOnSubscribe(s -> lifecycle.start());
+            lifecycle.start();
+            Maybe<T> pipeline = upstream;
             if (onSuccessConsumer != null) {
               pipeline = pipeline.doOnSuccess(t -> onSuccessConsumer.accept(lifecycle.span, t));
             }
@@ -599,7 +602,8 @@ public class Tracing {
       return Completable.defer(
           () -> {
             TracingLifecycle lifecycle = new TracingLifecycle();
-            return upstream.doOnSubscribe(s -> lifecycle.start()).doFinally(lifecycle::end);
+            lifecycle.start();
+            return upstream.doFinally(lifecycle::end);
           });
     }
   }

--- a/core/src/test/java/com/google/adk/telemetry/ContextPropagationTest.java
+++ b/core/src/test/java/com/google/adk/telemetry/ContextPropagationTest.java
@@ -62,6 +62,7 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -213,6 +214,70 @@ public class ContextPropagationTest {
     SpanData transformerSpanData = findSpanByName("transformer");
     assertParent(parentSpanData, transformerSpanData);
     assertTrue(transformerSpanData.hasEnded());
+  }
+
+  @Test
+  public void testTraceTransformerStartsSpanBeforeSubscribingToDeferredUpstream()
+      throws InterruptedException {
+    Span parentSpan = tracer.spanBuilder("parent").startSpan();
+    AtomicReference<String> flowableSpanId = new AtomicReference<>();
+    AtomicReference<String> singleSpanId = new AtomicReference<>();
+    AtomicReference<String> maybeSpanId = new AtomicReference<>();
+    AtomicReference<String> completableSpanId = new AtomicReference<>();
+
+    try (Scope s = parentSpan.makeCurrent()) {
+      Flowable.defer(
+              () -> {
+                flowableSpanId.set(Span.current().getSpanContext().getSpanId());
+                return Flowable.just(1);
+              })
+          .compose(Tracing.trace("flowable-transformer"))
+          .test()
+          .await()
+          .assertComplete();
+
+      Single.defer(
+              () -> {
+                singleSpanId.set(Span.current().getSpanContext().getSpanId());
+                return Single.just(1);
+              })
+          .compose(Tracing.trace("single-transformer"))
+          .test()
+          .await()
+          .assertComplete();
+
+      Maybe.defer(
+              () -> {
+                maybeSpanId.set(Span.current().getSpanContext().getSpanId());
+                return Maybe.just(1);
+              })
+          .compose(Tracing.trace("maybe-transformer"))
+          .test()
+          .await()
+          .assertComplete();
+
+      Completable.defer(
+              () -> {
+                completableSpanId.set(Span.current().getSpanContext().getSpanId());
+                return Completable.complete();
+              })
+          .compose(Tracing.trace("completable-transformer"))
+          .test()
+          .await()
+          .assertComplete();
+    } finally {
+      parentSpan.end();
+    }
+
+    SpanData parentSpanData = findSpanByName("parent");
+    assertDeferredUpstreamSawTransformerSpan(
+        parentSpanData, findSpanByName("flowable-transformer"), flowableSpanId);
+    assertDeferredUpstreamSawTransformerSpan(
+        parentSpanData, findSpanByName("single-transformer"), singleSpanId);
+    assertDeferredUpstreamSawTransformerSpan(
+        parentSpanData, findSpanByName("maybe-transformer"), maybeSpanId);
+    assertDeferredUpstreamSawTransformerSpan(
+        parentSpanData, findSpanByName("completable-transformer"), completableSpanId);
   }
 
   @Test
@@ -505,6 +570,38 @@ public class ContextPropagationTest {
   }
 
   @Test
+  public void testModelCallbacksObserveCallLlmSpan() throws InterruptedException {
+    TestLlm testLlm =
+        TestUtils.createTestLlm(
+            TestUtils.createLlmResponse(Content.fromParts(Part.fromText("response"))));
+    AtomicReference<String> beforeModelSpanId = new AtomicReference<>();
+    AtomicReference<String> afterModelSpanId = new AtomicReference<>();
+
+    LlmAgent agentWithCallbacks =
+        LlmAgent.builder()
+            .name("test_agent")
+            .description("description")
+            .model(testLlm)
+            .beforeModelCallback(
+                (callbackContext, llmRequest) -> {
+                  beforeModelSpanId.set(Span.current().getSpanContext().getSpanId());
+                  return Maybe.empty();
+                })
+            .afterModelCallback(
+                (callbackContext, llmResponse) -> {
+                  afterModelSpanId.set(Span.current().getSpanContext().getSpanId());
+                  return Maybe.empty();
+                })
+            .build();
+
+    runAgent(agentWithCallbacks);
+
+    SpanData callLlm = findSpanByName("call_llm");
+    assertEquals(callLlm.getSpanContext().getSpanId(), beforeModelSpanId.get());
+    assertEquals(callLlm.getSpanContext().getSpanId(), afterModelSpanId.get());
+  }
+
+  @Test
   public void testAgentWithToolCallTraceHierarchy() throws InterruptedException {
     // This test verifies the trace hierarchy created when an agent calls an LLM,
     // which then invokes a tool. The expected hierarchy is:
@@ -634,9 +731,9 @@ public class ContextPropagationTest {
     assertParent(agentASpan, agentACallLlm1);
     //         ├── execute_tool transfer_to_agent
     assertParent(agentACallLlm1, executeTool);
-    //         └── invoke_agent AgentB
-    assertParent(agentACallLlm1, agentBSpan);
-    //             └── call_llm 2
+    //     └── invoke_agent AgentB
+    assertParent(agentASpan, agentBSpan);
+    //         └── call_llm 2
     assertParent(agentBSpan, agentBCallLlm);
   }
 
@@ -683,6 +780,13 @@ public class ContextPropagationTest {
    */
   private void assertParent(SpanData parent, SpanData child) {
     assertEquals(parent.getSpanContext().getSpanId(), child.getParentSpanContext().getSpanId());
+  }
+
+  private void assertDeferredUpstreamSawTransformerSpan(
+      SpanData parent, SpanData transformer, AtomicReference<String> observedSpanId) {
+    assertParent(parent, transformer);
+    assertTrue(transformer.hasEnded());
+    assertEquals(transformer.getSpanContext().getSpanId(), observedSpanId.get());
   }
 
   /**


### PR DESCRIPTION
### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

- Closes: #1252
- Related: #1235

**Problem:**
ADK Java plugin callbacks are not consistently invoked with the semantically correct OpenTelemetry span as Span.current(). This affects plugin authors who enrich ADK-created spans using:

```
Span.current().setAttribute(...);
```

**Solution:**
- **`Tracing.TracerProvider`** — Start spans before subscribing to upstream streams, instead of in `doOnSubscribe`. This ensures deferred RxJava sources see the tracing span as `Span.current()`.

- **`Runner#runAsyncImpl`** — Capture `Context.current()` inside `Flowable.defer(...)` so the runner captures execution-time context, not stale assembly-time context.

- **`BaseAgent#run`** — Capture the parent context inside deferred execution so `invoke_agent` is correctly parented under the active `invocation` span.

- **`BaseLlmFlow#callLlm`** — Create the `call_llm` span before `beforeModelCallback`, so `beforeModelCallback`, model execution, `afterModelCallback`, and model error callbacks share the same `call_llm` span.

- **`BaseLlmFlow#callLlm`** — Re-scope emissions back to the parent context after the LLM segment, preventing follow-up tool/agent/LLM work from inheriting the previous `call_llm` context.

### Testing Plan

- **`ContextPropagationTest`** — Add coverage proving `Tracing.trace(...)` starts spans before deferred upstream code runs.
-  Existing coverage - **`ContextPropagationTest#testAgentWithToolCallTraceHierarchy`** and **`ContextPropagationTest#runnerRunAsync_propagatesContext`** which checks context propgation and hierarchy. Added **`testModelCallbacksObserveCallLlmSpan`** to check that the callbacks sees the correct current span.

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

**Manual End-to-End (E2E) Tests:**

Hierarchy remains correct
<img width="1617" height="366" alt="Screenshot 2026-06-09 at 10 41 40 pm" src="https://github.com/user-attachments/assets/fa863c47-7f0b-4656-9380-13985a014d9d" />

With context propgation 
<img width="1613" height="603" alt="Screenshot 2026-06-09 at 10 42 06 pm" src="https://github.com/user-attachments/assets/bb480556-29f0-4361-a04e-939235d385e7" />

### Checklist

- [x] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md) document.
- [x] My pull request contains a single commit.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [x] Any dependent changes have been merged and published in downstream modules.