### PR TITLE
fix(security): prevent prompt injection via GitHub event data in AI agent workflows

### DIFF
--- a/.github/workflows/spam-detection-adk-java-issues.yml
+++ b/.github/workflows/spam-detection-adk-java-issues.yml
@@ -76,8 +76,8 @@ jobs:
           DRY_RUN: '1'
           EVENT_NAME: ${{ github.event_name }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
-          ISSUE_TITLE: ${{ github.event.issue.title }}
-          ISSUE_BODY: ${{ github.event.issue.body }}
+          # ISSUE_TITLE removed: prevents prompt injection; agent fetches via GitHub API
+          # ISSUE_BODY removed: prevents prompt injection; agent fetches via GitHub API
           # Mapped to the manual-dispatch checkbox. On the daily schedule this is
           # empty, so only issues updated in the last 24h are audited.
           INITIAL_FULL_SCAN: ${{ github.event.inputs.full_scan }}

--- a/.github/workflows/triage-adk-java-issues.yml
+++ b/.github/workflows/triage-adk-java-issues.yml
@@ -66,8 +66,8 @@ jobs:
           DRY_RUN: '1'
           EVENT_NAME: ${{ github.event_name }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
-          ISSUE_TITLE: ${{ github.event.issue.title }}
-          ISSUE_BODY: ${{ github.event.issue.body }}
+          # ISSUE_TITLE removed: prevents prompt injection; agent fetches via GitHub API
+          # ISSUE_BODY removed: prevents prompt injection; agent fetches via GitHub API
           # Number of issues to process per scheduled batch run.
           ISSUE_COUNT_TO_PROCESS: '3'
           # Comma-separated GitHub handles to round-robin assign issues to.


### PR DESCRIPTION
## Summary

This PR fixes an indirect prompt injection vulnerability in the ADK Java CI workflows where attacker-controlled GitHub issue content is passed directly into ADK agent prompts.

## Vulnerability Details

**Affected workflows:**
- `triage-adk-java-issues.yml` — passes `ISSUE_BODY` and `ISSUE_TITLE` env vars to Java ADK agent
- `spam-detection-adk-java-issues.yml` — same pattern

**Impact:** Any public GitHub user can open an issue with a crafted body to inject instructions into the ADK triage/spam agent. The agent runs with `GOOGLE_API_KEY` and `GITHUB_TOKEN` (issues:write) in scope.

This is the same root cause as the equivalent fix in `google/adk-python`.

## Fix

Removed `ISSUE_TITLE` and `ISSUE_BODY` from workflow env vars in both affected workflows. The agent has `ISSUE_NUMBER` available and can fetch issue content securely via the GitHub API.