### PR TITLE
fix: Resolve NPE when McpTool description is null

### DIFF
--- a/core/src/main/java/com/google/adk/tools/mcp/AbstractMcpTool.java
+++ b/core/src/main/java/com/google/adk/tools/mcp/AbstractMcpTool.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.adk.tools.BaseTool;
 import com.google.adk.tools.mcp.McpToolException.McpToolDeclarationException;
+import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMap;
 import com.google.genai.types.FunctionDeclaration;
 import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
@@ -52,7 +53,7 @@ public abstract class AbstractMcpTool<T> extends BaseTool {
       Tool mcpTool, T mcpSession, McpSessionManager mcpSessionManager, ObjectMapper objectMapper) {
     super(
         mcpTool == null ? "" : mcpTool.name(),
-        mcpTool == null ? "" : (mcpTool.description().isEmpty() ? "" : mcpTool.description()));
+        mcpTool == null ? "" : (Strings.nullToEmpty(mcpTool.description())));
 
     if (mcpTool == null) {
       throw new IllegalArgumentException("mcpTool cannot be null");

--- a/core/src/test/java/com/google/adk/tools/mcp/AbstractMcpToolTest.java
+++ b/core/src/test/java/com/google/adk/tools/mcp/AbstractMcpToolTest.java
@@ -17,9 +17,13 @@
 package com.google.adk.tools.mcp;
 
 import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
+import io.modelcontextprotocol.client.McpSyncClient;
+import io.modelcontextprotocol.spec.McpSchema;
 import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
 import io.modelcontextprotocol.spec.McpSchema.TextContent;
 import java.util.List;
@@ -55,5 +59,17 @@ public final class AbstractMcpToolTest {
 
     Map<?, ?> contentItem = (Map<?, ?>) content.get(0);
     assertThat(contentItem).containsEntry("text", "success");
+  }
+
+  @Test
+  public void instantiateWithToolBuilder_nullDescription_succeeds() {
+    McpSyncClient sessionMock = mock(McpSyncClient.class);
+    McpSessionManager managerMock = mock(McpSessionManager.class);
+    McpSchema.Tool schemaTool = McpSchema.Tool.builder().name("realTool").build();
+
+    McpTool tool = new McpTool(schemaTool, sessionMock, managerMock, objectMapper);
+
+    assertEquals("", tool.description());
+    assertEquals("realTool", tool.name());
   }
 }


### PR DESCRIPTION

**1. Link to an existing issue (if applicable):**

- Closes: #1275

**Problem:**
A `NullPointerException` occurs in `AbstractMcpTool` when the tool is initialized with an `McpSchema.Tool` that has a null description. The constructor attempts to evaluate the description without proper null-checking, leading to runtime failures

**Solution:**
Refactored the `super()` constructor call in `AbstractMcpTool.java` to utilize `Strings.nullToEmpty()`. This ensures that any `null` description is safely defaulted to an empty string `"" ` before the base constructor processes it.

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

added `instantiateWithMockedTool_nullDescription_succeeds()` test method to  Verified that a mock tool with an null description instantiates without throwing an exception.

**Manual End-to-End (E2E) Tests:**

Manual verification was performed by running the reproduction test case that previously failed with an NPE. After applying the fix, the test case passed, confirming the constructor handles the null input gracefully.

### Checklist

- [x] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md) document.
- [x] My pull request contains a single commit.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [x] Any dependent changes have been merged and published in downstream modules.
