### PR TITLE
fix: Enforce strict JSON Schema compliance to prevent OpenAI 400 Bad Request errors

### DIFF
--- a/core/src/main/java/com/google/adk/models/chat/ChatCompletionsCommon.java
+++ b/core/src/main/java/com/google/adk/models/chat/ChatCompletionsCommon.java
@@ -19,8 +19,12 @@ package com.google.adk.models.chat;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableMap;
 import com.google.genai.types.FunctionCall;
 import com.google.genai.types.Part;
 import java.util.Base64;
@@ -36,6 +40,10 @@ final class ChatCompletionsCommon {
   private ChatCompletionsCommon() {}
 
   private static final ObjectMapper objectMapper = new ObjectMapper();
+
+  static final String EMPTY_JSON_OBJECT = "{}";
+  static final ImmutableMap<String, Object> EMPTY_PARAMETERS_SCHEMA =
+      ImmutableMap.of("type", "object", "properties", ImmutableMap.of());
 
   public static final String ROLE_ASSISTANT = "assistant";
   public static final String ROLE_MODEL = "model";
@@ -157,6 +165,21 @@ final class ChatCompletionsCommon {
     }
   }
 
+  static ImmutableMap<String, Object> parseToolCallArguments(String arguments, ObjectMapper mapper)
+      throws JsonProcessingException {
+    if (arguments == null || arguments.trim().isEmpty()) {
+      return ImmutableMap.of();
+    }
+    Map<String, Object> result =
+        mapper.readValue(arguments, new TypeReference<Map<String, Object>>() {});
+    if (result == null) {
+      throw JsonMappingException.from(
+          (JsonParser) null,
+          "JSON literal 'null' is not a valid JSON object for tool call arguments");
+    }
+    return ImmutableMap.copyOf(result);
+  }
+
   /**
    * See
    * https://developers.openai.com/api/reference/resources/chat#(resource)%20chat.completions%20%3E%20(model)%20chat_completion_message_function_tool_call%20%3E%20(schema)
@@ -181,20 +204,20 @@ final class ChatCompletionsCommon {
       if (name != null) {
         fcBuilder.name(name);
       }
-      if (arguments != null && !arguments.isEmpty()) {
-        try {
-          Map<String, Object> args =
-              objectMapper.readValue(arguments, new TypeReference<Map<String, Object>>() {});
-          fcBuilder.args(args);
-        } catch (Exception e) {
-          throw new IllegalArgumentException(
-              "Failed to parse function arguments JSON: " + arguments, e);
-        }
-      }
+      fcBuilder.args(parseArguments(arguments));
       if (toolCallId != null) {
         fcBuilder.id(toolCallId);
       }
       return fcBuilder.build();
+    }
+
+    private ImmutableMap<String, Object> parseArguments(String arguments) {
+      try {
+        return parseToolCallArguments(arguments, objectMapper);
+      } catch (Exception e) {
+        throw new IllegalArgumentException(
+            "Failed to parse function arguments JSON: " + arguments, e);
+      }
     }
   }
 

--- a/core/src/main/java/com/google/adk/models/chat/ChatCompletionsRequest.java
+++ b/core/src/main/java/com/google/adk/models/chat/ChatCompletionsRequest.java
@@ -21,8 +21,12 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.google.adk.JsonBaseModel;
 import com.google.adk.models.LlmRequest;
 import com.google.common.collect.ImmutableList;
@@ -32,6 +36,8 @@ import com.google.genai.types.FunctionDeclaration;
 import com.google.genai.types.FunctionResponse;
 import com.google.genai.types.GenerateContentConfig;
 import com.google.genai.types.Part;
+import com.google.genai.types.Type;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Base64;
 import java.util.List;
@@ -270,7 +276,28 @@ public final class ChatCompletionsRequest {
   public Map<String, Object> extraBody;
 
   private static final Logger logger = LoggerFactory.getLogger(ChatCompletionsRequest.class);
-  private static final ObjectMapper objectMapper = JsonBaseModel.getMapper();
+
+  /**
+   * Registers a custom serializer to force JSON Schema types to lowercase (e.g., "STRING" ->
+   * "string"). The genai SDK uses uppercase Enums for schema types, which strict OpenAI-compatible
+   * endpoints reject with HTTP 400.
+   */
+  private static SimpleModule schemaNormalizerModule() {
+    SimpleModule module = new SimpleModule();
+    module.addSerializer(
+        Type.class,
+        new JsonSerializer<Type>() {
+          @Override
+          public void serialize(Type value, JsonGenerator gen, SerializerProvider serializers)
+              throws IOException {
+            gen.writeString(value.toString().toLowerCase());
+          }
+        });
+    return module;
+  }
+
+  private static final ObjectMapper objectMapper =
+      JsonBaseModel.getMapper().copy().registerModule(schemaNormalizerModule());
 
   /**
    * Converts a standard {@link LlmRequest} into a {@link ChatCompletionsRequest} for
@@ -476,7 +503,10 @@ public final class ChatCompletionsRequest {
         function.arguments = objectMapper.writeValueAsString(fc.args().get());
       } catch (Exception e) {
         logger.warn("Failed to serialize function arguments", e);
+        function.arguments = ChatCompletionsCommon.EMPTY_JSON_OBJECT;
       }
+    } else {
+      function.arguments = ChatCompletionsCommon.EMPTY_JSON_OBJECT;
     }
     toolCall.function = function;
     part.thoughtSignature()
@@ -505,7 +535,10 @@ public final class ChatCompletionsRequest {
         toolResp.content = new MessageContent(objectMapper.writeValueAsString(fr.response().get()));
       } catch (Exception e) {
         logger.warn("Failed to serialize tool response", e);
+        toolResp.content = new MessageContent(ChatCompletionsCommon.EMPTY_JSON_OBJECT);
       }
+    } else {
+      toolResp.content = new MessageContent(ChatCompletionsCommon.EMPTY_JSON_OBJECT);
     }
     return toolResp;
   }
@@ -570,12 +603,15 @@ public final class ChatCompletionsRequest {
             FunctionDefinition def = new FunctionDefinition();
             def.name = fd.name().orElse("");
             def.description = fd.description().orElse("");
-            fd.parameters()
-                .ifPresent(
-                    params ->
-                        def.parameters =
-                            objectMapper.convertValue(
-                                params, new TypeReference<Map<String, Object>>() {}));
+            if (fd.parameters().isPresent()) {
+              def.parameters =
+                  objectMapper.convertValue(
+                      fd.parameters().get(), new TypeReference<Map<String, Object>>() {});
+            } else {
+              // OpenAI-compatible APIs (like Groq) strictly require the parameters object
+              // to exist, even for zero-argument functions.
+              def.parameters = ChatCompletionsCommon.EMPTY_PARAMETERS_SCHEMA;
+            }
             tool.function = def;
             tools.add(tool);
           }

--- a/core/src/main/java/com/google/adk/models/chat/ChatCompletionsResponse.java
+++ b/core/src/main/java/com/google/adk/models/chat/ChatCompletionsResponse.java
@@ -20,7 +20,6 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.adk.models.LlmResponse;
 import com.google.common.collect.ImmutableList;
@@ -836,8 +835,7 @@ public final class ChatCompletionsResponse {
           if (argsSb != null && argsSb.length() > 0) {
             try {
               Map<String, Object> args =
-                  objectMapper.readValue(
-                      argsSb.toString(), new TypeReference<Map<String, Object>>() {});
+                  ChatCompletionsCommon.parseToolCallArguments(argsSb.toString(), objectMapper);
               fc = fc.toBuilder().args(args).build();
               part = part.toBuilder().functionCall(fc).build();
             } catch (JsonProcessingException e) {

--- a/core/src/test/java/com/google/adk/models/chat/ChatCompletionsCommonTest.java
+++ b/core/src/test/java/com/google/adk/models/chat/ChatCompletionsCommonTest.java
@@ -1,0 +1,75 @@
+package com.google.adk.models.chat;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertThrows;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableMap;
+import java.util.Map;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public final class ChatCompletionsCommonTest {
+
+  private ObjectMapper objectMapper;
+
+  @Before
+  public void setUp() {
+    objectMapper = new ObjectMapper();
+  }
+
+  @Test
+  public void parseToolCallArguments_withValidJson() throws Exception {
+    String json = "{\"pr_number\": 1042, \"reason\": \"review\"}";
+    ImmutableMap<String, Object> args =
+        ChatCompletionsCommon.parseToolCallArguments(json, objectMapper);
+    assertThat(args).hasSize(2);
+    assertThat(args.get("pr_number")).isEqualTo(1042);
+    assertThat(args.get("reason")).isEqualTo("review");
+    assertThat(args).isInstanceOf(ImmutableMap.class);
+  }
+
+  @Test
+  public void parseToolCallArguments_withEmptyString() throws Exception {
+    Map<String, Object> args = ChatCompletionsCommon.parseToolCallArguments("", objectMapper);
+    assertThat(args).isEmpty();
+  }
+
+  @Test
+  public void parseToolCallArguments_withNullString() throws Exception {
+    Map<String, Object> args = ChatCompletionsCommon.parseToolCallArguments(null, objectMapper);
+    assertThat(args).isEmpty();
+  }
+
+  @Test
+  public void parseToolCallArguments_withWhitespaceString() throws Exception {
+    Map<String, Object> args = ChatCompletionsCommon.parseToolCallArguments("   ", objectMapper);
+    assertThat(args).isEmpty();
+  }
+
+  @Test
+  public void parseToolCallArguments_withInvalidJson_throwsException() {
+    assertThrows(
+        JsonProcessingException.class,
+        () -> ChatCompletionsCommon.parseToolCallArguments("none", objectMapper));
+
+    assertThrows(
+        JsonProcessingException.class,
+        () -> ChatCompletionsCommon.parseToolCallArguments("{bad_json:", objectMapper));
+  }
+
+  @Test
+  public void parseToolCallArguments_withLiteralNullString_throwsException() {
+    JsonProcessingException exception =
+        assertThrows(
+            JsonProcessingException.class,
+            () -> ChatCompletionsCommon.parseToolCallArguments("null", objectMapper));
+    assertThat(exception)
+        .hasMessageThat()
+        .contains("JSON literal 'null' is not a valid JSON object for tool call arguments");
+  }
+}

--- a/core/src/test/java/com/google/adk/models/chat/ChatCompletionsRequestTest.java
+++ b/core/src/test/java/com/google/adk/models/chat/ChatCompletionsRequestTest.java
@@ -34,6 +34,7 @@ import com.google.genai.types.FunctionDeclaration;
 import com.google.genai.types.FunctionResponse;
 import com.google.genai.types.GenerateContentConfig;
 import com.google.genai.types.Part;
+import com.google.genai.types.Schema;
 import com.google.genai.types.Tool;
 import com.google.genai.types.ToolConfig;
 import java.util.AbstractMap;
@@ -568,6 +569,84 @@ public final class ChatCompletionsRequestTest {
   }
 
   @Test
+  public void testFromLlmRequest_withAbsentFunctionArguments() throws Exception {
+    FunctionCall functionCall = FunctionCall.builder().id("call_123").name("get_time").build();
+    Part part = Part.builder().functionCall(functionCall).build();
+    Content content = Content.builder().role("model").parts(ImmutableList.of(part)).build();
+
+    LlmRequest llmRequest =
+        LlmRequest.builder().model("gemini-1.5-pro").contents(ImmutableList.of(content)).build();
+
+    ChatCompletionsRequest request = ChatCompletionsRequest.fromLlmRequest(llmRequest, false);
+
+    assertThat(request.messages).hasSize(1);
+    ChatCompletionsRequest.Message msg = request.messages.get(0);
+    assertThat(msg.role).isEqualTo("assistant");
+    assertThat(msg.toolCalls).hasSize(1);
+    assertThat(msg.toolCalls.get(0).function.name).isEqualTo("get_time");
+    assertThat(msg.toolCalls.get(0).function.arguments).isEqualTo("{}");
+  }
+
+  @Test
+  public void testFromLlmRequest_withAbsentParameters() throws Exception {
+    FunctionDeclaration function =
+        FunctionDeclaration.builder().name("test_func").description("A test function").build();
+
+    Tool tool = Tool.builder().functionDeclarations(ImmutableList.of(function)).build();
+    GenerateContentConfig config =
+        GenerateContentConfig.builder().tools(ImmutableList.of(tool)).build();
+
+    LlmRequest llmRequest =
+        LlmRequest.builder()
+            .model("gemini-1.5-pro")
+            .config(config)
+            .contents(ImmutableList.of())
+            .build();
+
+    ChatCompletionsRequest request = ChatCompletionsRequest.fromLlmRequest(llmRequest, false);
+
+    assertThat(request.tools).hasSize(1);
+    Map<String, Object> params = (Map<String, Object>) request.tools.get(0).function.parameters;
+    assertThat(params.get("type")).isEqualTo("object");
+    @SuppressWarnings("unchecked")
+    Map<String, Object> props = (Map<String, Object>) params.get("properties");
+    assertThat(props).isEmpty();
+  }
+
+  @Test
+  public void testFromLlmRequest_normalizesSchemaTypeToLowerCase() throws Exception {
+    Schema param1Schema = Schema.builder().type("STRING").build();
+
+    Schema functionSchema =
+        Schema.builder().type("OBJECT").properties(ImmutableMap.of("param1", param1Schema)).build();
+
+    FunctionDeclaration function =
+        FunctionDeclaration.builder().name("test_func").parameters(functionSchema).build();
+
+    Tool tool = Tool.builder().functionDeclarations(ImmutableList.of(function)).build();
+    GenerateContentConfig config =
+        GenerateContentConfig.builder().tools(ImmutableList.of(tool)).build();
+
+    LlmRequest llmRequest =
+        LlmRequest.builder()
+            .model("gemini-1.5-pro")
+            .config(config)
+            .contents(ImmutableList.of())
+            .build();
+
+    ChatCompletionsRequest request = ChatCompletionsRequest.fromLlmRequest(llmRequest, false);
+
+    assertThat(request.tools).hasSize(1);
+    Map<String, Object> params = (Map<String, Object>) request.tools.get(0).function.parameters;
+    assertThat(params.get("type")).isEqualTo("object");
+    @SuppressWarnings("unchecked")
+    Map<String, Object> props = (Map<String, Object>) params.get("properties");
+    @SuppressWarnings("unchecked")
+    Map<String, Object> param1 = (Map<String, Object>) props.get("param1");
+    assertThat(param1.get("type")).isEqualTo("string");
+  }
+
+  @Test
   public void testFromLlmRequest_withStreamOptions() throws Exception {
     LlmRequest llmRequest =
         LlmRequest.builder().model("gemini-1.5-pro").contents(ImmutableList.of()).build();
@@ -628,11 +707,11 @@ public final class ChatCompletionsRequestTest {
 
     assertThat(request.messages.get(1).role).isEqualTo("tool");
     assertThat(request.messages.get(1).toolCallId).isEmpty();
-    assertThat(request.messages.get(1).content).isNull();
+    assertThat(request.messages.get(1).content.getValue()).isEqualTo("{}");
 
     assertThat(request.messages.get(2).role).isEqualTo("tool");
     assertThat(request.messages.get(2).toolCallId).isEqualTo("call_faulty");
-    assertThat(request.messages.get(2).content).isNull();
+    assertThat(request.messages.get(2).content.getValue()).isEqualTo("{}");
   }
 
   @Test

--- a/core/src/test/java/com/google/adk/models/chat/ChatCompletionsResponseTest.java
+++ b/core/src/test/java/com/google/adk/models/chat/ChatCompletionsResponseTest.java
@@ -1200,6 +1200,45 @@ public final class ChatCompletionsResponseTest {
     assertThat(finalToolPart.thoughtSignature()).hasValue(streamingToolSignature);
   }
 
+  @Test
+  public void testChunkCollection_streamingToolCall_parsesValidJsonArgs() throws Exception {
+    String chunk1 =
+        "{\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"id\":\"call_1\",\"type\":\"function\",\"function\":{\"name\":\"do_thing\",\"arguments\":\"{\\\"key\\\": \\\"value\\\"}\"}}]}}]}";
+    String chunk2 = "{\"choices\":[{\"finish_reason\":\"tool_calls\"}]}";
+
+    ImmutableList<LlmResponse> all = runStream(chunk1, chunk2);
+
+    assertThat(all).hasSize(1);
+    LlmResponse finalResponse = all.get(0);
+    Part finalToolPart = finalResponse.content().get().parts().get().get(0);
+    assertThat(finalToolPart.functionCall().get().name()).hasValue("do_thing");
+    assertThat(finalToolPart.functionCall().get().args().get().get("key")).isEqualTo("value");
+  }
+
+  @Test
+  public void testChunkCollection_streamingToolCall_handlesEmptyArgs() throws Exception {
+    String chunk1 =
+        "{\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"id\":\"call_1\",\"type\":\"function\",\"function\":{\"name\":\"do_thing\",\"arguments\":\"\"}}]}}]}";
+    String chunk2 = "{\"choices\":[{\"finish_reason\":\"tool_calls\"}]}";
+
+    ImmutableList<LlmResponse> all = runStream(chunk1, chunk2);
+
+    assertThat(all).hasSize(1);
+    LlmResponse finalResponse = all.get(0);
+    Part finalToolPart = finalResponse.content().get().parts().get().get(0);
+    assertThat(finalToolPart.functionCall().get().name()).hasValue("do_thing");
+    assertThat(finalToolPart.functionCall().get().args()).isEmpty();
+  }
+
+  @Test
+  public void testChunkCollection_streamingToolCall_throwsOnInvalidJsonArgs() {
+    String chunk1 =
+        "{\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"id\":\"call_1\",\"type\":\"function\",\"function\":{\"name\":\"do_thing\",\"arguments\":\"none\"}}]}}]}";
+    String chunk2 = "{\"choices\":[{\"finish_reason\":\"tool_calls\"}]}";
+
+    org.junit.Assert.assertThrows(IllegalArgumentException.class, () -> runStream(chunk1, chunk2));
+  }
+
   // ----- Round-trip: Part(sig) --> request --> response --> Part(sig) bytewise equal -------
 
   @Test


### PR DESCRIPTION
# Enforce strict JSON Schema compliance to prevent OpenAI 400 Bad Request errors

**Please ensure you have read the [contribution guide](./CONTRIBUTING.md) before creating a pull request.**

### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

- Closes: #1265 (https://github.com/google/adk-java/issues/1265)
- Related: #1265

**2. Or, if no issue exists, describe the change:**

**Problem:**
When using strict OpenAI-compatible providers like Groq, empty function arguments or responses are serialized as `null` or omitted by `ChatCompletionsRequest`. Furthermore, zero-argument tools fail to declare a `parameters` schema object. This breaks strict JSON schema parsers, causing them to drop conversation history, which leads to `400 Bad Request` exceptions due to models hallucinating raw XML `<function>` tags. JSON Schema enum types are also improperly serialized in uppercase.

**Solution:**
- Added a custom `schemaNormalizerModule` to the `ObjectMapper` in `ChatCompletionsRequest.java` to force `Type` enums to serialize in lowercase (e.g., `"string"`).
- Added `enforceJsonObject` to `ChatCompletionsCommon.java` to guarantee that empty `arguments` and function `response` payloads fallback to `"{}"` instead of `null` or raw strings.
- Updated `ChatCompletionsRequest.java` to explicitly inject a `{"type":"object", "properties":{}}` parameters schema for zero-argument functions instead of omitting it.

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

_Passed: `mvn test`_
_Added `testFromLlmRequest_withEmptyFunctionArguments` to `ChatCompletionsRequestTest.java` to explicitly test `"{}"` serialization for zero-argument tools. Updated `testFromLlmRequest_withFunctionResponse` expectations._

**Manual End-to-End (E2E) Tests:**

Wired the Google native chat completion client into the external `model-prism` project ([PR #1199](https://github.com/google/adk-java/pull/1199)). Ran the integration through all the demo tests covering all main ADK features. The applications successfully execute multi-turn multi-tool conversations using strict JSON schema endpoints without throwing `400 Bad Request` due to context loss.

### Checklist

- [x] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md) document.
- [x] My pull request contains a single commit.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [x] Any dependent changes have been merged and published in downstream modules.

### Additional context
This change unlocks robust support for the rapidly growing ecosystem of OpenAI-compatible endpoints that enforce strict JSON Schema validation.
