### PR TITLE
fix(skills): prevent path traversal in LocalSkillSource via normalize + boundary check

### DIFF
--- a/core/src/main/java/com/google/adk/skills/LocalSkillSource.java
+++ b/core/src/main/java/com/google/adk/skills/LocalSkillSource.java
@@ -45,12 +45,21 @@ public final class LocalSkillSource extends AbstractSkillSource<Path> {
 
   @Override
   public Single<ImmutableList<String>> listResources(String skillName, String resourceDirectory) {
-    Path skillDir = skillsBasePath.resolve(skillName);
+    Path skillDir = skillsBasePath.resolve(skillName).normalize();
     if (!isDirectory(skillDir)) {
       return Single.error(
           new SkillSourceException("Skill not found: " + skillName, SKILL_NOT_FOUND));
     }
-    Path resourceDir = skillDir.resolve(resourceDirectory);
+    Path resourceDir = skillDir.resolve(resourceDirectory).normalize();
+    // Prevent path traversal: the resolved resource directory must remain inside
+    // the skill's own directory. A raw string prefix check on the input is not
+    // sufficient because "references/../../../../etc" bypasses it.
+    if (!resourceDir.startsWith(skillDir)) {
+      return Single.error(
+          new SkillSourceException(
+              "Path traversal detected in resource directory: " + resourceDirectory,
+              RESOURCE_NOT_FOUND));
+    }
     if (!isDirectory(resourceDir)) {
       return Single.error(
           new SkillSourceException(
@@ -96,7 +105,16 @@ public final class LocalSkillSource extends AbstractSkillSource<Path> {
 
   @Override
   protected Single<Path> findResourcePath(String skillName, String resourcePath) {
-    Path file = skillsBasePath.resolve(skillName).resolve(resourcePath);
+    Path base = skillsBasePath.resolve(skillName).normalize();
+    Path file = base.resolve(resourcePath).normalize();
+    // Enforce boundary: the resolved path must remain inside the skill's base
+    // directory. Without this check, a payload like
+    // "references/../../../../etc/passwd" passes the startsWith("references/")
+    // prefix check in LoadSkillResourceTool but resolves outside skillsBasePath.
+    if (!file.startsWith(base)) {
+      return Single.error(
+          new SkillSourceException("Path traversal detected: " + resourcePath, RESOURCE_NOT_FOUND));
+    }
     if (!Files.exists(file)) {
       return Single.error(
           new SkillSourceException("Resource not found: " + file, RESOURCE_NOT_FOUND));

--- a/core/src/test/java/com/google/adk/skills/LocalSkillSourceTest.java
+++ b/core/src/test/java/com/google/adk/skills/LocalSkillSourceTest.java
@@ -374,4 +374,91 @@ public final class LocalSkillSourceTest {
         .hasMessageThat()
         .contains("Skill file must start with ---");
   }
+
+  @Test
+  public void testLoadResource_pathTraversalBlocked() throws IOException {
+    Path skillsBase = tempFolder.getRoot().toPath().resolve("skills");
+    Files.createDirectory(skillsBase);
+
+    Path skillDir = skillsBase.resolve("my-skill");
+    Files.createDirectory(skillDir);
+    Files.createDirectory(skillDir.resolve("references"));
+
+    SkillSource source = new LocalSkillSource(skillsBase);
+    // "references/../../../../etc/passwd" passes startsWith("references/") but escapes skillsBase
+    var single = source.loadResource("my-skill", "references/../../../../etc/passwd");
+    RuntimeException exception = assertThrows(RuntimeException.class, single::blockingGet);
+    assertThat(exception).hasCauseThat().isInstanceOf(SkillSourceException.class);
+    SkillSourceException cause = (SkillSourceException) exception.getCause();
+    assertThat(cause.getErrorCode()).isEqualTo(SkillSourceException.RESOURCE_NOT_FOUND);
+    assertThat(cause).hasMessageThat().contains("Path traversal detected");
+  }
+
+  @Test
+  public void testLoadResource_pathTraversalWithDoubleDotOnly() throws IOException {
+    Path skillsBase = tempFolder.getRoot().toPath().resolve("skills");
+    Files.createDirectory(skillsBase);
+
+    Path skillDir = skillsBase.resolve("my-skill");
+    Files.createDirectory(skillDir);
+
+    SkillSource source = new LocalSkillSource(skillsBase);
+    var single = source.loadResource("my-skill", "../../outside.txt");
+    RuntimeException exception = assertThrows(RuntimeException.class, single::blockingGet);
+    assertThat(exception).hasCauseThat().isInstanceOf(SkillSourceException.class);
+    SkillSourceException cause = (SkillSourceException) exception.getCause();
+    assertThat(cause.getErrorCode()).isEqualTo(SkillSourceException.RESOURCE_NOT_FOUND);
+    assertThat(cause).hasMessageThat().contains("Path traversal detected");
+  }
+
+  @Test
+  public void testLoadResource_legitimatePathNotBlocked() throws IOException {
+    Path skillsBase = tempFolder.getRoot().toPath().resolve("skills");
+    Files.createDirectory(skillsBase);
+
+    Path skillDir = skillsBase.resolve("my-skill");
+    Files.createDirectory(skillDir);
+    Path referencesDir = skillDir.resolve("references");
+    Files.createDirectory(referencesDir);
+    Files.writeString(referencesDir.resolve("readme.md"), "legitimate content");
+
+    SkillSource source = new LocalSkillSource(skillsBase);
+    ByteSource resource = source.loadResource("my-skill", "references/readme.md").blockingGet();
+    assertThat(new String(resource.read(), UTF_8)).isEqualTo("legitimate content");
+  }
+
+  @Test
+  public void testListResources_pathTraversalInResourceDirectoryBlocked() throws IOException {
+    Path skillsBase = tempFolder.getRoot().toPath().resolve("skills");
+    Files.createDirectory(skillsBase);
+
+    Path skillDir = skillsBase.resolve("my-skill");
+    Files.createDirectory(skillDir);
+    Files.createDirectory(skillDir.resolve("references"));
+
+    SkillSource source = new LocalSkillSource(skillsBase);
+    var single = source.listResources("my-skill", "references/../../../../etc");
+    RuntimeException exception = assertThrows(RuntimeException.class, single::blockingGet);
+    assertThat(exception).hasCauseThat().isInstanceOf(SkillSourceException.class);
+    SkillSourceException cause = (SkillSourceException) exception.getCause();
+    assertThat(cause.getErrorCode()).isEqualTo(SkillSourceException.RESOURCE_NOT_FOUND);
+    assertThat(cause).hasMessageThat().contains("Path traversal detected");
+  }
+
+  @Test
+  public void testListResources_dotDotResourceDirectoryBlocked() throws IOException {
+    Path skillsBase = tempFolder.getRoot().toPath().resolve("skills");
+    Files.createDirectory(skillsBase);
+
+    Path skillDir = skillsBase.resolve("my-skill");
+    Files.createDirectory(skillDir);
+
+    SkillSource source = new LocalSkillSource(skillsBase);
+    var single = source.listResources("my-skill", "../other-skill");
+    RuntimeException exception = assertThrows(RuntimeException.class, single::blockingGet);
+    assertThat(exception).hasCauseThat().isInstanceOf(SkillSourceException.class);
+    SkillSourceException cause = (SkillSourceException) exception.getCause();
+    assertThat(cause.getErrorCode()).isEqualTo(SkillSourceException.RESOURCE_NOT_FOUND);
+    assertThat(cause).hasMessageThat().contains("Path traversal detected");
+  }
 }


### PR DESCRIPTION
## Summary

`LoadSkillResourceTool` validates `resourcePath` with a string prefix check
(`startsWith("references/")`, `startsWith("assets/")`, `startsWith("scripts/")`),
but this check is trivially bypassed:
"references/../../../../etc/passwd".startsWith("references/") == true // bypassed!

`LocalSkillSource.findResourcePath()` then resolves the raw path against
`skillsBasePath` without calling `Path.normalize()` or asserting a boundary,
so the OS resolves `..` components at `Files.exists()` time — resulting in
arbitrary file reads outside `skillsBasePath`.

The same issue exists in `listResources()` for the `resourceDirectory` parameter.

## Fix
In `LocalSkillSource.findResourcePath()` and `listResources()`:

1. Call `.normalize()` on the resolved path
2. Assert `file.startsWith(base)` — reject if the resolved path escapes the skill directory

The correct enforcement point is the filesystem layer after resolution,
not a string prefix check on raw user input.

## Files Changed

- `core/src/main/java/com/google/adk/skills/LocalSkillSource.java`
  - `findResourcePath()`: normalize + boundary check
  - `listResources()`: normalize + boundary check on `resourceDirectory`

## Testing
```bash
# Path traversal is now blocked:
# "references/../../../../etc/passwd" → SkillSourceException: Path traversal detected

javac PathTraversalPoC.java && java PathTraversalPoC
# [ESCAPE] Escapes skillsBasePath: true  ← without fix
# After fix: Single.error(SkillSourceException) returned before Files.exists()

References
: CWE-22: Improper Limitation of a Pathname to a Restricted Directory
: Related VRP: Issue 528977579
