### PR TITLE
feat: Add injectable time and UUID providers

### DIFF
--- a/core/src/main/java/com/google/adk/agents/BaseAgent.java
+++ b/core/src/main/java/com/google/adk/agents/BaseAgent.java
@@ -419,7 +419,8 @@ public abstract class BaseAgent {
                       content -> {
                         invocationContext.setEndInvocation(true);
                         return Event.builder()
-                            .id(Event.generateEventId())
+                            .id(invocationContext.newUuid())
+                            .timestamp(invocationContext.now().toEpochMilli())
                             .invocationId(invocationContext.invocationId())
                             .author(name())
                             .branch(invocationContext.branch().orElse(null))
@@ -436,7 +437,8 @@ public abstract class BaseAgent {
                   if (callbackContext.state().hasDelta()) {
                     Event.Builder eventBuilder =
                         Event.builder()
-                            .id(Event.generateEventId())
+                            .id(invocationContext.newUuid())
+                            .timestamp(invocationContext.now().toEpochMilli())
                             .invocationId(invocationContext.invocationId())
                             .author(name())
                             .branch(invocationContext.branch().orElse(null))

--- a/core/src/main/java/com/google/adk/agents/InvocationContext.java
+++ b/core/src/main/java/com/google/adk/agents/InvocationContext.java
@@ -22,6 +22,8 @@ import com.google.adk.apps.ResumabilityConfig;
 import com.google.adk.artifacts.BaseArtifactService;
 import com.google.adk.memory.BaseMemoryService;
 import com.google.adk.models.LlmCallsLimitExceededException;
+import com.google.adk.platform.TimeProvider;
+import com.google.adk.platform.UuidProvider;
 import com.google.adk.plugins.Plugin;
 import com.google.adk.plugins.PluginManager;
 import com.google.adk.sessions.BaseSessionService;
@@ -29,10 +31,10 @@ import com.google.adk.sessions.Session;
 import com.google.adk.summarizer.EventsCompactionConfig;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import com.google.genai.types.Content;
+import java.time.Instant;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.jspecify.annotations.Nullable;
@@ -56,6 +58,8 @@ public class InvocationContext {
   private final @Nullable ResumabilityConfig resumabilityConfig;
   private final InvocationCostManager invocationCostManager;
   private final Map<String, Object> callbackContextData;
+  private final TimeProvider timeProvider;
+  private final UuidProvider uuidProvider;
 
   @Nullable private String branch;
   private BaseAgent agent;
@@ -83,6 +87,8 @@ public class InvocationContext {
     // invocation invocation so that Plugins can access the same data it during the invocation
     // across all types of callbacks.
     this.callbackContextData = builder.callbackContextData;
+    this.timeProvider = builder.timeProvider;
+    this.uuidProvider = builder.uuidProvider;
   }
 
   /** Returns a new {@link Builder} for creating {@link InvocationContext} instances. */
@@ -197,9 +203,34 @@ public class InvocationContext {
     return session.userId();
   }
 
+  /** Returns the {@link TimeProvider} for this invocation. */
+  public TimeProvider timeProvider() {
+    return timeProvider;
+  }
+
+  /** Returns the {@link UuidProvider} for this invocation. */
+  public UuidProvider uuidProvider() {
+    return uuidProvider;
+  }
+
+  /** Returns the current time from this invocation's {@link TimeProvider}. */
+  public Instant now() {
+    return timeProvider.now();
+  }
+
+  /** Returns a new unique identifier from this invocation's {@link UuidProvider}. */
+  public String newUuid() {
+    return uuidProvider.newUuid();
+  }
+
   /** Generates a new unique ID for an invocation context. */
   public static String newInvocationContextId() {
-    return "e-" + UUID.randomUUID();
+    return newInvocationContextId(UuidProvider.SYSTEM);
+  }
+
+  /** Generates a new unique ID for an invocation context using the given {@link UuidProvider}. */
+  public static String newInvocationContextId(UuidProvider uuidProvider) {
+    return "e-" + uuidProvider.newUuid();
   }
 
   /**
@@ -289,6 +320,8 @@ public class InvocationContext {
       // invocation invocation so that Plugins can access the same data it during the invocation
       // across all types of callbacks.
       this.callbackContextData = context.callbackContextData;
+      this.timeProvider = context.timeProvider;
+      this.uuidProvider = context.uuidProvider;
     }
 
     private BaseSessionService sessionService;
@@ -309,6 +342,8 @@ public class InvocationContext {
     private @Nullable ResumabilityConfig resumabilityConfig;
     private InvocationCostManager invocationCostManager = new InvocationCostManager();
     private Map<String, Object> callbackContextData = new ConcurrentHashMap<>();
+    private TimeProvider timeProvider = TimeProvider.SYSTEM;
+    private UuidProvider uuidProvider = UuidProvider.SYSTEM;
 
     /**
      * Sets the session service for managing session state.
@@ -503,6 +538,30 @@ public class InvocationContext {
     }
 
     /**
+     * Sets the time provider for the invocation. Defaults to {@link TimeProvider#SYSTEM}.
+     *
+     * @param timeProvider the provider for the current time.
+     * @return this builder instance for chaining.
+     */
+    @CanIgnoreReturnValue
+    public Builder timeProvider(TimeProvider timeProvider) {
+      this.timeProvider = timeProvider;
+      return this;
+    }
+
+    /**
+     * Sets the UUID provider for the invocation. Defaults to {@link UuidProvider#SYSTEM}.
+     *
+     * @param uuidProvider the provider for new unique identifiers.
+     * @return this builder instance for chaining.
+     */
+    @CanIgnoreReturnValue
+    public Builder uuidProvider(UuidProvider uuidProvider) {
+      this.uuidProvider = uuidProvider;
+      return this;
+    }
+
+    /**
      * Builds the {@link InvocationContext} instance.
      *
      * @throws IllegalStateException if any required parameters are missing.
@@ -559,7 +618,9 @@ public class InvocationContext {
         && Objects.equals(contextCacheConfig, that.contextCacheConfig)
         && Objects.equals(resumabilityConfig, that.resumabilityConfig)
         && Objects.equals(invocationCostManager, that.invocationCostManager)
-        && Objects.equals(callbackContextData, that.callbackContextData);
+        && Objects.equals(callbackContextData, that.callbackContextData)
+        && Objects.equals(timeProvider, that.timeProvider)
+        && Objects.equals(uuidProvider, that.uuidProvider);
   }
 
   @Override
@@ -582,6 +643,8 @@ public class InvocationContext {
         contextCacheConfig,
         resumabilityConfig,
         invocationCostManager,
-        callbackContextData);
+        callbackContextData,
+        timeProvider,
+        uuidProvider);
   }
 }

--- a/core/src/main/java/com/google/adk/events/Event.java
+++ b/core/src/main/java/com/google/adk/events/Event.java
@@ -23,6 +23,8 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.adk.JsonBaseModel;
+import com.google.adk.platform.TimeProvider;
+import com.google.adk.platform.UuidProvider;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
@@ -34,12 +36,10 @@ import com.google.genai.types.FunctionResponse;
 import com.google.genai.types.GenerateContentResponseUsageMetadata;
 import com.google.genai.types.GroundingMetadata;
 import com.google.genai.types.Transcription;
-import java.time.Instant;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
-import java.util.UUID;
 import org.jspecify.annotations.Nullable;
 
 // TODO - b/413761119 update Agent.java when resolved.
@@ -74,7 +74,7 @@ public class Event extends JsonBaseModel {
   private Event() {}
 
   public static String generateEventId() {
-    return UUID.randomUUID().toString();
+    return UuidProvider.SYSTEM.newUuid();
   }
 
   /** The event id. */
@@ -598,7 +598,7 @@ public class Event extends JsonBaseModel {
       event.setCustomMetadata(customMetadata);
       event.setModelVersion(modelVersion);
       event.setActions(actions().orElseGet(() -> EventActions.builder().build()));
-      event.setTimestamp(timestamp().orElseGet(() -> Instant.now().toEpochMilli()));
+      event.setTimestamp(timestamp().orElseGet(() -> TimeProvider.SYSTEM.now().toEpochMilli()));
       event.setInputTranscription(inputTranscription);
       event.setOutputTranscription(outputTranscription);
       return event;

--- a/core/src/main/java/com/google/adk/flows/llmflows/BaseLlmFlow.java
+++ b/core/src/main/java/com/google/adk/flows/llmflows/BaseLlmFlow.java
@@ -451,7 +451,7 @@ public abstract class BaseLlmFlow implements BaseFlow {
 
                         final Event mutableEventTemplate =
                             Event.builder()
-                                .id(Event.generateEventId())
+                                .id(context.newUuid())
                                 .invocationId(context.invocationId())
                                 .author(context.agent().name())
                                 .branch(context.branch().orElse(null))
@@ -466,7 +466,7 @@ public abstract class BaseLlmFlow implements BaseFlow {
                             .doFinally(
                                 () -> {
                                   String oldId = mutableEventTemplate.id();
-                                  String newId = Event.generateEventId();
+                                  String newId = context.newUuid();
                                   logger.debug("Resetting event ID from {} to {}", oldId, newId);
                                   mutableEventTemplate.setId(newId);
                                 })
@@ -474,7 +474,7 @@ public abstract class BaseLlmFlow implements BaseFlow {
                                 event -> {
                                   // Update event ID for the new resulting events
                                   String oldId = event.id();
-                                  String newId = Event.generateEventId();
+                                  String newId = context.newUuid();
                                   logger.debug("Resetting event ID from {} to {}", oldId, newId);
                                   event = event.toBuilder().id(newId).build();
                                   Flowable<Event> postProcessedEvents = Flowable.just(event);
@@ -575,7 +575,7 @@ public abstract class BaseLlmFlow implements BaseFlow {
                 return Flowable.empty();
               }
 
-              String eventIdForSendData = Event.generateEventId();
+              String eventIdForSendData = invocationContext.newUuid();
               LlmAgent agent = (LlmAgent) invocationContext.agent();
               BaseLlm llm =
                   agent.resolvedModel().model().isPresent()
@@ -667,7 +667,7 @@ public abstract class BaseLlmFlow implements BaseFlow {
                       .flatMap(
                           llmResponse -> {
                             Event baseEventForThisLlmResponse =
-                                liveEventBuilderTemplate.id(Event.generateEventId()).build();
+                                liveEventBuilderTemplate.id(invocationContext.newUuid()).build();
                             return postprocess(
                                 invocationContext,
                                 baseEventForThisLlmResponse,
@@ -752,7 +752,7 @@ public abstract class BaseLlmFlow implements BaseFlow {
     }
 
     Event modelResponseEvent =
-        buildModelResponseEvent(baseEventForLlmResponse, llmRequest, updatedResponse);
+        buildModelResponseEvent(context, baseEventForLlmResponse, llmRequest, updatedResponse);
     if (modelResponseEvent.functionCalls().isEmpty()
         || modelResponseEvent.partial().orElse(false)) {
       return processorEvents.concatWith(Flowable.just(modelResponseEvent));
@@ -798,9 +798,13 @@ public abstract class BaseLlmFlow implements BaseFlow {
   }
 
   private Event buildModelResponseEvent(
-      Event baseEventForLlmResponse, LlmRequest llmRequest, LlmResponse llmResponse) {
+      InvocationContext context,
+      Event baseEventForLlmResponse,
+      LlmRequest llmRequest,
+      LlmResponse llmResponse) {
     Event.Builder eventBuilder =
         baseEventForLlmResponse.toBuilder()
+            .timestamp(context.now().toEpochMilli())
             .content(llmResponse.content().orElse(null))
             .partial(llmResponse.partial().orElse(null))
             .errorCode(llmResponse.errorCode().orElse(null))
@@ -820,7 +824,7 @@ public abstract class BaseLlmFlow implements BaseFlow {
     logger.debug("event: {} functionCalls: {}", event, event.functionCalls());
 
     if (!event.functionCalls().isEmpty()) {
-      Functions.populateClientFunctionCallId(event);
+      Functions.populateClientFunctionCallId(event, context.uuidProvider());
       Set<String> longRunningToolIds =
           Functions.getLongRunningFunctionCalls(event.functionCalls(), llmRequest.tools());
       logger.debug("longRunningToolIds: {}", longRunningToolIds);

--- a/core/src/main/java/com/google/adk/flows/llmflows/CodeExecution.java
+++ b/core/src/main/java/com/google/adk/flows/llmflows/CodeExecution.java
@@ -226,6 +226,8 @@ public final class CodeExecution {
               llmRequest.contents().add(codeContent);
               Event codeEvent =
                   Event.builder()
+                      .id(invocationContext.newUuid())
+                      .timestamp(invocationContext.now().toEpochMilli())
                       .invocationId(invocationContext.invocationId())
                       .author(llmAgent.name())
                       .content(codeContent)
@@ -307,6 +309,8 @@ public final class CodeExecution {
 
     Event codeEvent =
         Event.builder()
+            .id(invocationContext.newUuid())
+            .timestamp(invocationContext.now().toEpochMilli())
             .invocationId(invocationContext.invocationId())
             .author(llmAgent.name())
             .content(responseContent)
@@ -456,6 +460,8 @@ public final class CodeExecution {
               }
               eventActionsBuilder.artifactDelta(artifactDelta);
               return Event.builder()
+                  .id(invocationContext.newUuid())
+                  .timestamp(invocationContext.now().toEpochMilli())
                   .invocationId(invocationContext.invocationId())
                   .author(invocationContext.agent().name())
                   .content(resultContent)

--- a/core/src/main/java/com/google/adk/flows/llmflows/Functions.java
+++ b/core/src/main/java/com/google/adk/flows/llmflows/Functions.java
@@ -30,6 +30,7 @@ import com.google.adk.events.Event;
 import com.google.adk.events.EventActions;
 import com.google.adk.events.ToolConfirmation;
 import com.google.adk.models.FunctionCallIds;
+import com.google.adk.platform.UuidProvider;
 import com.google.adk.telemetry.Instrumentation;
 import com.google.adk.telemetry.Instrumentation.ToolExecution;
 import com.google.adk.telemetry.Tracing;
@@ -79,6 +80,11 @@ public final class Functions {
     return FunctionCallIds.generateClientFunctionCallId();
   }
 
+  /** Generates a unique ID for a function call using the given {@link UuidProvider}. */
+  public static String generateClientFunctionCallId(UuidProvider uuidProvider) {
+    return FunctionCallIds.generateClientFunctionCallId(uuidProvider);
+  }
+
   /**
    * Populates missing function call IDs in the provided event's content.
    *
@@ -88,6 +94,18 @@ public final class Functions {
    * @param modelResponseEvent The event potentially containing function calls.
    */
   public static void populateClientFunctionCallId(Event modelResponseEvent) {
+    populateClientFunctionCallId(modelResponseEvent, UuidProvider.SYSTEM);
+  }
+
+  /**
+   * Populates missing function call IDs in the provided event's content using the given {@link
+   * UuidProvider}.
+   *
+   * @param modelResponseEvent The event potentially containing function calls.
+   * @param uuidProvider The provider used to mint new function call IDs.
+   */
+  public static void populateClientFunctionCallId(
+      Event modelResponseEvent, UuidProvider uuidProvider) {
     Optional<Content> originalContentOptional = modelResponseEvent.content();
     if (originalContentOptional.isEmpty()) {
       return;
@@ -105,7 +123,7 @@ public final class Functions {
         FunctionCall functionCall = part.functionCall().get();
         if (functionCall.id().isEmpty() || functionCall.id().get().isEmpty()) {
           FunctionCall updatedFunctionCall =
-              functionCall.toBuilder().id(generateClientFunctionCallId()).build();
+              functionCall.toBuilder().id(generateClientFunctionCallId(uuidProvider)).build();
           newParts.add(part.toBuilder().functionCall(updatedFunctionCall).build());
           modified = true;
         } else {
@@ -170,7 +188,7 @@ public final class Functions {
                 return Maybe.empty();
               }
               Optional<Event> maybeMergedEvent =
-                  Functions.mergeParallelFunctionResponseEvents(events);
+                  Functions.mergeParallelFunctionResponseEvents(invocationContext, events);
               if (maybeMergedEvent.isEmpty()) {
                 return Maybe.empty();
               }
@@ -234,7 +252,8 @@ public final class Functions {
               if (events.isEmpty()) {
                 return Maybe.empty();
               }
-              return Maybe.fromOptional(Functions.mergeParallelFunctionResponseEvents(events));
+              return Maybe.fromOptional(
+                  Functions.mergeParallelFunctionResponseEvents(invocationContext, events));
             });
   }
 
@@ -560,7 +579,7 @@ public final class Functions {
   }
 
   private static Optional<Event> mergeParallelFunctionResponseEvents(
-      List<Event> functionResponseEvents) {
+      InvocationContext invocationContext, List<Event> functionResponseEvents) {
     if (functionResponseEvents.isEmpty()) {
       return Optional.empty();
     }
@@ -584,7 +603,7 @@ public final class Functions {
 
     return Optional.of(
         Event.builder()
-            .id(Event.generateEventId())
+            .id(invocationContext.newUuid())
             .invocationId(baseEvent.invocationId())
             .author(baseEvent.author())
             .branch(baseEvent.branch().orElse(null))
@@ -735,7 +754,8 @@ public final class Functions {
             .build();
 
     return Event.builder()
-        .id(Event.generateEventId())
+        .id(invocationContext.newUuid())
+        .timestamp(invocationContext.now().toEpochMilli())
         .invocationId(invocationContext.invocationId())
         .author(invocationContext.agent().name())
         .branch(invocationContext.branch().orElse(null))
@@ -780,7 +800,7 @@ public final class Functions {
                       functionCallsById.get(entry.getKey()),
                       "toolConfirmation",
                       entry.getValue()))
-              .id(generateClientFunctionCallId())
+              .id(generateClientFunctionCallId(invocationContext.uuidProvider()))
               .build();
 
       longRunningToolIds.add(requestConfirmationFunctionCall.id().get());
@@ -796,6 +816,8 @@ public final class Functions {
 
     return Optional.of(
         Event.builder()
+            .id(invocationContext.newUuid())
+            .timestamp(invocationContext.now().toEpochMilli())
             .invocationId(invocationContext.invocationId())
             .author(invocationContext.agent().name())
             .branch(invocationContext.branch().orElse(null))

--- a/core/src/main/java/com/google/adk/flows/llmflows/OutputSchema.java
+++ b/core/src/main/java/com/google/adk/flows/llmflows/OutputSchema.java
@@ -109,7 +109,8 @@ public final class OutputSchema implements RequestProcessor {
   public static Event createFinalModelResponseEvent(
       InvocationContext context, String jsonResponse) {
     return Event.builder()
-        .id(Event.generateEventId())
+        .id(context.newUuid())
+        .timestamp(context.now().toEpochMilli())
         .invocationId(context.invocationId())
         .author(context.agent().name())
         .branch(context.branch().orElse(null))

--- a/core/src/main/java/com/google/adk/models/FunctionCallIds.java
+++ b/core/src/main/java/com/google/adk/models/FunctionCallIds.java
@@ -16,7 +16,7 @@
 
 package com.google.adk.models;
 
-import java.util.UUID;
+import com.google.adk.platform.UuidProvider;
 
 /** Constants and helpers for ADK-generated function call IDs. */
 public final class FunctionCallIds {
@@ -26,7 +26,15 @@ public final class FunctionCallIds {
 
   /** Returns a new client-side function call ID with the ADK prefix. */
   public static String generateClientFunctionCallId() {
-    return AF_FUNCTION_CALL_ID_PREFIX + UUID.randomUUID();
+    return generateClientFunctionCallId(UuidProvider.SYSTEM);
+  }
+
+  /**
+   * Returns a new client-side function call ID with the ADK prefix, minted from the given {@link
+   * UuidProvider}.
+   */
+  public static String generateClientFunctionCallId(UuidProvider uuidProvider) {
+    return AF_FUNCTION_CALL_ID_PREFIX + uuidProvider.newUuid();
   }
 
   /** Returns whether {@code id} was generated client-side by the ADK. */

--- a/core/src/main/java/com/google/adk/platform/TimeProvider.java
+++ b/core/src/main/java/com/google/adk/platform/TimeProvider.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.adk.platform;
+
+import java.time.Instant;
+
+/**
+ * Supplies the current time for ADK-generated timestamps.
+ *
+ * <p>The default {@link #SYSTEM} provider reads the wall clock. Integrations that need custom
+ * timestamps can install a custom provider on an invocation; see {@code InvocationContext}.
+ */
+@FunctionalInterface
+public interface TimeProvider {
+
+  /** A provider backed by the system wall clock ({@link Instant#now()}). */
+  TimeProvider SYSTEM = Instant::now;
+
+  /** Returns the current time. */
+  Instant now();
+}

--- a/core/src/main/java/com/google/adk/platform/UuidProvider.java
+++ b/core/src/main/java/com/google/adk/platform/UuidProvider.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.adk.platform;
+
+import java.util.UUID;
+
+/**
+ * Supplies new unique identifiers for ADK-generated IDs (events, invocations, function calls).
+ *
+ * <p>The default {@link #SYSTEM} provider returns random UUIDs. Integrations that need customized
+ * identifiers can install a custom provider on an invocation; see {@code InvocationContext}.
+ */
+@FunctionalInterface
+public interface UuidProvider {
+
+  /** A provider backed by {@link UUID#randomUUID()}. */
+  UuidProvider SYSTEM = () -> UUID.randomUUID().toString();
+
+  /** Returns a new unique identifier. */
+  String newUuid();
+}

--- a/core/src/main/java/com/google/adk/platform/package-info.java
+++ b/core/src/main/java/com/google/adk/platform/package-info.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Seams for overriding system operations such as reading the current time and generating unique
+ * IDs.
+ *
+ * <p>By default ADK uses the wall clock and random UUIDs. Integrations that need customized
+ * timestamps and identifiers can install custom {@link com.google.adk.platform.TimeProvider} and
+ * {@link com.google.adk.platform.UuidProvider} implementations. Providers are carried on an
+ * invocation rather than in static state, which keeps them isolated to a single run and safe for
+ * concurrent invocations with independent providers.
+ */
+package com.google.adk.platform;

--- a/core/src/main/java/com/google/adk/runner/Runner.java
+++ b/core/src/main/java/com/google/adk/runner/Runner.java
@@ -36,6 +36,8 @@ import com.google.adk.flows.llmflows.Functions;
 import com.google.adk.flows.llmflows.PersistBarrier;
 import com.google.adk.memory.BaseMemoryService;
 import com.google.adk.models.Model;
+import com.google.adk.platform.TimeProvider;
+import com.google.adk.platform.UuidProvider;
 import com.google.adk.plugins.Plugin;
 import com.google.adk.plugins.PluginManager;
 import com.google.adk.sessions.BaseSessionService;
@@ -87,6 +89,8 @@ public class Runner {
   @Nullable private final EventsCompactionConfig eventsCompactionConfig;
   @Nullable private final ContextCacheConfig contextCacheConfig;
   private final @Nullable ResumabilityConfig resumabilityConfig;
+  private final TimeProvider timeProvider;
+  private final UuidProvider uuidProvider;
   private final ConcurrentMap<String, Completable> activeSessionCompletables =
       new MapMaker().weakValues().makeMap();
 
@@ -96,9 +100,11 @@ public class Runner {
     private BaseAgent agent;
     private String appName;
     private BaseArtifactService artifactService = new InMemoryArtifactService();
-    private BaseSessionService sessionService = new InMemorySessionService();
+    @Nullable private BaseSessionService sessionService = null;
     @Nullable private BaseMemoryService memoryService = null;
     private List<? extends Plugin> plugins = ImmutableList.of();
+    private TimeProvider timeProvider = TimeProvider.SYSTEM;
+    private UuidProvider uuidProvider = UuidProvider.SYSTEM;
 
     @CanIgnoreReturnValue
     public Builder app(App app) {
@@ -153,6 +159,18 @@ public class Runner {
       return this;
     }
 
+    @CanIgnoreReturnValue
+    public Builder timeProvider(TimeProvider timeProvider) {
+      this.timeProvider = timeProvider;
+      return this;
+    }
+
+    @CanIgnoreReturnValue
+    public Builder uuidProvider(UuidProvider uuidProvider) {
+      this.uuidProvider = uuidProvider;
+      return this;
+    }
+
     public Runner build() {
       BaseAgent buildAgent;
       String buildAppName;
@@ -192,19 +210,22 @@ public class Runner {
       if (artifactService == null) {
         throw new IllegalStateException("Artifact service must be provided.");
       }
-      if (sessionService == null) {
-        throw new IllegalStateException("Session service must be provided.");
-      }
+      BaseSessionService buildSessionService =
+          sessionService != null
+              ? sessionService
+              : new InMemorySessionService(timeProvider, uuidProvider);
       return new Runner(
           buildAgent,
           buildAppName,
           artifactService,
-          sessionService,
+          buildSessionService,
           memoryService,
           buildPlugins,
           buildEventsCompactionConfig,
           buildContextCacheConfig,
-          buildResumabilityConfig);
+          buildResumabilityConfig,
+          timeProvider,
+          uuidProvider);
     }
   }
 
@@ -286,15 +307,44 @@ public class Runner {
       @Nullable EventsCompactionConfig eventsCompactionConfig,
       @Nullable ContextCacheConfig contextCacheConfig,
       @Nullable ResumabilityConfig resumabilityConfig) {
+    this(
+        agent,
+        appName,
+        artifactService,
+        sessionService,
+        memoryService,
+        plugins,
+        eventsCompactionConfig,
+        contextCacheConfig,
+        resumabilityConfig,
+        TimeProvider.SYSTEM,
+        UuidProvider.SYSTEM);
+  }
+
+  private Runner(
+      BaseAgent agent,
+      String appName,
+      BaseArtifactService artifactService,
+      BaseSessionService sessionService,
+      @Nullable BaseMemoryService memoryService,
+      List<? extends Plugin> plugins,
+      @Nullable EventsCompactionConfig eventsCompactionConfig,
+      @Nullable ContextCacheConfig contextCacheConfig,
+      @Nullable ResumabilityConfig resumabilityConfig,
+      TimeProvider timeProvider,
+      UuidProvider uuidProvider) {
     this.agent = agent;
     this.appName = appName;
     this.artifactService = artifactService;
     this.sessionService = sessionService;
     this.memoryService = memoryService;
     this.pluginManager = new PluginManager(plugins);
-    this.eventsCompactionConfig = createEventsCompactionConfig(agent, eventsCompactionConfig);
+    this.eventsCompactionConfig =
+        createEventsCompactionConfig(agent, eventsCompactionConfig, timeProvider, uuidProvider);
     this.contextCacheConfig = contextCacheConfig;
     this.resumabilityConfig = resumabilityConfig;
+    this.timeProvider = timeProvider;
+    this.uuidProvider = uuidProvider;
   }
 
   /**
@@ -385,7 +435,8 @@ public class Runner {
     // Appends only. We do not yield the event because it's not from the model.
     Event.Builder eventBuilder =
         Event.builder()
-            .id(Event.generateEventId())
+            .id(invocationContext.newUuid())
+            .timestamp(invocationContext.now().toEpochMilli())
             .invocationId(invocationContext.invocationId())
             .author("user")
             .content(newMessage);
@@ -522,7 +573,7 @@ public class Runner {
             () -> {
               Context capturedContext = Context.current();
               BaseAgent rootAgent = this.agent;
-              String invocationId = InvocationContext.newInvocationContextId();
+              String invocationId = InvocationContext.newInvocationContextId(this.uuidProvider);
 
               // Pre-merge stateDelta so onUserMessageCallback can access it.
               // Safe: session is a copy; persistence still happens via appendNewMessageToSession.
@@ -594,7 +645,8 @@ public class Runner {
             .map(
                 content ->
                     Event.builder()
-                        .id(Event.generateEventId())
+                        .id(contextWithUpdatedSession.newUuid())
+                        .timestamp(contextWithUpdatedSession.now().toEpochMilli())
                         .invocationId(contextWithUpdatedSession.invocationId())
                         .author("model")
                         .content(content)
@@ -711,6 +763,8 @@ public class Runner {
         .eventsCompactionConfig(this.eventsCompactionConfig)
         .contextCacheConfig(this.contextCacheConfig)
         .resumabilityConfig(this.resumabilityConfig)
+        .timeProvider(this.timeProvider)
+        .uuidProvider(this.uuidProvider)
         .agent(this.findAgentToRun(session, rootAgent));
   }
 
@@ -910,7 +964,10 @@ public class Runner {
 
   @Nullable
   private static EventsCompactionConfig createEventsCompactionConfig(
-      BaseAgent agent, @Nullable EventsCompactionConfig config) {
+      BaseAgent agent,
+      @Nullable EventsCompactionConfig config,
+      TimeProvider timeProvider,
+      UuidProvider uuidProvider) {
     if (config == null || config.summarizer() != null) {
       return config;
     }
@@ -920,7 +977,7 @@ public class Runner {
             .map(LlmAgent.class::cast)
             .flatMap(LlmAgent::model)
             .flatMap(Model::model)
-            .map(LlmEventSummarizer::new)
+            .map(baseLlm -> new LlmEventSummarizer(baseLlm, timeProvider, uuidProvider))
             .orElseThrow(
                 () ->
                     new IllegalArgumentException(

--- a/core/src/main/java/com/google/adk/sessions/InMemorySessionService.java
+++ b/core/src/main/java/com/google/adk/sessions/InMemorySessionService.java
@@ -20,6 +20,8 @@ import static java.util.stream.Collectors.toCollection;
 
 import com.google.adk.events.Event;
 import com.google.adk.events.EventActions;
+import com.google.adk.platform.TimeProvider;
+import com.google.adk.platform.UuidProvider;
 import com.google.common.collect.ImmutableList;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import io.reactivex.rxjava3.core.Completable;
@@ -32,7 +34,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import org.jspecify.annotations.Nullable;
@@ -58,11 +59,21 @@ public final class InMemorySessionService implements BaseSessionService {
   // Structure: appName -> stateKey -> stateValue
   private final ConcurrentMap<String, ConcurrentMap<String, Object>> appState;
 
+  private final TimeProvider timeProvider;
+  private final UuidProvider uuidProvider;
+
   /** Creates a new instance of the in-memory session service with empty storage. */
   public InMemorySessionService() {
+    this(TimeProvider.SYSTEM, UuidProvider.SYSTEM);
+  }
+
+  /** Creates a new instance backed by the given time and UUID providers. */
+  public InMemorySessionService(TimeProvider timeProvider, UuidProvider uuidProvider) {
     this.sessions = new ConcurrentHashMap<>();
     this.userState = new ConcurrentHashMap<>();
     this.appState = new ConcurrentHashMap<>();
+    this.timeProvider = timeProvider;
+    this.uuidProvider = uuidProvider;
   }
 
   @Override
@@ -87,7 +98,7 @@ public final class InMemorySessionService implements BaseSessionService {
         Optional.ofNullable(sessionId)
             .map(String::trim)
             .filter(s -> !s.isEmpty())
-            .orElseGet(() -> UUID.randomUUID().toString());
+            .orElseGet(uuidProvider::newUuid);
 
     // Ensure state map and events list are mutable for the new session
     ConcurrentMap<String, Object> initialState =
@@ -99,7 +110,7 @@ public final class InMemorySessionService implements BaseSessionService {
             .appName(appName)
             .userId(userId)
             .state(initialState)
-            .lastUpdateTime(Instant.now())
+            .lastUpdateTime(timeProvider.now())
             .build();
 
     sessions

--- a/core/src/main/java/com/google/adk/summarizer/LlmEventSummarizer.java
+++ b/core/src/main/java/com/google/adk/summarizer/LlmEventSummarizer.java
@@ -25,6 +25,8 @@ import com.google.adk.events.EventActions;
 import com.google.adk.events.EventCompaction;
 import com.google.adk.models.BaseLlm;
 import com.google.adk.models.LlmRequest;
+import com.google.adk.platform.TimeProvider;
+import com.google.adk.platform.UuidProvider;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.genai.types.Content;
@@ -51,14 +53,30 @@ public final class LlmEventSummarizer implements BaseEventSummarizer {
 
   private final BaseLlm baseLlm;
   private final String promptTemplate;
+  private final TimeProvider timeProvider;
+  private final UuidProvider uuidProvider;
 
   public LlmEventSummarizer(BaseLlm baseLlm) {
-    this(baseLlm, DEFAULT_PROMPT_TEMPLATE);
+    this(baseLlm, DEFAULT_PROMPT_TEMPLATE, TimeProvider.SYSTEM, UuidProvider.SYSTEM);
   }
 
   public LlmEventSummarizer(BaseLlm baseLlm, String promptTemplate) {
+    this(baseLlm, promptTemplate, TimeProvider.SYSTEM, UuidProvider.SYSTEM);
+  }
+
+  public LlmEventSummarizer(BaseLlm baseLlm, TimeProvider timeProvider, UuidProvider uuidProvider) {
+    this(baseLlm, DEFAULT_PROMPT_TEMPLATE, timeProvider, uuidProvider);
+  }
+
+  public LlmEventSummarizer(
+      BaseLlm baseLlm,
+      String promptTemplate,
+      TimeProvider timeProvider,
+      UuidProvider uuidProvider) {
     this.baseLlm = baseLlm;
     this.promptTemplate = promptTemplate;
+    this.timeProvider = timeProvider;
+    this.uuidProvider = uuidProvider;
   }
 
   @Override
@@ -100,10 +118,11 @@ public final class LlmEventSummarizer implements BaseEventSummarizer {
                         .map(
                             compaction ->
                                 Event.builder()
-                                    .id(Event.generateEventId())
+                                    .id(uuidProvider.newUuid())
+                                    .timestamp(timeProvider.now().toEpochMilli())
                                     .author("user")
                                     .actions(EventActions.builder().compaction(compaction).build())
-                                    .invocationId(Event.generateEventId())
+                                    .invocationId(uuidProvider.newUuid())
                                     .build())));
   }
 

--- a/core/src/test/java/com/google/adk/agents/InvocationContextTest.java
+++ b/core/src/test/java/com/google/adk/agents/InvocationContextTest.java
@@ -23,12 +23,15 @@ import static org.mockito.Mockito.mock;
 import com.google.adk.artifacts.BaseArtifactService;
 import com.google.adk.memory.BaseMemoryService;
 import com.google.adk.models.LlmCallsLimitExceededException;
+import com.google.adk.platform.TimeProvider;
+import com.google.adk.platform.UuidProvider;
 import com.google.adk.plugins.PluginManager;
 import com.google.adk.sessions.BaseSessionService;
 import com.google.adk.sessions.Session;
 import com.google.adk.summarizer.EventsCompactionConfig;
 import com.google.common.collect.ImmutableMap;
 import com.google.genai.types.Content;
+import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -256,6 +259,77 @@ public final class InvocationContextTest {
     // Basic check for UUID format after "e-"
     assertThat(id.substring(2))
         .matches("^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$");
+  }
+
+  @Test
+  public void testNewInvocationContextId_withCustomProvider() {
+    UuidProvider provider = () -> "deterministic-uuid";
+
+    String id = InvocationContext.newInvocationContextId(provider);
+
+    assertThat(id).isEqualTo("e-deterministic-uuid");
+  }
+
+  @Test
+  public void providers_defaultToSystem() {
+    InvocationContext context =
+        InvocationContext.builder()
+            .sessionService(mockSessionService)
+            .artifactService(mockArtifactService)
+            .agent(mockAgent)
+            .session(session)
+            .build();
+
+    assertThat(context.timeProvider()).isEqualTo(TimeProvider.SYSTEM);
+    assertThat(context.uuidProvider()).isEqualTo(UuidProvider.SYSTEM);
+    assertThat(context.newUuid())
+        .matches("^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$");
+    Instant before = Instant.now();
+    Instant now = context.now();
+    assertThat(now).isAtLeast(before);
+  }
+
+  @Test
+  public void providers_customAreCarriedAndUsedByAccessors() {
+    Instant fixed = Instant.ofEpochMilli(1234L);
+    TimeProvider fixedClock = () -> fixed;
+    UuidProvider fixedUuids = () -> "fixed-uuid";
+
+    InvocationContext context =
+        InvocationContext.builder()
+            .sessionService(mockSessionService)
+            .artifactService(mockArtifactService)
+            .agent(mockAgent)
+            .session(session)
+            .timeProvider(fixedClock)
+            .uuidProvider(fixedUuids)
+            .build();
+
+    assertThat(context.timeProvider()).isEqualTo(fixedClock);
+    assertThat(context.uuidProvider()).isEqualTo(fixedUuids);
+    assertThat(context.now()).isEqualTo(fixed);
+    assertThat(context.newUuid()).isEqualTo("fixed-uuid");
+  }
+
+  @Test
+  public void toBuilder_carriesProviders() {
+    TimeProvider fixedClock = () -> Instant.ofEpochMilli(1234L);
+    UuidProvider fixedUuids = () -> "fixed-uuid";
+
+    InvocationContext originalContext =
+        InvocationContext.builder()
+            .sessionService(mockSessionService)
+            .artifactService(mockArtifactService)
+            .agent(mockAgent)
+            .session(session)
+            .timeProvider(fixedClock)
+            .uuidProvider(fixedUuids)
+            .build();
+
+    InvocationContext copiedContext = originalContext.toBuilder().build();
+
+    assertThat(copiedContext.timeProvider()).isEqualTo(fixedClock);
+    assertThat(copiedContext.uuidProvider()).isEqualTo(fixedUuids);
   }
 
   @Test

--- a/core/src/test/java/com/google/adk/flows/llmflows/CodeExecutionTest.java
+++ b/core/src/test/java/com/google/adk/flows/llmflows/CodeExecutionTest.java
@@ -47,6 +47,7 @@ import com.google.genai.types.Content;
 import com.google.genai.types.Part;
 import io.reactivex.rxjava3.core.Single;
 import io.reactivex.rxjava3.observers.TestObserver;
+import java.time.Instant;
 import java.util.ArrayList;
 import org.junit.Before;
 import org.junit.Rule;
@@ -81,6 +82,8 @@ public class CodeExecutionTest {
     when(invocationContext.appName()).thenReturn("app");
     when(invocationContext.userId()).thenReturn("user");
     when(invocationContext.artifactService()).thenReturn(mockArtifactService);
+    when(invocationContext.now()).thenReturn(Instant.ofEpochMilli(1234L));
+    when(invocationContext.newUuid()).thenReturn("test-event-id");
     when(mockArtifactService.saveArtifact(
             anyString(), anyString(), anyString(), anyString(), any(Part.class)))
         .thenReturn(Single.just(1));

--- a/core/src/test/java/com/google/adk/flows/llmflows/FunctionsTest.java
+++ b/core/src/test/java/com/google/adk/flows/llmflows/FunctionsTest.java
@@ -25,6 +25,7 @@ import com.google.adk.agents.InvocationContext;
 import com.google.adk.agents.RunConfig;
 import com.google.adk.agents.RunConfig.ToolExecutionMode;
 import com.google.adk.events.Event;
+import com.google.adk.platform.UuidProvider;
 import com.google.adk.testing.TestUtils;
 import com.google.adk.tools.BaseTool;
 import com.google.adk.tools.ToolContext;
@@ -76,6 +77,31 @@ public final class FunctionsTest {
           .author("agent")
           .content(Content.fromParts(Part.fromFunctionCall("other_function", ImmutableMap.of())))
           .build();
+
+  @Test
+  public void generateClientFunctionCallId_withProvider_derivesFromProvider() {
+    UuidProvider provider = () -> "deterministic-uuid";
+
+    String id = Functions.generateClientFunctionCallId(provider);
+
+    assertThat(id).isEqualTo("adk-deterministic-uuid");
+  }
+
+  @Test
+  public void populateClientFunctionCallId_withProvider_usesProvider() {
+    Event event =
+        Event.builder()
+            .id("event1")
+            .invocationId("invocation1")
+            .author("agent")
+            .content(Content.fromParts(Part.fromFunctionCall("some_function", ImmutableMap.of())))
+            .build();
+
+    Functions.populateClientFunctionCallId(event, () -> "deterministic-uuid");
+
+    Part populatedPart = event.content().get().parts().get().get(0);
+    assertThat(populatedPart.functionCall().get().id()).hasValue("adk-deterministic-uuid");
+  }
 
   @Test
   public void handleFunctionCalls_noFunctionCalls() {

--- a/core/src/test/java/com/google/adk/platform/TimeProviderTest.java
+++ b/core/src/test/java/com/google/adk/platform/TimeProviderTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.adk.platform;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import java.time.Instant;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public final class TimeProviderTest {
+
+  @Test
+  public void system_returnsWallClockTime() {
+    Instant before = Instant.now();
+    Instant now = TimeProvider.SYSTEM.now();
+    Instant after = Instant.now();
+
+    assertThat(now).isAtLeast(before);
+    assertThat(now).isAtMost(after);
+  }
+
+  @Test
+  public void customProvider_returnsFixedTime() {
+    Instant fixed = Instant.ofEpochMilli(1234L);
+    TimeProvider provider = () -> fixed;
+
+    assertThat(provider.now()).isEqualTo(fixed);
+    assertThat(provider.now()).isEqualTo(fixed);
+  }
+}

--- a/core/src/test/java/com/google/adk/platform/UuidProviderTest.java
+++ b/core/src/test/java/com/google/adk/platform/UuidProviderTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.adk.platform;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public final class UuidProviderTest {
+
+  @Test
+  public void system_returnsUniqueUuidStrings() {
+    String first = UuidProvider.SYSTEM.newUuid();
+    String second = UuidProvider.SYSTEM.newUuid();
+
+    assertThat(first).isNotEmpty();
+    assertThat(first).isNotEqualTo(second);
+    assertThat(first).matches("^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$");
+  }
+
+  @Test
+  public void customProvider_returnsDeterministicSequence() {
+    UuidProvider provider =
+        new UuidProvider() {
+          private final AtomicInteger counter = new AtomicInteger();
+
+          @Override
+          public String newUuid() {
+            return String.format("uuid-%04d", counter.getAndIncrement());
+          }
+        };
+
+    assertThat(provider.newUuid()).isEqualTo("uuid-0000");
+    assertThat(provider.newUuid()).isEqualTo("uuid-0001");
+    assertThat(provider.newUuid()).isEqualTo("uuid-0002");
+  }
+}

--- a/core/src/test/java/com/google/adk/runner/RunnerTest.java
+++ b/core/src/test/java/com/google/adk/runner/RunnerTest.java
@@ -54,6 +54,8 @@ import com.google.adk.events.Event;
 import com.google.adk.flows.llmflows.Functions;
 import com.google.adk.models.LlmRequest;
 import com.google.adk.models.LlmResponse;
+import com.google.adk.platform.TimeProvider;
+import com.google.adk.platform.UuidProvider;
 import com.google.adk.plugins.BasePlugin;
 import com.google.adk.sessions.BaseSessionService;
 import com.google.adk.sessions.GetSessionConfig;
@@ -1804,6 +1806,85 @@ public final class RunnerTest {
     assertThat(simplifyEvents(results))
         .containsExactly("author: content for event 1", "author: content for event 2")
         .inOrder();
+  }
+
+  /**
+   * Verification of custom time/UUID provider behavior: running identical input twice with the same
+   * deterministic clock and UUID provider yields byte-identical event ids, timestamps, and
+   * invocation ids.
+   */
+  @Test
+  public void runAsync_withDeterministicProviders_producesIdenticalEvents() {
+    List<Event> firstRun = runWithDeterministicProviders();
+    List<Event> secondRun = runWithDeterministicProviders();
+
+    assertThat(firstRun).isNotEmpty();
+
+    List<String> firstIds = firstRun.stream().map(Event::id).toList();
+    List<String> secondIds = secondRun.stream().map(Event::id).toList();
+    assertThat(firstIds).isEqualTo(secondIds);
+
+    List<Long> firstTimestamps = firstRun.stream().map(Event::timestamp).toList();
+    List<Long> secondTimestamps = secondRun.stream().map(Event::timestamp).toList();
+    assertThat(firstTimestamps).isEqualTo(secondTimestamps);
+
+    List<String> firstInvocationIds = firstRun.stream().map(Event::invocationId).toList();
+    List<String> secondInvocationIds = secondRun.stream().map(Event::invocationId).toList();
+    assertThat(firstInvocationIds).isEqualTo(secondInvocationIds);
+
+    // The injected clock seam is actually used: every event carries the fixed timestamp.
+    assertThat(firstTimestamps).doesNotContain(null);
+    assertThat(firstTimestamps.stream().distinct().toList()).containsExactly(1234L);
+    // The invocation id is minted from the injected UUID provider.
+    assertThat(firstInvocationIds.stream().distinct().toList()).containsExactly("e-uuid-0000");
+  }
+
+  @Test
+  public void build_defaultSessionService_usesRunnerProviders() {
+    TimeProvider fixedClock = () -> Instant.ofEpochMilli(1234L);
+    UuidProvider fixedUuids = () -> "session-uuid";
+    Runner deterministicRunner =
+        Runner.builder()
+            .app(App.builder().name("test").rootAgent(agent).build())
+            .timeProvider(fixedClock)
+            .uuidProvider(fixedUuids)
+            .build();
+
+    Session createdSession =
+        deterministicRunner.sessionService().createSession("test", "user").blockingGet();
+
+    assertThat(createdSession.id()).isEqualTo("session-uuid");
+    assertThat(createdSession.lastUpdateTime()).isEqualTo(Instant.ofEpochMilli(1234L));
+  }
+
+  private List<Event> runWithDeterministicProviders() {
+    TimeProvider fixedClock = () -> Instant.ofEpochMilli(1234L);
+    UuidProvider sequentialUuids =
+        new UuidProvider() {
+          private final AtomicInteger counter = new AtomicInteger();
+
+          @Override
+          public String newUuid() {
+            return String.format("uuid-%04d", counter.getAndIncrement());
+          }
+        };
+    LlmAgent deterministicAgent =
+        createTestAgentBuilder(createTestLlm(createLlmResponse(createContent("from llm")))).build();
+    Runner deterministicRunner =
+        Runner.builder()
+            .app(App.builder().name("test").rootAgent(deterministicAgent).build())
+            .timeProvider(fixedClock)
+            .uuidProvider(sequentialUuids)
+            .build();
+    Session deterministicSession =
+        deterministicRunner
+            .sessionService()
+            .createSession("test", "user", new ConcurrentHashMap<String, Object>(), "fixed-session")
+            .blockingGet();
+    return deterministicRunner
+        .runAsync("user", deterministicSession.id(), createContent("hi"))
+        .toList()
+        .blockingGet();
   }
 
   private Content createContent(String text) {

--- a/core/src/test/java/com/google/adk/sessions/InMemorySessionServiceTest.java
+++ b/core/src/test/java/com/google/adk/sessions/InMemorySessionServiceTest.java
@@ -19,6 +19,8 @@ import static com.google.common.truth.Truth.assertThat;
 
 import com.google.adk.events.Event;
 import com.google.adk.events.EventActions;
+import com.google.adk.platform.TimeProvider;
+import com.google.adk.platform.UuidProvider;
 import io.reactivex.rxjava3.core.Single;
 import java.lang.reflect.Field;
 import java.time.Instant;
@@ -64,6 +66,18 @@ public final class InMemorySessionServiceTest {
     assertThat(session.appName()).isEqualTo("app-name");
     assertThat(session.userId()).isEqualTo("user-id");
     assertThat(session.state()).isEmpty();
+  }
+
+  @Test
+  public void createSession_withDeterministicProviders_usesProvidersForIdAndTime() {
+    TimeProvider fixedClock = () -> Instant.ofEpochMilli(1234L);
+    UuidProvider fixedUuids = () -> "fixed-session-id";
+    InMemorySessionService sessionService = new InMemorySessionService(fixedClock, fixedUuids);
+
+    Session session = sessionService.createSession("app-name", "user-id").blockingGet();
+
+    assertThat(session.id()).isEqualTo("fixed-session-id");
+    assertThat(session.lastUpdateTime()).isEqualTo(Instant.ofEpochMilli(1234L));
   }
 
   @Test

--- a/core/src/test/java/com/google/adk/summarizer/LlmEventSummarizerTest.java
+++ b/core/src/test/java/com/google/adk/summarizer/LlmEventSummarizerTest.java
@@ -34,6 +34,7 @@ import com.google.genai.types.FunctionCall;
 import com.google.genai.types.FunctionResponse;
 import com.google.genai.types.Part;
 import io.reactivex.rxjava3.core.Flowable;
+import java.time.Instant;
 import java.util.Map;
 import org.junit.Before;
 import org.junit.Rule;
@@ -114,6 +115,26 @@ public class LlmEventSummarizerTest {
     assertThat(llmRequest.model()).hasValue("test-model");
     assertThat(llmRequest.contents().get(0).role()).hasValue("user");
     assertThat(llmRequest.contents().get(0).parts().get().get(0).text()).hasValue(expectedPrompt);
+  }
+
+  @Test
+  public void summarizeEvents_usesInjectedProviders() {
+    LlmEventSummarizer providerSummarizer =
+        new LlmEventSummarizer(mockLlm, () -> Instant.ofEpochMilli(1234L), () -> "summary-uuid");
+    ImmutableList<Event> events =
+        ImmutableList.of(createEvent(1L, "Hello", "user"), createEvent(2L, "Hi there!", "model"));
+    LlmResponse mockLlmResponse =
+        LlmResponse.builder()
+            .content(Content.builder().parts(ImmutableList.of(Part.fromText("Summary"))).build())
+            .build();
+    when(mockLlm.generateContent(any(LlmRequest.class), eq(false)))
+        .thenReturn(Flowable.just(mockLlmResponse));
+
+    Event compactedEvent = providerSummarizer.summarizeEvents(events).blockingGet();
+
+    assertThat(compactedEvent.id()).isEqualTo("summary-uuid");
+    assertThat(compactedEvent.invocationId()).isEqualTo("summary-uuid");
+    assertThat(compactedEvent.timestamp()).isEqualTo(1234L);
   }
 
   @Test


### PR DESCRIPTION
### Link to Issue or Description of Change

**Problem:**
ADK generates timestamps and IDs by calling `Instant.now()` and `UUID.randomUUID()` directly. There are use cases where it's useful to have custom clock and UUID providers, such as when you want to make runs reproducible/deterministic.

`adk-python` already solves this with `platform.time` / `platform.uuid` - see https://github.com/google/adk-python/pull/4200.  Closely inspired by that, we propose adding similar functionality for `adk-java`.  Note that a similar PR is open right now for `adk-go`: https://github.com/google/adk-go/pull/964.

**Solution:**
Introduce a leaf package `com.google.adk.platform` with two functional interfaces:

- `TimeProvider` — `Instant now()`, default `SYSTEM` backed by `Instant::now`.
- `UuidProvider` — `String newUuid()`, default `SYSTEM` backed by `UUID.randomUUID()`.

Both default to today's wall-clock / random behavior, so this change is fully backwards-compatible.

The providers are **threaded as data through `InvocationContext`** rather than stored in an ambient `ThreadLocal`. ADK's core flow hops threads via `RxJava` (e.g. `BaseLlmFlow` observes on `Schedulers.io()` / the agent executor), and events are built downstream on those worker threads. We considered using a `ThreadLocal` but that would silently fall back to the system providers after a thread hop, failing open with no error. So the proposed solution here, carrying the providers on the `InvocationContext` (which is already captured in the RxJava lambdas and passed down the chain) makes them visible on whatever thread builds an event, so this is thread-safe. This mirrors the proposed changes to `adk-go`, which diverged from `adk-python`'s contextvar mechanism for the same concurrency reason.

Users configure the providers **once** on the `Runner` (`Runner.builder().timeProvider(...).uuidProvider(...)`); no knowledge of ADK's internal threads is required.

The other files edited in this PR are just call sites updated to derive from the in-scope providers:
- `InvocationContext` — invocation ID, plus `now()` / `newUuid()` accessors.
- `BaseLlmFlow`, `Functions`, `OutputSchema` — event IDs + timestamps, function-call IDs.
- `Runner` — invocation ID + event builds.
- `InMemorySessionService` — auto session ID + `lastUpdateTime` (constructor injection; default constructor keeps `SYSTEM` behavior).

`Event.generateEventId()` and the `Event.Builder.build()` timestamp default now delegate to `UuidProvider.SYSTEM` / `TimeProvider.SYSTEM`, so the platform interfaces are the single source for generated IDs and timestamps while the `Event` API stays unchanged.

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

New/updated tests:
- `platform/TimeProviderTest`, `platform/UuidProviderTest` — `SYSTEM` defaults + custom-provider behavior.
- `InvocationContextTest` — providers default to `SYSTEM`, are carried by the builder/`toBuilder()`, and drive `now()` / `newUuid()`.
- `FunctionsTest` — function-call ID derives from the injected provider.
- `InMemorySessionServiceTest` — injected providers produce a deterministic session ID and `lastUpdateTime`.
- `RunnerTest.runAsync_withDeterministicProviders_producesIdenticalEvents` — the headline guarantee: running the same input twice through the full flow yields byte-identical event IDs, timestamps, and invocation IDs.

Local results (`./mvnw -pl core test`, openjdk@17), all green:
```
TimeProviderTest / UuidProviderTest  Tests run: 2,   Failures: 0, Errors: 0, Skipped: 0
RunnerTest                            Tests run: 139, Failures: 0, Errors: 0, Skipped: 0
InvocationContextTest / FunctionsTest / InMemorySessionServiceTest  Failures: 0, Errors: 0
```
`./mvnw -pl core fmt:check` — 0 non-complying files.

**Manual End-to-End (E2E) Tests:**

This is an in-process library seam with no runtime/config surface to exercise manually. The guarantee is verified by the unit test above, which asserts two independent runs of the same invocation produce identical IDs and timestamps.

### Checklist

- [x] I have read the CONTRIBUTING.md document.
- [x] My pull request contains a single commit.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [x] Any dependent changes have been merged and published in downstream modules.

### Additional context

Motivated by maintaining feature parity with `adk-python` and the proposed changes to `adk-go`.
