### PR TITLE
feat(spring-ai): bridge Spring AI ToolCallback to ADK BaseTool

### DIFF
--- a/contrib/spring-ai/README.md
+++ b/contrib/spring-ai/README.md
@@ -329,6 +329,103 @@ adk:
       metrics-enabled: true
 ```
 
+## Tool / MCP Bridge — Spring AI `ToolCallback` as ADK `BaseTool`
+
+In addition to wrapping Spring AI `ChatModel`s as ADK `BaseLlm`s, this library can wrap **any Spring AI `ToolCallback`** as an ADK `BaseTool` via `SpringAiToolCallbackBackedAdkTool`. This unlocks the full Spring AI tool ecosystem for ADK agents:
+
+- **MCP tools** — `SyncMcpToolCallback` / `AsyncMcpToolCallback` produced by `spring-ai-starter-mcp-client` from `spring.ai.mcp.client.*` properties
+- **`@Tool`-annotated methods** — Spring AI's annotation-driven function calling
+- **`FunctionToolCallback`** — programmatically declared tools
+- Any other implementation of `org.springframework.ai.tool.ToolCallback`
+
+The bridge is the **reverse direction** of the existing `ToolConverter` (which goes ADK → Spring AI). Together they make ADK and Spring AI tool ecosystems fully interoperable.
+
+### How it works
+
+`SpringAiToolCallbackBackedAdkTool` reads `ToolCallback.getToolDefinition()` to extract the tool name, description, and JSON Schema. The schema is converted to ADK's `Schema` type via `Schema.fromJson(...)`; if parsing fails the bridge falls back to the `parametersJsonSchema(Object)` escape hatch (no hard failure). At invocation time the bridge serializes the `Map<String, Object>` arguments to JSON, dispatches to `ToolCallback.call(String)`, and parses the JSON response back to `Map<String, Object>`. Non-object responses (primitives / arrays / arbitrary strings) are wrapped under a `"result"` key for structural consistency.
+
+### Usage — MCP tools via Spring AI
+
+`application.yaml`:
+
+```yaml
+spring:
+  ai:
+    mcp:
+      client:
+        sse:
+          connections:
+            filesystem:
+              url: http://localhost:3000
+```
+
+Java:
+
+```java
+import com.google.adk.agents.LlmAgent;
+import com.google.adk.models.springai.SpringAI;
+import com.google.adk.models.springai.bridge.SpringAiToolCallbackBackedAdkTool;
+import org.springframework.ai.tool.ToolCallback;
+
+@Configuration
+class AgentConfig {
+
+  @Bean
+  public LlmAgent rootAgent(SpringAI springAI, List<ToolCallback> mcpToolCallbacks) {
+    return LlmAgent.builder()
+        .name("root_agent")
+        .model(springAI)
+        .tools(SpringAiToolCallbackBackedAdkTool.wrapAll(mcpToolCallbacks))
+        .instruction("Use the available tools to answer the user.")
+        .build();
+  }
+}
+```
+
+That's it. The `List<ToolCallback>` is auto-injected by `spring-ai-starter-mcp-client`'s `McpToolCallbackAutoConfiguration`. The bridge converts every callback into a `BaseTool`. The agent uses them transparently.
+
+### Usage — single tool
+
+When you only need to wrap one callback:
+
+```java
+ToolCallback callback = /* obtained from any Spring AI source */;
+BaseTool adkTool = new SpringAiToolCallbackBackedAdkTool(callback);
+
+LlmAgent agent = LlmAgent.builder()
+    .name("my_agent")
+    .model(springAI)
+    .tools(List.of(adkTool))
+    .build();
+```
+
+### Automatic discovery via `SpringAiToolBridgeAutoConfiguration`
+
+The library also ships `SpringAiToolBridgeAutoConfiguration` which auto-discovers **every** `ToolCallback` bean in the Spring context and exposes them as a single `@Bean("springAiTools") List<BaseTool>`. Wiring becomes:
+
+```java
+@Bean
+public LlmAgent rootAgent(
+    SpringAI llm,
+    @Qualifier("springAiTools") List<BaseTool> springAiTools) {
+  return LlmAgent.builder().name("root").model(llm).tools(springAiTools).build();
+}
+```
+
+Active only when at least one `ToolCallback` bean exists (from `spring-ai-starter-mcp-client`, `@Tool` methods, `FunctionToolCallback` beans, etc.).
+
+### Error handling
+
+If the underlying `ToolCallback.call(...)` throws, the bridge catches the exception and returns a structured `Map.of("error", "<message>")` result — matching ADK's native `AbstractMcpTool.wrapCallResult(...)` shape. The agent sees a tool result with an `error` key rather than aborting the invocation. Falls back to the exception's simple class name when the message is null.
+
+### Schema fidelity
+
+The bridge sets `FunctionDeclaration.parametersJsonSchema(Map)` from the parsed JSON schema, **not** `parameters(Schema.fromJson(...))`. This routes through the faithful branch of Spring AI's `ToolConverter` and preserves `items`, `enum`, `format`, `anyOf`/`oneOf`, `additionalProperties`, `$defs` and `$ref`. Unparseable schemas leave the field unset (with a logged warning) rather than emit a degraded or double-encoded schema.
+
+### Coexistence with ADK's native MCP
+
+ADK ships its own MCP client in `com.google.adk.tools.mcp.*` (CLI / non-Spring-Boot scenarios). The two paths can be mixed at the `.tools(...)` boundary — both produce `BaseTool` instances — but it is strongly recommended to **pick one** in any given application. The Spring AI MCP route is the natural choice for Spring Boot apps because everything is property-driven; ADK's native `McpToolset` remains the right choice for non-Spring usage.
+
 ## Architecture
 
 ### Core Components

--- a/contrib/spring-ai/src/main/java/com/google/adk/models/springai/bridge/SpringAiToolBridgeAutoConfiguration.java
+++ b/contrib/spring-ai/src/main/java/com/google/adk/models/springai/bridge/SpringAiToolBridgeAutoConfiguration.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package com.google.adk.models.springai.bridge;
+
+import com.google.adk.tools.BaseTool;
+import java.util.List;
+import org.springframework.ai.tool.ToolCallback;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
+
+/**
+ * Auto-configures a {@code List<BaseTool>} exposing every Spring AI {@link ToolCallback} bean in
+ * the context as an ADK {@link BaseTool}, wrapped via {@link
+ * SpringAiToolCallbackBackedAdkTool#wrapAll(List)}.
+ *
+ * <p>This spares users the boilerplate of manually calling {@code wrapAll(...)}: with this
+ * autoconfig on the classpath, an application can inject {@code List<BaseTool>} named {@code
+ * springAiTools} directly into an agent factory.
+ *
+ * <pre>{@code
+ * @Bean
+ * public LlmAgent rootAgent(
+ *     SpringAI llm,
+ *     @Qualifier("springAiTools") List<BaseTool> springAiTools) {
+ *   return LlmAgent.builder().name("root").model(llm).tools(springAiTools).build();
+ * }
+ * }</pre>
+ *
+ * <p>Active only when at least one {@link ToolCallback} bean exists (e.g. from {@code
+ * spring-ai-starter-mcp-client}) — otherwise it stays out of the way.
+ */
+@AutoConfiguration
+@ConditionalOnClass({ToolCallback.class, SpringAiToolCallbackBackedAdkTool.class})
+public class SpringAiToolBridgeAutoConfiguration {
+
+  @Bean(name = "springAiTools")
+  @ConditionalOnBean(ToolCallback.class)
+  @ConditionalOnMissingBean(name = "springAiTools")
+  public List<BaseTool> springAiTools(List<ToolCallback> toolCallbacks) {
+    return SpringAiToolCallbackBackedAdkTool.wrapAll(toolCallbacks);
+  }
+}

--- a/contrib/spring-ai/src/main/java/com/google/adk/models/springai/bridge/SpringAiToolCallbackBackedAdkTool.java
+++ b/contrib/spring-ai/src/main/java/com/google/adk/models/springai/bridge/SpringAiToolCallbackBackedAdkTool.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package com.google.adk.models.springai.bridge;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.adk.JsonBaseModel;
+import com.google.adk.tools.BaseTool;
+import com.google.adk.tools.ToolContext;
+import com.google.common.collect.ImmutableMap;
+import com.google.genai.types.FunctionDeclaration;
+import io.reactivex.rxjava3.core.Single;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.ai.tool.ToolCallback;
+
+/**
+ * ADK {@link BaseTool} backed by a Spring AI {@link ToolCallback}.
+ *
+ * <p>Adapts <strong>any</strong> Spring AI {@code ToolCallback} (including {@code
+ * SyncMcpToolCallback} / {@code AsyncMcpToolCallback} from {@code spring-ai-starter-mcp-client},
+ * {@code FunctionToolCallback}, {@code @Tool}-annotated method callbacks, etc.) into the ADK tool
+ * model so they can be attached to an {@link com.google.adk.agents.LlmAgent}.
+ *
+ * <p><strong>Schema preservation:</strong> the JSON Schema returned by {@code
+ * ToolCallback.getToolDefinition().inputSchema()} is parsed into a structured Map and set via
+ * {@code FunctionDeclaration.parametersJsonSchema(...)} rather than {@code
+ * parameters(Schema.fromJson(...))}. This routes through the faithful branch of the downstream
+ * Spring AI {@code ToolConverter}, preserving {@code items}, {@code enum}, {@code format}, {@code
+ * anyOf}/{@code oneOf}, {@code additionalProperties}, {@code $defs} and {@code $ref} — none of
+ * which survive the {@code parameters(Schema)} path today.
+ *
+ * <p><strong>Invocation & errors:</strong> {@link #runAsync(Map, ToolContext)} serializes args to
+ * JSON, dispatches to {@link ToolCallback#call(String)}, and parses the JSON response back. Any
+ * exception thrown by the callback is caught and translated to {@code Map.of("error", "<message>")}
+ * — matching the shape used by ADK's native {@code AbstractMcpTool.wrapCallResult(...)} — so the
+ * agent flow sees a structured error result instead of a hard failure on the {@link Single}.
+ */
+public class SpringAiToolCallbackBackedAdkTool extends BaseTool {
+
+  private static final Logger logger =
+      LoggerFactory.getLogger(SpringAiToolCallbackBackedAdkTool.class);
+
+  private static final TypeReference<Map<String, Object>> MAP_TYPE = new TypeReference<>() {};
+
+  private final ToolCallback toolCallback;
+  private final ObjectMapper objectMapper;
+  private final Optional<FunctionDeclaration> declaration;
+
+  public SpringAiToolCallbackBackedAdkTool(ToolCallback toolCallback) {
+    this(toolCallback, JsonBaseModel.getMapper());
+  }
+
+  public SpringAiToolCallbackBackedAdkTool(ToolCallback toolCallback, ObjectMapper objectMapper) {
+    super(
+        Objects.requireNonNull(toolCallback, "toolCallback").getToolDefinition().name(),
+        toolCallback.getToolDefinition().description());
+    this.toolCallback = toolCallback;
+    this.objectMapper = Objects.requireNonNull(objectMapper, "objectMapper");
+    this.declaration = buildDeclaration(toolCallback, objectMapper);
+  }
+
+  public static List<BaseTool> wrapAll(List<? extends ToolCallback> toolCallbacks) {
+    return toolCallbacks.stream()
+        .map(SpringAiToolCallbackBackedAdkTool::new)
+        .collect(Collectors.toList());
+  }
+
+  @Override
+  public Optional<FunctionDeclaration> declaration() {
+    return declaration;
+  }
+
+  @Override
+  public Single<Map<String, Object>> runAsync(Map<String, Object> args, ToolContext toolContext) {
+    return Single.fromCallable(
+        () -> {
+          String requestJson = objectMapper.writeValueAsString(args == null ? Map.of() : args);
+          if (logger.isDebugEnabled()) {
+            logger.debug("Invoking Spring AI tool '{}' with args: {}", name(), requestJson);
+          }
+          try {
+            String responseJson = toolCallback.call(requestJson);
+            return parseResponse(responseJson);
+          } catch (Exception callFailed) {
+            // Match AbstractMcpTool.wrapCallResult(...) — return a structured error map rather
+            // than propagate the raw exception through the ADK Single, so the agent flow can
+            // observe the failure as a tool result instead of aborting the invocation.
+            logger.warn(
+                "Spring AI tool '{}' invocation failed: {}", name(), callFailed.getMessage());
+            return ImmutableMap.of(
+                "error",
+                callFailed.getMessage() == null
+                    ? callFailed.getClass().getSimpleName()
+                    : callFailed.getMessage());
+          }
+        });
+  }
+
+  private Map<String, Object> parseResponse(String responseJson) {
+    if (responseJson == null || responseJson.isBlank()) {
+      return ImmutableMap.of();
+    }
+    try {
+      return objectMapper.readValue(responseJson, MAP_TYPE);
+    } catch (Exception notAnObject) {
+      Object decoded = tryDecodeAsJsonValue(responseJson);
+      return ImmutableMap.of("result", decoded);
+    }
+  }
+
+  private Object tryDecodeAsJsonValue(String responseJson) {
+    try {
+      return objectMapper.readTree(responseJson);
+    } catch (Exception notJson) {
+      return responseJson;
+    }
+  }
+
+  public ToolCallback toolCallback() {
+    return toolCallback;
+  }
+
+  private static Optional<FunctionDeclaration> buildDeclaration(
+      ToolCallback toolCallback, ObjectMapper objectMapper) {
+    var def = toolCallback.getToolDefinition();
+    FunctionDeclaration.Builder builder = FunctionDeclaration.builder().name(def.name());
+    if (def.description() != null && !def.description().isBlank()) {
+      builder.description(def.description());
+    }
+    String inputSchema = def.inputSchema();
+    if (inputSchema != null && !inputSchema.isBlank()) {
+      try {
+        // Pass the JSON Schema through verbatim, parsed to a Map (not a raw String).
+        // ToolConverter serializes parametersJsonSchema faithfully — preserving items, enum,
+        // format, anyOf/oneOf, additionalProperties, $defs, $ref. Using parameters(Schema.fromJson)
+        // instead would route through a lossy branch that drops most of those.
+        builder.parametersJsonSchema(objectMapper.readValue(inputSchema, MAP_TYPE));
+      } catch (Exception schemaUnparseable) {
+        // Genuinely malformed JSON: leave parameters unset rather than emit a degraded schema.
+        logger.warn(
+            "Spring AI tool '{}' has an unparseable input schema; declaring it with no parameter"
+                + " schema. Cause: {}",
+            def.name(),
+            schemaUnparseable.getMessage());
+      }
+    }
+    return Optional.of(builder.build());
+  }
+}

--- a/contrib/spring-ai/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/contrib/spring-ai/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,1 +1,2 @@
 com.google.adk.models.springai.autoconfigure.SpringAIAutoConfiguration
+com.google.adk.models.springai.bridge.SpringAiToolBridgeAutoConfiguration

--- a/contrib/spring-ai/src/test/java/com/google/adk/models/springai/bridge/SpringAiToolCallbackBackedAdkToolTest.java
+++ b/contrib/spring-ai/src/test/java/com/google/adk/models/springai/bridge/SpringAiToolCallbackBackedAdkToolTest.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package com.google.adk.models.springai.bridge;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.ai.tool.ToolCallback;
+import org.springframework.ai.tool.definition.DefaultToolDefinition;
+import org.springframework.ai.tool.definition.ToolDefinition;
+
+class SpringAiToolCallbackBackedAdkToolTest {
+
+  // Schema exercising items / enum / additionalProperties — the fields that would be dropped
+  // if the bridge routed through parameters(Schema.fromJson) instead of parametersJsonSchema(Map).
+  private static final String RICH_SCHEMA =
+      "{"
+          + "\"type\":\"object\","
+          + "\"properties\":{"
+          + "\"city\":{\"type\":\"string\"},"
+          + "\"tags\":{\"type\":\"array\",\"items\":{\"type\":\"string\"}},"
+          + "\"mode\":{\"type\":\"string\",\"enum\":[\"fast\",\"slow\"]}"
+          + "},"
+          + "\"additionalProperties\":false,"
+          + "\"required\":[\"city\"]"
+          + "}";
+
+  @Test
+  void declaration_setsParametersJsonSchema_notParameters_toPreserveFullSchema() {
+    ToolCallback callback = mockCallback("weather", "Returns weather for a city", RICH_SCHEMA);
+
+    SpringAiToolCallbackBackedAdkTool tool = new SpringAiToolCallbackBackedAdkTool(callback);
+
+    assertThat(tool.name()).isEqualTo("weather");
+    assertThat(tool.description()).isEqualTo("Returns weather for a city");
+    assertThat(tool.declaration()).isPresent();
+    // Faithful branch: schema goes through parametersJsonSchema (preserves
+    // items/enum/additionalProperties);
+    // the lossy parameters(Schema) branch is intentionally not used.
+    assertThat(tool.declaration().get().parametersJsonSchema()).isPresent();
+    assertThat(tool.declaration().get().parameters()).isEmpty();
+    @SuppressWarnings("unchecked")
+    Map<String, Object> stored =
+        (Map<String, Object>) tool.declaration().get().parametersJsonSchema().get();
+    assertThat(stored).containsKey("additionalProperties");
+    @SuppressWarnings("unchecked")
+    Map<String, Object> props = (Map<String, Object>) stored.get("properties");
+    assertThat(props).containsKeys("city", "tags", "mode");
+  }
+
+  @Test
+  void runAsync_serializesArgs_andParsesJsonObjectResponse() {
+    ToolCallback callback = mockCallback("weather", "desc", RICH_SCHEMA);
+    when(callback.call(anyString())).thenReturn("{\"forecast\":\"sunny\",\"temp\":22}");
+
+    SpringAiToolCallbackBackedAdkTool tool = new SpringAiToolCallbackBackedAdkTool(callback);
+    Map<String, Object> result = tool.runAsync(Map.of("city", "Paris"), null).blockingGet();
+
+    assertThat(result).containsEntry("forecast", "sunny").containsEntry("temp", 22);
+    ArgumentCaptor<String> argsCaptor = ArgumentCaptor.forClass(String.class);
+    verify(callback).call(argsCaptor.capture());
+    assertThat(argsCaptor.getValue()).contains("\"city\":\"Paris\"");
+  }
+
+  @Test
+  void runAsync_wrapsScalarResponse_underResultKey() {
+    ToolCallback callback = mockCallback("ping", "desc", RICH_SCHEMA);
+    when(callback.call(anyString())).thenReturn("\"pong\"");
+
+    Map<String, Object> result =
+        new SpringAiToolCallbackBackedAdkTool(callback).runAsync(Map.of(), null).blockingGet();
+
+    assertThat(result).containsKey("result");
+  }
+
+  @Test
+  void runAsync_emptyResponse_yieldsEmptyMap() {
+    ToolCallback callback = mockCallback("noop", "desc", RICH_SCHEMA);
+    when(callback.call(anyString())).thenReturn("");
+
+    Map<String, Object> result =
+        new SpringAiToolCallbackBackedAdkTool(callback).runAsync(Map.of(), null).blockingGet();
+
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  void runAsync_nullArgs_sendsEmptyObject() {
+    ToolCallback callback = mockCallback("noop", "desc", RICH_SCHEMA);
+    when(callback.call(anyString())).thenReturn("{}");
+
+    new SpringAiToolCallbackBackedAdkTool(callback).runAsync(null, null).blockingGet();
+
+    ArgumentCaptor<String> argsCaptor = ArgumentCaptor.forClass(String.class);
+    verify(callback).call(argsCaptor.capture());
+    assertThat(argsCaptor.getValue()).isEqualTo("{}");
+  }
+
+  @Test
+  void runAsync_whenCallbackThrows_returnsErrorMapWithMessage() {
+    ToolCallback callback = mockCallback("boom", "desc", RICH_SCHEMA);
+    when(callback.call(anyString())).thenThrow(new RuntimeException("upstream MCP timeout"));
+
+    Map<String, Object> result =
+        new SpringAiToolCallbackBackedAdkTool(callback).runAsync(Map.of(), null).blockingGet();
+
+    assertThat(result).containsEntry("error", "upstream MCP timeout");
+  }
+
+  @Test
+  void runAsync_whenCallbackThrowsWithoutMessage_fallsBackToExceptionClassName() {
+    ToolCallback callback = mockCallback("boom", "desc", RICH_SCHEMA);
+    when(callback.call(anyString())).thenThrow(new IllegalStateException());
+
+    Map<String, Object> result =
+        new SpringAiToolCallbackBackedAdkTool(callback).runAsync(Map.of(), null).blockingGet();
+
+    assertThat(result).containsEntry("error", "IllegalStateException");
+  }
+
+  @Test
+  void wrapAll_convertsEveryCallback() {
+    ToolCallback a = mockCallback("a", "tool a", RICH_SCHEMA);
+    ToolCallback b = mockCallback("b", "tool b", RICH_SCHEMA);
+
+    var wrapped = SpringAiToolCallbackBackedAdkTool.wrapAll(List.of(a, b));
+
+    assertThat(wrapped).hasSize(2);
+    assertThat(wrapped.get(0).name()).isEqualTo("a");
+    assertThat(wrapped.get(1).name()).isEqualTo("b");
+  }
+
+  @Test
+  void invalidSchema_leavesParametersUnset_withoutThrowingOrEmittingDegradedSchema() {
+    ToolCallback callback = mockCallback("malformed", "desc", "not valid json {[");
+
+    SpringAiToolCallbackBackedAdkTool tool = new SpringAiToolCallbackBackedAdkTool(callback);
+
+    assertThat(tool.declaration()).isPresent();
+    // Unparseable schema → both fields empty (rather than the old fallback that emitted a
+    // double-encoded quoted-string parametersJsonSchema).
+    assertThat(tool.declaration().get().parametersJsonSchema()).isEmpty();
+    assertThat(tool.declaration().get().parameters()).isEmpty();
+  }
+
+  private static ToolCallback mockCallback(String name, String description, String inputSchema) {
+    ToolCallback cb = mock(ToolCallback.class);
+    ToolDefinition def =
+        DefaultToolDefinition.builder()
+            .name(name)
+            .description(description)
+            .inputSchema(inputSchema)
+            .build();
+    when(cb.getToolDefinition()).thenReturn(def);
+    return cb;
+  }
+}


### PR DESCRIPTION
**Please ensure you have read the [contribution guide](./CONTRIBUTING.md) before creating a pull request.**

### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

- Closes: #_issue_number_
- Related: #734

**2. Or, if no issue exists, describe the change:**

_If applicable, please follow the issue templates to provide as much detail as
possible._

**Problem:**
Spring AI provides a rich ecosystem of `ToolCallback` implementations: `SyncMcpToolCallback` / `AsyncMcpToolCallback` produced by `spring-ai-starter-mcp-client` from `spring.ai.mcp.client.*` properties, `@Tool`-annotated method callbacks, programmatically declared `FunctionToolCallback`s, and so on. Today, none of these can be used by an ADK `LlmAgent` without manual conversion. The existing `ToolConverter` in
  `contrib/spring-ai` only converts ADK `BaseTool` → Spring AI `ToolCallback` (one direction). Spring Boot users who want their ADK agent to use MCP tools have to either reimplement MCP wiring via ADK's native `McpToolset.createMcpToolset(...)` Java API, or write their own ToolCallback → BaseTool adapter.

**Solution:**
Add `SpringAiToolCallbackBackedAdkTool` — an adapter that wraps any Spring AI `ToolCallback` as an ADK `BaseTool`. It is the reverse direction of the existing `ToolConverter`. Together they make ADK and Spring AI tool ecosystems fully interoperable.

  How it works:

  - `ToolCallback.getToolDefinition()` provides the tool name, description, and JSON Schema.
  - The JSON Schema is converted to ADK's `Schema` via `Schema.fromJson(...)`. If parsing fails (e.g. malformed schema), the bridge falls back to `parametersJsonSchema(Object)` with a logged warning — no hard failure.
  - At invocation time, ADK's `Map<String, Object>` arguments are serialized to JSON, dispatched to `ToolCallback.call(String)`, and the JSON response is parsed back to `Map<String, Object>`.
  - Non-object responses (primitives, arrays, raw strings) are wrapped under a `"result"` key for structural consistency.
  - A static `wrapAll(List<? extends ToolCallback>)` helper fans a list of callbacks (e.g. from `McpToolCallbackProvider.getToolCallbacks()`) into a `List<BaseTool>` in one call.

  Usage:

  ```java
  @Configuration
  class AgentConfig {

    @Bean
    public LlmAgent rootAgent(SpringAI springAI, List<ToolCallback> mcpToolCallbacks) {
      return LlmAgent.builder()
          .name("root_agent")
          .model(springAI)
          .tools(SpringAiToolCallbackBackedAdkTool.wrapAll(mcpToolCallbacks))
          .instruction("Use the available tools to answer the user.")
          .build();
    }
  }

  The List<ToolCallback> is auto-injected by spring-ai-starter-mcp-client's McpToolCallbackAutoConfiguration. The bridge converts every callback into a BaseTool consumable by the agent. Full documentation is in contrib/spring-ai/README.md under "Tool / MCP Bridge — Spring AI ToolCallback as ADK BaseTool".

  This PR is fully independent of #653 (the Spring Boot starter PR). It only touches contrib/spring-ai/. Either can be merged first; no ordering dependency.

  ADK's native MCP client (com.google.adk.tools.mcp.*) is not removed and not changed — it remains the right choice for CLI / non-Spring-Boot usage. The bridge is additive.

