### PR TITLE
fix: ignore usage-only responses (except for BIDI mode)

### DIFF
--- a/core/src/main/java/com/google/adk/flows/llmflows/BaseLlmFlow.java
+++ b/core/src/main/java/com/google/adk/flows/llmflows/BaseLlmFlow.java
@@ -743,7 +743,8 @@ public abstract class BaseLlmFlow implements BaseFlow {
         && updatedResponse.errorCode().isEmpty()
         && !updatedResponse.interrupted().orElse(false)
         && !updatedResponse.turnComplete().orElse(false)
-        && updatedResponse.usageMetadata().isEmpty()
+        && (context.runConfig().streamingMode() != StreamingMode.BIDI
+            || updatedResponse.usageMetadata().isEmpty())
         && updatedResponse.inputTranscription().isEmpty()
         && updatedResponse.outputTranscription().isEmpty()) {
       return processorEvents;

--- a/core/src/test/java/com/google/adk/flows/llmflows/BaseLlmFlowTest.java
+++ b/core/src/test/java/com/google/adk/flows/llmflows/BaseLlmFlowTest.java
@@ -31,6 +31,7 @@ import com.google.adk.agents.Callbacks;
 import com.google.adk.agents.InvocationContext;
 import com.google.adk.agents.LlmAgent;
 import com.google.adk.agents.ReadonlyContext;
+import com.google.adk.agents.RunConfig;
 import com.google.adk.events.Event;
 import com.google.adk.flows.llmflows.RequestProcessor.RequestProcessingResult;
 import com.google.adk.flows.llmflows.ResponseProcessor.ResponseProcessingResult;
@@ -834,7 +835,7 @@ public final class BaseLlmFlowTest {
   }
 
   @Test
-  public void postprocess_noResponseProcessors_onlyUsageMetadata_returnsEvent() {
+  public void postprocess_noResponseProcessors_onlyUsageMetadata_returnsNoEvent() {
     GenerateContentResponseUsageMetadata usageMetadata =
         createGenerateContentResponseUsageMetadata().build();
     LlmResponse llmResponse = LlmResponse.builder().usageMetadata(usageMetadata).build();
@@ -858,12 +859,40 @@ public final class BaseLlmFlowTest {
             .toList()
             .blockingGet();
 
+    assertThat(events).isEmpty();
+  }
+
+  @Test
+  public void postprocess_bidiUsageMetadataOnlyResponse_returnsEvent() {
+    GenerateContentResponseUsageMetadata usageMetadata =
+        createGenerateContentResponseUsageMetadata().build();
+    LlmResponse llmResponse = LlmResponse.builder().usageMetadata(usageMetadata).build();
+    InvocationContext invocationContext =
+        createInvocationContext(
+            createTestAgent(createTestLlm(llmResponse)),
+            RunConfig.builder().setStreamingMode(RunConfig.StreamingMode.BIDI).build());
+    BaseLlmFlow baseLlmFlow = createBaseLlmFlowWithoutProcessors();
+    Event baseEvent =
+        Event.builder()
+            .invocationId(invocationContext.invocationId())
+            .author(invocationContext.agent().name())
+            .build();
+
+    List<Event> events =
+        baseLlmFlow
+            .postprocess(
+                invocationContext,
+                baseEvent,
+                LlmRequest.builder().build(),
+                llmResponse,
+                Context.current())
+            .toList()
+            .blockingGet();
+
     assertThat(events).hasSize(1);
     Event event = getOnlyElement(events);
     assertThat(event.content()).isEmpty();
     assertThat(event.usageMetadata()).hasValue(usageMetadata);
-    assertThat(event.author()).isEqualTo(invocationContext.agent().name());
-    assertThat(event.invocationId()).isEqualTo(invocationContext.invocationId());
   }
 
   @Test

--- a/core/src/test/java/com/google/adk/flows/llmflows/CodeExecutionTest.java
+++ b/core/src/test/java/com/google/adk/flows/llmflows/CodeExecutionTest.java
@@ -16,6 +16,8 @@
 
 package com.google.adk.flows.llmflows;
 
+import static com.google.adk.testing.TestUtils.createGenerateContentResponseUsageMetadata;
+import static com.google.adk.testing.TestUtils.createInvocationContext;
 import static com.google.adk.testing.TestUtils.createLlmResponse;
 import static com.google.adk.testing.TestUtils.createTestAgentBuilder;
 import static com.google.adk.testing.TestUtils.createTestLlm;
@@ -120,6 +122,37 @@ public class CodeExecutionTest {
     Part executionResultPart = events.get(1).content().get().parts().get().get(0);
     assertThat(executionResultPart.codeExecutionResult().get().output())
         .hasValue("Code execution result:\nhello\n\n");
+  }
+
+  @Test
+  public void run_withCodeExecutionResponseAndUsageMetadata_continuesToFinalAnswer() {
+    String code = "print('hello')";
+    Content codeResponseContent =
+        Content.builder()
+            .role("model")
+            .parts(Part.fromText("```tool_code\n" + code + "\n```"))
+            .build();
+    var usageMetadata = createGenerateContentResponseUsageMetadata().build();
+    LlmResponse codeResponse =
+        createLlmResponse(codeResponseContent).toBuilder().usageMetadata(usageMetadata).build();
+    Content finalResponseContent = Content.fromParts(Part.fromText("Done."));
+    testLlm = createTestLlm(codeResponse, createLlmResponse(finalResponseContent));
+    agent = createTestAgentBuilder(testLlm).codeExecutor(mockCodeExecutor).build();
+    InvocationContext realInvocationContext = createInvocationContext(agent);
+    CodeExecutionResult executionResult = CodeExecutionResult.builder().stdout("hello\n").build();
+    when(mockCodeExecutor.errorRetryAttempts()).thenReturn(2);
+    when(mockCodeExecutor.executeCode(any(), any())).thenReturn(executionResult);
+    when(mockCodeExecutor.codeBlockDelimiters())
+        .thenReturn(ImmutableList.of(ImmutableList.of("```tool_code\n", "\n```")));
+
+    ImmutableList<Event> events =
+        ImmutableList.copyOf(new SingleFlow().run(realInvocationContext).toList().blockingGet());
+
+    assertThat(testLlm.getRequests()).hasSize(2);
+    assertThat(events).hasSize(3);
+    assertThat(events.get(0).usageMetadata()).isEmpty();
+    assertThat(events.get(1).hasTrailingCodeExecutionResult()).isTrue();
+    assertThat(events.get(2).content()).hasValue(finalResponseContent);
   }
 
   @Test


### PR DESCRIPTION
### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

- Closes: #1245

**Problem:**
In ADK Java code execution flows, if the model response that contains executable code also has usageMetadata, ADK emits an extra contentless usage-only event after the codeExecutionResult event. That extra event is considered final=true, so BaseLlmFlow stops the loop and does not call the LLM again with the code execution result.

**Solution:**
Skipping metadata only events unless its in BIDI mode - aligns with adk-python behaviour.

### Testing Plan
- Added unit test to ensure 2nd inference call
- Added unit to ensure it doesn't affect BIDI mode

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

_Please include a summary of passed java test results._

**Manual End-to-End (E2E) Tests:**

Testing using example mentioned in #1245

### Checklist

- [x] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md) document.
- [x] My pull request contains a single commit.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [x] Any dependent changes have been merged and published in downstream modules.