### PR TITLE
feat: Updated Spring AI to 2.0.0, ECJ, build works with Java 25

### DIFF
--- a/contrib/spring-ai/pom.xml
+++ b/contrib/spring-ai/pom.xml
@@ -29,7 +29,7 @@
     <description>Spring AI integration for the Agent Development Kit.</description>
 
     <properties>
-        <spring-ai.version>2.0.0-M3</spring-ai.version>
+        <spring-ai.version>2.0.0</spring-ai.version>
         <testcontainers.version>1.21.3</testcontainers.version>
     </properties>
 
@@ -126,17 +126,7 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.ai</groupId>
-            <artifactId>spring-ai-vertex-ai-gemini</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.ai</groupId>
             <artifactId>spring-ai-google-genai</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.ai</groupId>
-            <artifactId>spring-ai-azure-openai</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/contrib/spring-ai/src/test/java/com/google/adk/models/springai/integrations/GeminiApiIntegrationTest.java
+++ b/contrib/spring-ai/src/test/java/com/google/adk/models/springai/integrations/GeminiApiIntegrationTest.java
@@ -62,7 +62,7 @@ class GeminiApiIntegrationTest {
     GoogleGenAiChatOptions options = GoogleGenAiChatOptions.builder().model(GEMINI_MODEL).build();
 
     GoogleGenAiChatModel geminiModel =
-        GoogleGenAiChatModel.builder().genAiClient(genAiClient).defaultOptions(options).build();
+        GoogleGenAiChatModel.builder().genAiClient(genAiClient).options(options).build();
 
     // Wrap with SpringAI
     SpringAI springAI = new SpringAI(geminiModel, GEMINI_MODEL);
@@ -104,7 +104,7 @@ class GeminiApiIntegrationTest {
     GoogleGenAiChatOptions options = GoogleGenAiChatOptions.builder().model(GEMINI_MODEL).build();
 
     GoogleGenAiChatModel geminiModel =
-        GoogleGenAiChatModel.builder().genAiClient(genAiClient).defaultOptions(options).build();
+        GoogleGenAiChatModel.builder().genAiClient(genAiClient).options(options).build();
 
     SpringAI springAI = new SpringAI(geminiModel, GEMINI_MODEL);
 
@@ -149,7 +149,7 @@ class GeminiApiIntegrationTest {
     GoogleGenAiChatOptions options = GoogleGenAiChatOptions.builder().model(GEMINI_MODEL).build();
 
     GoogleGenAiChatModel geminiModel =
-        GoogleGenAiChatModel.builder().genAiClient(genAiClient).defaultOptions(options).build();
+        GoogleGenAiChatModel.builder().genAiClient(genAiClient).options(options).build();
 
     LlmAgent agent =
         LlmAgent.builder()
@@ -193,7 +193,7 @@ class GeminiApiIntegrationTest {
     GoogleGenAiChatOptions options = GoogleGenAiChatOptions.builder().model(GEMINI_MODEL).build();
 
     GoogleGenAiChatModel geminiModel =
-        GoogleGenAiChatModel.builder().genAiClient(genAiClient).defaultOptions(options).build();
+        GoogleGenAiChatModel.builder().genAiClient(genAiClient).options(options).build();
 
     SpringAI springAI = new SpringAI(geminiModel, GEMINI_MODEL);
 
@@ -298,7 +298,7 @@ class GeminiApiIntegrationTest {
         Client.builder().apiKey(System.getenv("GOOGLE_API_KEY")).vertexAI(false).build();
 
     GoogleGenAiChatModel geminiModel =
-        GoogleGenAiChatModel.builder().genAiClient(genAiClient).defaultOptions(options).build();
+        GoogleGenAiChatModel.builder().genAiClient(genAiClient).options(options).build();
 
     SpringAI springAI = new SpringAI(geminiModel, GEMINI_MODEL);
 

--- a/contrib/spring-ai/src/test/java/com/google/adk/models/springai/integrations/OpenAiApiIntegrationTest.java
+++ b/contrib/spring-ai/src/test/java/com/google/adk/models/springai/integrations/OpenAiApiIntegrationTest.java
@@ -34,7 +34,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 import org.springframework.ai.openai.OpenAiChatModel;
 import org.springframework.ai.openai.OpenAiChatOptions;
-import org.springframework.ai.openai.api.OpenAiApi;
 
 /**
  * Integration tests with real OpenAI API.
@@ -50,8 +49,14 @@ class OpenAiApiIntegrationTest {
   @Test
   void testSimpleAgentWithRealOpenAiApi() {
     // Create OpenAI model using Spring AI's builder pattern
-    OpenAiApi openAiApi = OpenAiApi.builder().apiKey(System.getenv("OPENAI_API_KEY")).build();
-    OpenAiChatModel openAiModel = OpenAiChatModel.builder().openAiApi(openAiApi).build();
+    OpenAiChatModel openAiModel =
+        OpenAiChatModel.builder()
+            .options(
+                OpenAiChatOptions.builder()
+                    .apiKey(System.getenv("OPENAI_API_KEY"))
+                    .model(GPT_MODEL)
+                    .build())
+            .build();
 
     // Wrap with SpringAI
     SpringAI springAI = new SpringAI(openAiModel, GPT_MODEL);
@@ -84,8 +89,14 @@ class OpenAiApiIntegrationTest {
 
   @Test
   void testStreamingWithRealOpenAiApi() {
-    OpenAiApi openAiApi = OpenAiApi.builder().apiKey(System.getenv("OPENAI_API_KEY")).build();
-    OpenAiChatModel openAiModel = OpenAiChatModel.builder().openAiApi(openAiApi).build();
+    OpenAiChatModel openAiModel =
+        OpenAiChatModel.builder()
+            .options(
+                OpenAiChatOptions.builder()
+                    .apiKey(System.getenv("OPENAI_API_KEY"))
+                    .model(GPT_MODEL)
+                    .build())
+            .build();
 
     SpringAI springAI = new SpringAI(openAiModel, GPT_MODEL);
 
@@ -124,8 +135,14 @@ class OpenAiApiIntegrationTest {
 
   @Test
   void testAgentWithToolsAndRealApi() {
-    OpenAiApi openAiApi = OpenAiApi.builder().apiKey(System.getenv("OPENAI_API_KEY")).build();
-    OpenAiChatModel openAiModel = OpenAiChatModel.builder().openAiApi(openAiApi).build();
+    OpenAiChatModel openAiModel =
+        OpenAiChatModel.builder()
+            .options(
+                OpenAiChatOptions.builder()
+                    .apiKey(System.getenv("OPENAI_API_KEY"))
+                    .model(GPT_MODEL)
+                    .build())
+            .build();
 
     LlmAgent agent =
         LlmAgent.builder()
@@ -164,11 +181,14 @@ class OpenAiApiIntegrationTest {
   void testConfigurationOptions() {
     // Test with custom configuration
     OpenAiChatOptions options =
-        OpenAiChatOptions.builder().model(GPT_MODEL).temperature(0.7).maxTokens(100).build();
+        OpenAiChatOptions.builder()
+            .apiKey(System.getenv("OPENAI_API_KEY"))
+            .model(GPT_MODEL)
+            .temperature(0.7)
+            .maxTokens(100)
+            .build();
 
-    OpenAiApi openAiApi = OpenAiApi.builder().apiKey(System.getenv("OPENAI_API_KEY")).build();
-    OpenAiChatModel openAiModel =
-        OpenAiChatModel.builder().openAiApi(openAiApi).defaultOptions(options).build();
+    OpenAiChatModel openAiModel = OpenAiChatModel.builder().options(options).build();
 
     SpringAI springAI = new SpringAI(openAiModel, GPT_MODEL);
 

--- a/contrib/spring-ai/src/test/java/com/google/adk/models/springai/ollama/LocalModelIntegrationTest.java
+++ b/contrib/spring-ai/src/test/java/com/google/adk/models/springai/ollama/LocalModelIntegrationTest.java
@@ -51,7 +51,7 @@ class LocalModelIntegrationTest {
         OllamaChatOptions.builder().model(ollamaContainer.getModelName()).build();
 
     OllamaChatModel chatModel =
-        OllamaChatModel.builder().ollamaApi(ollamaApi).defaultOptions(options).build();
+        OllamaChatModel.builder().ollamaApi(ollamaApi).options(options).build();
     springAI = new SpringAI(chatModel, ollamaContainer.getModelName());
   }
 

--- a/dev/pom.xml
+++ b/dev/pom.xml
@@ -82,10 +82,6 @@
       <artifactId>graphviz-java</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.eclipse.jdt</groupId>
-      <artifactId>ecj</artifactId>
-    </dependency>
-    <dependency>
       <groupId>io.opentelemetry</groupId>
       <artifactId>opentelemetry-sdk-common</artifactId>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,6 @@
     <okhttp.version>5.3.2</okhttp.version>
     <docker-java.version>3.7.0</docker-java.version>
     <graphviz.version>0.18.1</graphviz.version>
-    <ecj.version>3.41.0</ecj.version>
     <maven.version>3.9.0</maven.version>
     <langchain4j.version>1.12.2</langchain4j.version>
     <slf4j.version>2.0.17</slf4j.version>
@@ -265,11 +264,6 @@
         <version>${graphviz.version}</version>
       </dependency>
       <dependency>
-        <groupId>org.eclipse.jdt</groupId>
-        <artifactId>ecj</artifactId>
-        <version>${ecj.version}</version>
-      </dependency>
-      <dependency>
         <groupId>org.apache.maven</groupId>
         <artifactId>maven-plugin-api</artifactId>
         <version>${maven.version}</version>
@@ -328,6 +322,14 @@
             <target>${java.version}</target>
             <release>${maven.compiler.release}</release>
             <parameters>true</parameters>
+            <!-- Required for AutoValue. With incremental compilation enabled, the compiler
+                 plugin can split the source set and run the AutoValue annotation processor over
+                 only a subset of sources, so some generated AutoValue_* types are never produced.
+                 That surfaces non-deterministically as "cannot be resolved to a type" at compile
+                 time or TypeNotPresentException at runtime (notably on JDK 25). Forcing a single
+                 javac pass over all sources makes annotation processing see every @AutoValue type
+                 and become deterministic, independent of the build JDK. -->
+            <useIncrementalCompilation>false</useIncrementalCompilation>
             <annotationProcessorPaths>
               <path>
                 <groupId>com.google.auto.value</groupId>


### PR DESCRIPTION
* Updated Spring AI to GA version 2.0.0
*  Parent pom.xml

- Added <useIncrementalCompilation>false</useIncrementalCompilation> to the maven-compiler-plugin config (with an explanatory comment) → makes AutoValue annotation  processing deterministic across all modules and JDKs, including JDK 25
- Removed the unused ecj.version property and the org.eclipse.jdt:ecj dependencyManagement entry.

* dev/pom.xml

- Removed the unused org.eclipse.jdt:ecj dependency.