### PR TITLE
fix: Enable Jackson serialization for ToolConfig

### DIFF
--- a/core/src/main/java/com/google/adk/tools/BaseTool.java
+++ b/core/src/main/java/com/google/adk/tools/BaseTool.java
@@ -21,6 +21,7 @@ import static com.google.common.collect.ImmutableList.toImmutableList;
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.adk.JsonBaseModel;
@@ -334,8 +335,8 @@ public abstract class BaseTool {
 
   /** Configuration class for a tool definition in YAML/JSON. */
   public static class ToolConfig extends JsonBaseModel {
-    private String name;
-    private ToolArgsConfig args;
+    @JsonProperty private String name;
+    @JsonProperty private ToolArgsConfig args;
 
     public ToolConfig() {}
 

--- a/core/src/test/java/com/google/adk/tools/BaseToolTest.java
+++ b/core/src/test/java/com/google/adk/tools/BaseToolTest.java
@@ -1,9 +1,11 @@
 package com.google.adk.tools;
 
 import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.*;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.adk.JsonBaseModel;
 import com.google.adk.agents.InvocationContext;
 import com.google.adk.agents.LlmAgent;
 import com.google.adk.models.Gemini;
@@ -355,4 +357,46 @@ public final class BaseToolTest {
   }
 
   public record TestToolArgs(int i, String s) {}
+
+  @Test
+  public void testToolConfigJsonSerialization() {
+    BaseTool.ToolArgsConfig args = new BaseTool.ToolArgsConfig();
+    args.put("arg1", "value1");
+    args.put("arg2", 2);
+
+    BaseTool.ToolConfig config = new BaseTool.ToolConfig("testTool", args);
+
+    String json = config.toJson();
+    assertNotNull(json);
+    assertFalse(json.isEmpty());
+
+    assertTrue(json.contains("\"name\":\"testTool\""));
+    assertTrue(json.contains("\"arg1\":\"value1\""));
+    assertTrue(json.contains("\"arg2\":2"));
+  }
+
+  @Test
+  public void testToolConfigJsonDeserialization() throws Exception {
+    String jsonInput =
+        """
+        {
+          "name": "deserializing",
+          "args": {
+            "timeoutMs": 5000,
+            "retryCount": 3
+          }
+        }
+        """;
+
+    BaseTool.ToolConfig config =
+        JsonBaseModel.getMapper().readValue(jsonInput, BaseTool.ToolConfig.class);
+
+    assertNotNull(config);
+    assertEquals("deserializing", config.name());
+
+    assertNotNull(config.args());
+    assertEquals(2, config.args().size());
+    assertEquals(5000, config.args().getAdditionalProperties().get("timeoutMs"));
+    assertEquals(3, config.args().getAdditionalProperties().get("retryCount"));
+  }
 }


### PR DESCRIPTION
**Please ensure you have read the [contribution guide](./CONTRIBUTING.md) before creating a pull request.**

### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

- Closes: #1277

**Problem:**
The `BaseTool.ToolConfig` class inherits a `toJson()` method from JsonBaseModel, but Jackson fails to serialize it, throwing an InvalidDefinitionException: No serializer found for class ...ToolConfig. This occurs because the class uses fluent accessors (name() and args()) instead of standard JavaBean getters, and the fields lacked the necessary Jackson annotations for property discovery.

**Solution:**
Added `@JsonProperty` annotations to the name and args fields in BaseTool.ToolConfig. This explicitly tells Jackson to include these fields during serialization while preserving the existing YAML/JSON deserialization logic, which continues to use the no-args constructor and standard setters

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

### Checklist

- [x] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md) document.
- [x] My pull request contains a single commit.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [x] Any dependent changes have been merged and published in downstream modules.