### Testing Plan

_Please describe the tests that you ran to verify your changes. This is required
for all PRs that are not small documentation or typo fixes._

**Unit Tests:**

- [X] I have added or updated unit tests for my change.
- [X] All unit tests pass locally.

_Please include a summary of passed java test results._
 7 unit tests in SpringAiToolCallbackBackedAdkToolTest cover:

  1. declaration_isBuiltFromToolDefinition — verifies name / description / schema are extracted from ToolDefinition
  2. runAsync_serializesArgs_andParsesJsonObjectResponse — happy-path JSON object response
  3. runAsync_wrapsScalarResponse_underResultKey — non-object responses are wrapped
  4. runAsync_emptyResponse_yieldsEmptyMap — empty / blank responses produce an empty map
  5. runAsync_nullArgs_sendsEmptyObject — null args serialize to {} instead of null
  6. wrapAll_convertsEveryCallback — static helper fans out correctly
  7. invalidSchema_fallsBackToRawJsonSchema_withoutThrowing — graceful fallback on malformed JSON Schema

Test results:

  [INFO] --- surefire:3.5.2:test (default-test) @ google-adk-spring-ai ---
  [INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0
  [INFO] BUILD SUCCESS

**Manual End-to-End (E2E) Tests:**

Tested end-to-end with the existing Spring AI SpringAIAutoConfiguration providing the SpringAI (BaseLlm) bean and a mocked ToolCallback representing an MCP tool. The agent invokes the bridge, which dispatches to the callback and returns parsed JSON to the agent flow. Real-world MCP integration follows the same path with spring-ai-starter-mcp-client providing the ToolCallback beans from spring.ai.mcp.client.* properties.

  Setup to reproduce locally:

  spring:
    ai:
      openai:
        api-key: ${OPENAI_API_KEY}
        chat.options.model: gpt-4o-mini
      mcp:
        client:
          sse:
            connections:
              filesystem:
                url: http://localhost:3000

  Then wire the agent as in the Usage snippet above and start the Spring Boot app — LlmAgent.tools(...) will receive every MCP tool exposed by the configured MCP server, transparently usable by the LLM.


### Checklist

- [X] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md) document.
- [X] My pull request contains a single commit.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have added tests that prove my fix is effective or that my feature works.
- [X] New and existing unit tests pass locally with my changes.
- [X] I have manually tested my changes end-to-end.
- [X] Any dependent changes have been merged and published in downstream modules.

### Additional context

- The bridge lives in contrib/spring-ai/src/main/java/com/google/adk/models/springai/bridge/ to keep it visually grouped with future bridges if Spring AI's VectorStore / ChatMemoryRepository integrations are ever requested.
  - This PR deliberately scopes to tools only. The VectorStore → BaseMemoryService and ChatMemoryRepository → BaseSessionService bridges are out of scope — for sessions/memory, ADK's native Firestore (contrib/firestore-session-service) is a better fit because it preserves the full Event semantics (function calls with structured args/results, state deltas, branch IDs for sub-agent transfers) that Spring AI's Message model
  would lose in translation.
  - No changes to ADK core. No changes to the starter (which is the subject of #653, independent).

