### PR TITLE
BQAA (Java): preview-readiness fixes — redaction, table bootstrap, drop stats, reliability

### DIFF
--- a/core/src/main/java/com/google/adk/plugins/agentanalytics/BatchProcessor.java
+++ b/core/src/main/java/com/google/adk/plugins/agentanalytics/BatchProcessor.java
@@ -28,6 +28,7 @@ import com.google.cloud.bigquery.storage.v1.AppendRowsResponse;
 import com.google.cloud.bigquery.storage.v1.Exceptions.AppendSerializationError;
 import com.google.cloud.bigquery.storage.v1.StreamWriter;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableMap;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -37,6 +38,7 @@ import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.apache.arrow.memory.BufferAllocator;
@@ -67,6 +69,11 @@ class BatchProcessor implements AutoCloseable {
   final AtomicBoolean flushLock = new AtomicBoolean(false);
   private final Schema arrowSchema;
   private final VectorSchemaRoot root;
+
+  // Drop accounting so hosts can programmatically detect lost analytics rows.
+  private final AtomicLong droppedQueueFull = new AtomicLong();
+  private final AtomicLong droppedAppendError = new AtomicLong();
+  private final AtomicLong droppedSerializationError = new AtomicLong();
 
   public BatchProcessor(
       StreamWriter writer,
@@ -105,6 +112,7 @@ class BatchProcessor implements AutoCloseable {
 
   public void append(Map<String, Object> row) {
     if (!queue.offer(row)) {
+      droppedQueueFull.incrementAndGet();
       logger.warning("BigQuery event queue is full, dropping event.");
       return;
     }
@@ -139,6 +147,7 @@ class BatchProcessor implements AutoCloseable {
         try (ArrowRecordBatch recordBatch = new VectorUnloader(root).getRecordBatch()) {
           AppendRowsResponse result = writer.append(recordBatch).get();
           if (result.hasError()) {
+            droppedAppendError.addAndGet(batch.size());
             logger.severe("BigQuery append error: " + result.getError().getMessage());
             for (var error : result.getRowErrorsList()) {
               logger.severe(
@@ -153,6 +162,7 @@ class BatchProcessor implements AutoCloseable {
           Thread.currentThread().interrupt();
         }
         if (e.getCause() instanceof AppendSerializationError ase) {
+          droppedSerializationError.addAndGet(batch.size());
           logger.log(
               Level.SEVERE, "Failed to write batch to BigQuery due to serialization error", ase);
           Map<Integer, String> rowIndexToErrorMessage = ase.getRowIndexToErrorMessage();
@@ -167,6 +177,7 @@ class BatchProcessor implements AutoCloseable {
                 "AppendSerializationError occurred, but no row-specific errors were provided.");
           }
         } else {
+          droppedAppendError.addAndGet(batch.size());
           logger.log(Level.SEVERE, "Failed to write batch to BigQuery", e);
         }
       } finally {
@@ -245,6 +256,17 @@ class BatchProcessor implements AutoCloseable {
         }
       }
     }
+  }
+
+  /**
+   * Returns a snapshot of dropped-row counters keyed by reason ({@code queue_full}, {@code
+   * append_error}, {@code serialization_error}). Non-zero values indicate lost analytics rows.
+   */
+  ImmutableMap<String, Long> getDropStats() {
+    return ImmutableMap.of(
+        "queue_full", droppedQueueFull.get(),
+        "append_error", droppedAppendError.get(),
+        "serialization_error", droppedSerializationError.get());
   }
 
   @Override

--- a/core/src/main/java/com/google/adk/plugins/agentanalytics/BigQueryAgentAnalyticsPlugin.java
+++ b/core/src/main/java/com/google/adk/plugins/agentanalytics/BigQueryAgentAnalyticsPlugin.java
@@ -215,10 +215,14 @@ public class BigQueryAgentAnalyticsPlugin extends BasePlugin {
             throw e;
           }
         }
+        tableReady = true;
       } else if (config.autoSchemaUpgrade()) {
-        maybeUpgradeSchema(bigQuery, table);
+        // Only treat the table as ready if the schema upgrade actually succeeded, so a failed
+        // upgrade is retried on a later event instead of being masked by tableEnsured=true.
+        tableReady = maybeUpgradeSchema(bigQuery, table);
+      } else {
+        tableReady = true;
       }
-      tableReady = true;
     } catch (BigQueryException e) {
       processBigQueryException(e, "Failed to check or create/upgrade BigQuery table: " + tableId);
     } catch (RuntimeException e) {
@@ -289,7 +293,7 @@ public class BigQueryAgentAnalyticsPlugin extends BasePlugin {
     Map<String, Object> row = new HashMap<>();
     row.put("timestamp", Instant.now());
     row.put("event_type", eventType);
-    row.put("agent", resolveAgentName(invocationContext));
+    row.put("agent", resolveAgentName(invocationContext, eventData));
     row.put("session_id", invocationContext.session().id());
     row.put("invocation_id", invocationContext.invocationId());
     row.put("user_id", invocationContext.userId());
@@ -352,18 +356,28 @@ public class BigQueryAgentAnalyticsPlugin extends BasePlugin {
 
   /**
    * Resolves the agent name defensively. Workflow-driven callbacks may have no current agent; fall
-   * back to a sentinel rather than letting an NPE drop the row.
+   * back to the event author (via {@code EventData.fallbackAgentName}, mirroring the Python plugin)
+   * and finally to a sentinel, rather than letting an NPE drop the row.
    */
-  private static String resolveAgentName(InvocationContext invocationContext) {
+  private static String resolveAgentName(
+      InvocationContext invocationContext, Optional<EventData> eventData) {
     try {
       BaseAgent agent = invocationContext.agent();
       if (agent != null && agent.name() != null) {
         return agent.name();
       }
     } catch (RuntimeException e) {
-      // Fall through to the sentinel below.
+      // Fall through to the author/sentinel fallback below.
     }
-    return "unknown";
+    return eventData.flatMap(EventData::fallbackAgentName).orElse("unknown");
+  }
+
+  private static EventData.Builder withFallbackAgent(
+      EventData.Builder builder, @Nullable String author) {
+    if (author != null && !author.isEmpty()) {
+      builder.setFallbackAgentName(author);
+    }
+    return builder;
   }
 
   private ResolvedTraceIds getResolvedTraceIds(
@@ -525,12 +539,14 @@ public class BigQueryAgentAnalyticsPlugin extends BasePlugin {
     Completable logCompletable = Completable.complete();
     if (!event.actions().stateDelta().isEmpty()) {
       EventData.Builder eventDataBuilder =
-          EventData.builder()
-              .setExtraAttributes(
-                  ImmutableMap.<String, Object>builder()
-                      .put("state_delta", event.actions().stateDelta())
-                      .put("author", event.author())
-                      .buildOrThrow());
+          withFallbackAgent(
+              EventData.builder()
+                  .setExtraAttributes(
+                      ImmutableMap.<String, Object>builder()
+                          .put("state_delta", event.actions().stateDelta())
+                          .put("author", event.author())
+                          .buildOrThrow()),
+              event.author());
       logCompletable =
           logEvent(
               "STATE_DELTA",
@@ -618,7 +634,11 @@ public class BigQueryAgentAnalyticsPlugin extends BasePlugin {
                     invocationContext,
                     contentObject,
                     a2aTruncated.isTruncated() || contentTruncated,
-                    Optional.of(EventData.builder().setExtraAttributes(extraAttributes).build())));
+                    Optional.of(
+                        withFallbackAgent(
+                                EventData.builder().setExtraAttributes(extraAttributes),
+                                event.author())
+                            .build())));
       }
     }
 
@@ -653,7 +673,11 @@ public class BigQueryAgentAnalyticsPlugin extends BasePlugin {
                     invocationContext,
                     visibleContent,
                     false,
-                    Optional.of(EventData.builder().setExtraAttributes(extraAttributes).build())));
+                    Optional.of(
+                        withFallbackAgent(
+                                EventData.builder().setExtraAttributes(extraAttributes),
+                                event.author())
+                            .build())));
       }
     }
 

--- a/core/src/main/java/com/google/adk/plugins/agentanalytics/BigQueryAgentAnalyticsPlugin.java
+++ b/core/src/main/java/com/google/adk/plugins/agentanalytics/BigQueryAgentAnalyticsPlugin.java
@@ -51,6 +51,7 @@ import com.google.cloud.bigquery.StandardTableDefinition;
 import com.google.cloud.bigquery.Table;
 import com.google.cloud.bigquery.TableId;
 import com.google.cloud.bigquery.TableInfo;
+import com.google.cloud.bigquery.TimePartitioning;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -65,10 +66,12 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.jspecify.annotations.Nullable;
@@ -105,6 +108,9 @@ public class BigQueryAgentAnalyticsPlugin extends BasePlugin {
   public BigQueryAgentAnalyticsPlugin(BigQueryLoggerConfig config, BigQuery bigQuery)
       throws IOException {
     this(config, bigQuery, new PluginState(config));
+    // Register on the public construction paths only (not the package-private test constructor),
+    // so a host that never calls close() still gets a best-effort drain at JVM exit.
+    registerShutdownHook();
   }
 
   BigQueryAgentAnalyticsPlugin(BigQueryLoggerConfig config, BigQuery bigQuery, PluginState state) {
@@ -112,6 +118,31 @@ public class BigQueryAgentAnalyticsPlugin extends BasePlugin {
     this.config = config;
     this.bigQuery = bigQuery;
     this.state = state;
+  }
+
+  private void registerShutdownHook() {
+    Runtime.getRuntime()
+        .addShutdownHook(
+            new Thread(
+                () -> {
+                  try {
+                    state
+                        .close()
+                        .blockingAwait(config.shutdownTimeout().toMillis(), TimeUnit.MILLISECONDS);
+                  } catch (RuntimeException e) {
+                    logger.log(Level.WARNING, "Error draining BQAA analytics on JVM shutdown", e);
+                  }
+                },
+                "bq-analytics-shutdown"));
+  }
+
+  /**
+   * Returns aggregated dropped-row counters keyed by reason ({@code queue_full}, {@code
+   * append_error}, {@code serialization_error}). Non-zero values indicate analytics rows that never
+   * reached BigQuery.
+   */
+  public ImmutableMap<String, Long> getDropStats() {
+    return state.getDropStats();
   }
 
   private static BigQuery createBigQuery(BigQueryLoggerConfig config) throws IOException {
@@ -133,24 +164,36 @@ public class BigQueryAgentAnalyticsPlugin extends BasePlugin {
     if (!tableEnsured) {
       synchronized (tableEnsuredLock) {
         if (!tableEnsured) {
-          // Table creation is expensive, so we only do it once per plugin instance.
-          tableEnsured = true;
-          ensureTableExists(bigQuery, config);
+          // Only mark the table as ensured after a successful setup, so a transient first-run
+          // failure (auth blip, missing dataset, quota) is retried on subsequent events instead
+          // of permanently disabling table creation/upgrade for this plugin instance.
+          if (ensureTableExists(bigQuery, config)) {
+            tableEnsured = true;
+          }
         }
       }
     }
   }
 
-  private void ensureTableExists(BigQuery bigQuery, BigQueryLoggerConfig config) {
+  /** Returns true if the events table is present (created or already existed) and ready. */
+  private boolean ensureTableExists(BigQuery bigQuery, BigQueryLoggerConfig config) {
     TableId tableId = TableId.of(config.projectId(), config.datasetId(), config.tableName());
     Schema schema = BigQuerySchema.getEventsSchema();
+    boolean tableReady = false;
     try {
       Table table = bigQuery.getTable(tableId);
-      logger.info("BigQuery table: " + tableId);
+      logger.fine("BigQuery table: " + tableId);
       if (table == null) {
         logger.info("Creating BigQuery table: " + tableId);
         StandardTableDefinition.Builder tableDefinitionBuilder =
-            StandardTableDefinition.newBuilder().setSchema(schema);
+            StandardTableDefinition.newBuilder()
+                .setSchema(schema)
+                // Day-partition on the event timestamp for cost/pruning parity with the Python
+                // plugin. Time-filtered analytics queries prune partitions instead of full scans.
+                .setTimePartitioning(
+                    TimePartitioning.newBuilder(TimePartitioning.Type.DAY)
+                        .setField("timestamp")
+                        .build());
         if (!config.clusteringFields().isEmpty()) {
           tableDefinitionBuilder.setClustering(
               Clustering.newBuilder().setFields(config.clusteringFields()).build());
@@ -161,10 +204,21 @@ public class BigQueryAgentAnalyticsPlugin extends BasePlugin {
                     ImmutableMap.of(
                         BigQuerySchema.SCHEMA_VERSION_LABEL_KEY, BigQuerySchema.SCHEMA_VERSION))
                 .build();
-        bigQuery.create(tableInfo);
+        try {
+          bigQuery.create(tableInfo);
+        } catch (BigQueryException e) {
+          // Another writer may have created the table concurrently; treat that as success.
+          String msg = e.getMessage();
+          if (msg != null && msg.toLowerCase(Locale.ROOT).contains("already exists")) {
+            logger.info("BigQuery table already exists (concurrent create): " + tableId);
+          } else {
+            throw e;
+          }
+        }
       } else if (config.autoSchemaUpgrade()) {
         maybeUpgradeSchema(bigQuery, table);
       }
+      tableReady = true;
     } catch (BigQueryException e) {
       processBigQueryException(e, "Failed to check or create/upgrade BigQuery table: " + tableId);
     } catch (RuntimeException e) {
@@ -178,6 +232,7 @@ public class BigQueryAgentAnalyticsPlugin extends BasePlugin {
     } catch (RuntimeException e) {
       logger.log(Level.WARNING, "Failed to create/update BigQuery views for table: " + tableId, e);
     }
+    return tableReady;
   }
 
   private void processBigQueryException(BigQueryException e, String logMessage) {
@@ -234,7 +289,7 @@ public class BigQueryAgentAnalyticsPlugin extends BasePlugin {
     Map<String, Object> row = new HashMap<>();
     row.put("timestamp", Instant.now());
     row.put("event_type", eventType);
-    row.put("agent", invocationContext.agent().name());
+    row.put("agent", resolveAgentName(invocationContext));
     row.put("session_id", invocationContext.session().id());
     row.put("invocation_id", invocationContext.invocationId());
     row.put("user_id", invocationContext.userId());
@@ -295,6 +350,22 @@ public class BigQueryAgentAnalyticsPlugin extends BasePlugin {
     return Completable.complete();
   }
 
+  /**
+   * Resolves the agent name defensively. Workflow-driven callbacks may have no current agent; fall
+   * back to a sentinel rather than letting an NPE drop the row.
+   */
+  private static String resolveAgentName(InvocationContext invocationContext) {
+    try {
+      BaseAgent agent = invocationContext.agent();
+      if (agent != null && agent.name() != null) {
+        return agent.name();
+      }
+    } catch (RuntimeException e) {
+      // Fall through to the sentinel below.
+    }
+    return "unknown";
+  }
+
   private ResolvedTraceIds getResolvedTraceIds(
       InvocationContext invocationContext, Optional<EventData> eventData) {
     TraceManager traceManager = state.getTraceManager(invocationContext.invocationId());
@@ -329,6 +400,9 @@ public class BigQueryAgentAnalyticsPlugin extends BasePlugin {
       EventData eventData, InvocationContext invocationContext) {
     Map<String, Object> attributes = new HashMap<>(eventData.extraAttributes());
     TraceManager traceManager = state.getTraceManager(invocationContext.invocationId());
+    // Populate the root agent name from the invocation context if it has not been set yet, so
+    // attributes.root_agent_name is a real name rather than the sentinel default.
+    traceManager.initTraceIfNeeded(invocationContext);
     attributes.put("root_agent_name", traceManager.getRootAgentName());
     eventData.model().ifPresent(m -> attributes.put("model", m));
     eventData.modelVersion().ifPresent(mv -> attributes.put("model_version", mv));
@@ -446,19 +520,24 @@ public class BigQueryAgentAnalyticsPlugin extends BasePlugin {
     if (state.isProcessed(invocationContext.invocationId())) {
       return Maybe.empty();
     }
-    EventData.Builder eventDataBuilder =
-        EventData.builder()
-            .setExtraAttributes(
-                ImmutableMap.<String, Object>builder()
-                    .put("state_delta", event.actions().stateDelta())
-                    .put("author", event.author())
-                    .buildOrThrow());
-    Completable logCompletable =
-        logEvent(
-            "STATE_DELTA",
-            invocationContext,
-            event.content().orElse(null),
-            Optional.of(eventDataBuilder.build()));
+    // Only emit STATE_DELTA when there is an actual state change, matching the Python plugin
+    // (which does not write a STATE_DELTA row for events with an empty state delta).
+    Completable logCompletable = Completable.complete();
+    if (!event.actions().stateDelta().isEmpty()) {
+      EventData.Builder eventDataBuilder =
+          EventData.builder()
+              .setExtraAttributes(
+                  ImmutableMap.<String, Object>builder()
+                      .put("state_delta", event.actions().stateDelta())
+                      .put("author", event.author())
+                      .buildOrThrow());
+      logCompletable =
+          logEvent(
+              "STATE_DELTA",
+              invocationContext,
+              event.content().orElse(null),
+              Optional.of(eventDataBuilder.build()));
+    }
 
     if (event.content().isPresent() && event.content().get().parts().isPresent()) {
       for (Part part : event.content().get().parts().get()) {

--- a/core/src/main/java/com/google/adk/plugins/agentanalytics/BigQueryAgentAnalyticsPlugin.java
+++ b/core/src/main/java/com/google/adk/plugins/agentanalytics/BigQueryAgentAnalyticsPlugin.java
@@ -387,8 +387,11 @@ public class BigQueryAgentAnalyticsPlugin extends BasePlugin {
         eventData
             .flatMap(EventData::traceIdOverride)
             .orElseGet(() -> traceManager.getTraceId(invocationContext));
-    Optional<SpanIds> ambientSpanIds = traceManager.getAmbientSpanAndParent();
-    SpanIds spanIds = ambientSpanIds.orElse(traceManager.getCurrentSpanAndParent());
+    // span_id / parent_span_id must reference the BQAA internal execution tree (spans that are
+    // written as rows), not an ambient OpenTelemetry framework span that is never logged as a row.
+    // Otherwise parent_span_id would dangle. Ambient OTel still governs trace_id (via getTraceId)
+    // for cross-system correlation.
+    SpanIds spanIds = traceManager.getCurrentSpanAndParent();
 
     return new ResolvedTraceIds(
         traceId,
@@ -481,15 +484,13 @@ public class BigQueryAgentAnalyticsPlugin extends BasePlugin {
     EventData.Builder eventDataBuilder = EventData.builder();
     eventDataBuilder.setTraceIdOverride(traceId);
     eventDataBuilder.setLatency(popped.get().duration());
-    // Only override span IDs when no ambient OTel span exists.
-    // Keep STARTING/COMPLETED pairs consistent.
-    if (!traceManager.hasAmbientSpan()) {
-      if (parentSpanId.isPresent()) {
-        eventDataBuilder.setParentSpanIdOverride(parentSpanId.get());
-      }
-      if (popped.get().spanId() != null) {
-        eventDataBuilder.setSpanIdOverride(popped.get().spanId());
-      }
+    // Always record the internal execution-tree span so the STARTING/COMPLETED pair stays
+    // internally joinable and parent_span_id references a logged row, regardless of ambient OTel.
+    if (parentSpanId.isPresent()) {
+      eventDataBuilder.setParentSpanIdOverride(parentSpanId.get());
+    }
+    if (popped.get().spanId() != null) {
+      eventDataBuilder.setSpanIdOverride(popped.get().spanId());
     }
     return Optional.of(eventDataBuilder.build());
   }
@@ -860,8 +861,9 @@ public class BigQueryAgentAnalyticsPlugin extends BasePlugin {
       }
     }
 
-    boolean hasAmbient = traceManager.hasAmbientSpan();
-    boolean useOverride = isPopped && !hasAmbient;
+    // Always record the internal execution-tree span for the final response so parent_span_id
+    // references a logged row, regardless of any ambient OpenTelemetry span.
+    boolean useOverride = isPopped;
 
     EventData.Builder eventDataBuilder = EventData.builder();
     if (!duration.isZero()) {
@@ -909,19 +911,17 @@ public class BigQueryAgentAnalyticsPlugin extends BasePlugin {
     SpanIds spanIds = traceManager.getCurrentSpanAndParent();
     String parentSpanId = spanIds.spanId().orElse(null);
 
-    boolean hasAmbient = traceManager.hasAmbientSpan();
     EventData.Builder eventDataBuilder =
         EventData.builder().setStatus("ERROR").setErrorMessage(error.getMessage());
     if (popped.isPresent()) {
       eventDataBuilder.setLatency(popped.get().duration());
     }
-    if (!hasAmbient) {
-      if (spanId != null) {
-        eventDataBuilder.setSpanIdOverride(spanId);
-      }
-      if (parentSpanId != null) {
-        eventDataBuilder.setParentSpanIdOverride(parentSpanId);
-      }
+    // Always record the internal execution-tree span so parent_span_id references a logged row.
+    if (spanId != null) {
+      eventDataBuilder.setSpanIdOverride(spanId);
+    }
+    if (parentSpanId != null) {
+      eventDataBuilder.setParentSpanIdOverride(parentSpanId);
     }
     return logEvent("LLM_ERROR", invocationContext, null, Optional.of(eventDataBuilder.build()))
         .andThen(Maybe.empty());
@@ -966,16 +966,14 @@ public class BigQueryAgentAnalyticsPlugin extends BasePlugin {
             getToolOrigin(tool));
 
     SpanIds spanIds = traceManager.getCurrentSpanAndParent();
-    boolean hasAmbient = traceManager.hasAmbientSpan();
 
     EventData.Builder eventDataBuilder = EventData.builder();
     if (popped.isPresent()) {
       eventDataBuilder.setLatency(popped.get().duration());
     }
-    if (!hasAmbient) {
-      popped.ifPresent(p -> eventDataBuilder.setSpanIdOverride(p.spanId()));
-      spanIds.spanId().ifPresent(eventDataBuilder::setParentSpanIdOverride);
-    }
+    // Always record the internal execution-tree span so parent_span_id references a logged row.
+    popped.ifPresent(p -> eventDataBuilder.setSpanIdOverride(p.spanId()));
+    spanIds.spanId().ifPresent(eventDataBuilder::setParentSpanIdOverride);
 
     return logEvent(
             "TOOL_COMPLETED",
@@ -1008,17 +1006,15 @@ public class BigQueryAgentAnalyticsPlugin extends BasePlugin {
             .buildOrThrow();
 
     SpanIds spanIds = traceManager.getCurrentSpanAndParent();
-    boolean hasAmbient = traceManager.hasAmbientSpan();
 
     EventData.Builder eventDataBuilder =
         EventData.builder().setStatus("ERROR").setErrorMessage(error.getMessage());
     if (popped.isPresent()) {
       eventDataBuilder.setLatency(popped.get().duration());
     }
-    if (!hasAmbient) {
-      popped.ifPresent(p -> eventDataBuilder.setSpanIdOverride(p.spanId()));
-      spanIds.spanId().ifPresent(eventDataBuilder::setParentSpanIdOverride);
-    }
+    // Always record the internal execution-tree span so parent_span_id references a logged row.
+    popped.ifPresent(p -> eventDataBuilder.setSpanIdOverride(p.spanId()));
+    spanIds.spanId().ifPresent(eventDataBuilder::setParentSpanIdOverride);
 
     return logEvent(
             "TOOL_ERROR",

--- a/core/src/main/java/com/google/adk/plugins/agentanalytics/BigQueryLoggerConfig.java
+++ b/core/src/main/java/com/google/adk/plugins/agentanalytics/BigQueryLoggerConfig.java
@@ -222,7 +222,23 @@ public abstract class BigQueryLoggerConfig {
     @CanIgnoreReturnValue
     public abstract Builder credentials(Credentials credentials);
 
-    public abstract BigQueryLoggerConfig build();
+    abstract BigQueryLoggerConfig autoBuild();
+
+    public BigQueryLoggerConfig build() {
+      BigQueryLoggerConfig config = autoBuild();
+      if (config.batchSize() <= 0) {
+        throw new IllegalArgumentException("batchSize must be positive, got " + config.batchSize());
+      }
+      if (config.queueMaxSize() <= 0) {
+        throw new IllegalArgumentException(
+            "queueMaxSize must be positive, got " + config.queueMaxSize());
+      }
+      if (config.maxContentLength() <= 0) {
+        throw new IllegalArgumentException(
+            "maxContentLength must be positive, got " + config.maxContentLength());
+      }
+      return config;
+    }
   }
 
   /** Retry configuration for BigQuery writes. */

--- a/core/src/main/java/com/google/adk/plugins/agentanalytics/BigQueryUtils.java
+++ b/core/src/main/java/com/google/adk/plugins/agentanalytics/BigQueryUtils.java
@@ -233,7 +233,7 @@ final class BigQueryUtils {
   }
 
   /** Adds missing columns to an existing table if the actual schema is behind the desired schema. */
-  static void maybeUpgradeSchema(BigQuery bigQuery, Table existingTable) {
+  static boolean maybeUpgradeSchema(BigQuery bigQuery, Table existingTable) {
     // Always diff the actual table schema against the desired schema rather than trusting the
     // stored version label alone: a table stamped with the current label can still be missing
     // columns (e.g. it was created by an older build), and those must be reconciled.
@@ -242,7 +242,12 @@ final class BigQueryUtils {
             existingTable.getDefinition().getSchema().getFields(),
             BigQuerySchema.getEventsSchema().getFields());
 
-    if (!diff.newTopLevelFields().isEmpty() || !diff.updatedRecordFields().isEmpty()) {
+    if (diff.newTopLevelFields().isEmpty() && diff.updatedRecordFields().isEmpty()) {
+      // Nothing to reconcile; the table already satisfies the desired schema.
+      return true;
+    }
+
+    {
       ImmutableMap<String, Field> updatedFields =
           diff.updatedRecordFields().stream().collect(toImmutableMap(Field::getName, f -> f));
       ImmutableSet<String> updatedNames = updatedFields.keySet();
@@ -281,9 +286,11 @@ final class BigQueryUtils {
                 .build();
 
         var unused = bigQuery.update(updatedTable);
+        return true;
       } catch (BigQueryException e) {
         logger.log(
             Level.WARNING, "Schema auto-upgrade failed for " + existingTable.getTableId(), e);
+        return false;
       }
     }
   }
@@ -325,24 +332,41 @@ final class BigQueryUtils {
                   .setType(StandardSQLTypeName.STRUCT, FieldList.of(mergedSub))
                   .build());
         }
-      } else if (!desiredField
-          .getType()
-          .getStandardType()
-          .equals(existingField.getType().getStandardType())) {
-        // Additive auto-upgrade cannot reconcile a type change on an existing column. Surface it
-        // instead of silently ignoring it, since it will otherwise appear later as opaque Storage
+      } else {
+        // Additive auto-upgrade cannot reconcile a type or mode change on an existing column
+        // (including nested non-STRUCT fields, since this method recurses into STRUCTs). Surface
+        // it instead of silently ignoring it, since it otherwise appears later as opaque Storage
         // Write append failures.
-        logger.warning(
-            String.format(
-                "Incompatible schema drift on column '%s': table has %s but the plugin expects %s."
-                    + " This cannot be auto-upgraded; writes may fail until the column is fixed"
-                    + " manually.",
-                desiredField.getName(),
-                existingField.getType().getStandardType(),
-                desiredField.getType().getStandardType()));
+        boolean typeDrift =
+            !desiredField
+                .getType()
+                .getStandardType()
+                .equals(existingField.getType().getStandardType());
+        boolean modeDrift = !modesEqual(existingField.getMode(), desiredField.getMode());
+        if (typeDrift || modeDrift) {
+          logger.warning(
+              String.format(
+                  "Incompatible schema drift on column '%s': table has %s/%s but the plugin expects"
+                      + " %s/%s. This cannot be auto-upgraded; writes may fail until the column is"
+                      + " fixed manually.",
+                  desiredField.getName(),
+                  existingField.getType().getStandardType(),
+                  normalizeMode(existingField.getMode()),
+                  desiredField.getType().getStandardType(),
+                  normalizeMode(desiredField.getMode())));
+        }
       }
     }
     return new SchemaDiff(ImmutableList.copyOf(newFields), ImmutableList.copyOf(updatedRecords));
+  }
+
+  // BigQuery leaves Field.getMode() null to mean NULLABLE; normalize before comparing.
+  private static Field.Mode normalizeMode(Field.Mode mode) {
+    return mode == null ? Field.Mode.NULLABLE : mode;
+  }
+
+  private static boolean modesEqual(Field.Mode a, Field.Mode b) {
+    return normalizeMode(a) == normalizeMode(b);
   }
 
   private record SchemaDiff(

--- a/core/src/main/java/com/google/adk/plugins/agentanalytics/BigQueryUtils.java
+++ b/core/src/main/java/com/google/adk/plugins/agentanalytics/BigQueryUtils.java
@@ -232,7 +232,9 @@ final class BigQueryUtils {
     }
   }
 
-  /** Adds missing columns to an existing table if the actual schema is behind the desired schema. */
+  /**
+   * Adds missing columns to an existing table if the actual schema is behind the desired schema.
+   */
   static boolean maybeUpgradeSchema(BigQuery bigQuery, Table existingTable) {
     // Always diff the actual table schema against the desired schema rather than trusting the
     // stored version label alone: a table stamped with the current label can still be missing
@@ -310,6 +312,9 @@ final class BigQueryUtils {
       } else if (desiredField.getType().getStandardType().equals(StandardSQLTypeName.STRUCT)
           && existingField.getType().getStandardType().equals(StandardSQLTypeName.STRUCT)
           && desiredField.getSubFields() != null) {
+        // Mode drift on the STRUCT column itself (e.g. NULLABLE vs REPEATED) is just as
+        // un-upgradeable as on a scalar; check it before recursing into subfields.
+        warnOnIncompatibleDrift(existingField, desiredField);
 
         SchemaDiff subDiff =
             schemaFieldsMatch(existingField.getSubFields(), desiredField.getSubFields());
@@ -333,31 +338,32 @@ final class BigQueryUtils {
                   .build());
         }
       } else {
-        // Additive auto-upgrade cannot reconcile a type or mode change on an existing column
-        // (including nested non-STRUCT fields, since this method recurses into STRUCTs). Surface
-        // it instead of silently ignoring it, since it otherwise appears later as opaque Storage
-        // Write append failures.
-        boolean typeDrift =
-            !desiredField
-                .getType()
-                .getStandardType()
-                .equals(existingField.getType().getStandardType());
-        boolean modeDrift = !modesEqual(existingField.getMode(), desiredField.getMode());
-        if (typeDrift || modeDrift) {
-          logger.warning(
-              String.format(
-                  "Incompatible schema drift on column '%s': table has %s/%s but the plugin expects"
-                      + " %s/%s. This cannot be auto-upgraded; writes may fail until the column is"
-                      + " fixed manually.",
-                  desiredField.getName(),
-                  existingField.getType().getStandardType(),
-                  normalizeMode(existingField.getMode()),
-                  desiredField.getType().getStandardType(),
-                  normalizeMode(desiredField.getMode())));
-        }
+        warnOnIncompatibleDrift(existingField, desiredField);
       }
     }
     return new SchemaDiff(ImmutableList.copyOf(newFields), ImmutableList.copyOf(updatedRecords));
+  }
+
+  // Additive auto-upgrade cannot reconcile a type or mode change on an existing column
+  // (including nested non-STRUCT fields, since schemaFieldsMatch recurses into STRUCTs). Surface
+  // it instead of silently ignoring it, since it otherwise appears later as opaque Storage
+  // Write append failures.
+  private static void warnOnIncompatibleDrift(Field existingField, Field desiredField) {
+    boolean typeDrift =
+        !desiredField.getType().getStandardType().equals(existingField.getType().getStandardType());
+    boolean modeDrift = !modesEqual(existingField.getMode(), desiredField.getMode());
+    if (typeDrift || modeDrift) {
+      logger.warning(
+          String.format(
+              "Incompatible schema drift on column '%s': table has %s/%s but the plugin expects"
+                  + " %s/%s. This cannot be auto-upgraded; writes may fail until the column is"
+                  + " fixed manually.",
+              desiredField.getName(),
+              existingField.getType().getStandardType(),
+              normalizeMode(existingField.getMode()),
+              desiredField.getType().getStandardType(),
+              normalizeMode(desiredField.getMode())));
+    }
   }
 
   // BigQuery leaves Field.getMode() null to mean NULLABLE; normalize before comparing.

--- a/core/src/main/java/com/google/adk/plugins/agentanalytics/BigQueryUtils.java
+++ b/core/src/main/java/com/google/adk/plugins/agentanalytics/BigQueryUtils.java
@@ -16,8 +16,6 @@
 
 package com.google.adk.plugins.agentanalytics;
 
-import static com.google.adk.plugins.agentanalytics.BigQuerySchema.SCHEMA_VERSION;
-import static com.google.adk.plugins.agentanalytics.BigQuerySchema.SCHEMA_VERSION_LABEL_KEY;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static java.util.stream.Collectors.toCollection;
@@ -179,8 +177,27 @@ final class BigQueryUtils {
     return FRAMEWORK_PREFIX + "/" + Version.JAVA_ADK_VERSION;
   }
 
+  private static final java.util.regex.Pattern SAFE_IDENTIFIER =
+      java.util.regex.Pattern.compile("[A-Za-z0-9_\\-]+");
+
+  private static boolean isSafeIdentifier(String id) {
+    return id != null && SAFE_IDENTIFIER.matcher(id).matches();
+  }
+
   /** Creates and/or replaces the analytics views in BigQuery. */
   static void createAnalyticsViews(BigQuery bigQuery, BigQueryLoggerConfig config) {
+    // View DDL is assembled by string interpolation; refuse to build it if any operator-supplied
+    // identifier contains characters (backticks, quotes, dots, semicolons) that could break or
+    // redirect the statement.
+    if (!isSafeIdentifier(config.projectId())
+        || !isSafeIdentifier(config.datasetId())
+        || !isSafeIdentifier(config.tableName())
+        || !isSafeIdentifier(config.viewPrefix())) {
+      logger.warning(
+          "Skipping analytics view creation: project/dataset/table/viewPrefix contains characters"
+              + " that are unsafe to interpolate into DDL.");
+      return;
+    }
     for (Map.Entry<String, ImmutableList<String>> entry : EVENT_VIEW_DEFS.entrySet()) {
       String eventType = entry.getKey();
       ImmutableList<String> extraCols = entry.getValue();
@@ -215,17 +232,11 @@ final class BigQueryUtils {
     }
   }
 
-  /** Adds missing columns to an existing table if the schema version has changed. */
+  /** Adds missing columns to an existing table if the actual schema is behind the desired schema. */
   static void maybeUpgradeSchema(BigQuery bigQuery, Table existingTable) {
-    String storedVersion =
-        Optional.ofNullable(existingTable.getLabels())
-            .map(labels -> labels.get(SCHEMA_VERSION_LABEL_KEY))
-            .orElse("");
-
-    if (storedVersion.equals(SCHEMA_VERSION)) {
-      return;
-    }
-
+    // Always diff the actual table schema against the desired schema rather than trusting the
+    // stored version label alone: a table stamped with the current label can still be missing
+    // columns (e.g. it was created by an older build), and those must be reconciled.
     SchemaDiff diff =
         schemaFieldsMatch(
             existingTable.getDefinition().getSchema().getFields(),
@@ -314,6 +325,21 @@ final class BigQueryUtils {
                   .setType(StandardSQLTypeName.STRUCT, FieldList.of(mergedSub))
                   .build());
         }
+      } else if (!desiredField
+          .getType()
+          .getStandardType()
+          .equals(existingField.getType().getStandardType())) {
+        // Additive auto-upgrade cannot reconcile a type change on an existing column. Surface it
+        // instead of silently ignoring it, since it will otherwise appear later as opaque Storage
+        // Write append failures.
+        logger.warning(
+            String.format(
+                "Incompatible schema drift on column '%s': table has %s but the plugin expects %s."
+                    + " This cannot be auto-upgraded; writes may fail until the column is fixed"
+                    + " manually.",
+                desiredField.getName(),
+                existingField.getType().getStandardType(),
+                desiredField.getType().getStandardType()));
       }
     }
     return new SchemaDiff(ImmutableList.copyOf(newFields), ImmutableList.copyOf(updatedRecords));

--- a/core/src/main/java/com/google/adk/plugins/agentanalytics/EventData.java
+++ b/core/src/main/java/com/google/adk/plugins/agentanalytics/EventData.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.google.adk.plugins.agentanalytics;
 
 import com.google.auto.value.AutoValue;
@@ -6,7 +22,7 @@ import java.time.Duration;
 import java.util.Map;
 import java.util.Optional;
 
-/** Typed container for structured fields passed to _log_event. */
+/** Typed container for structured fields passed to the plugin's event-logging method. */
 @AutoValue
 abstract class EventData {
   abstract Optional<String> spanIdOverride();

--- a/core/src/main/java/com/google/adk/plugins/agentanalytics/EventData.java
+++ b/core/src/main/java/com/google/adk/plugins/agentanalytics/EventData.java
@@ -47,6 +47,10 @@ abstract class EventData {
 
   abstract Optional<String> traceIdOverride();
 
+  // Fallback name for the `agent` column when the InvocationContext has no current agent (e.g.
+  // workflow-driven callbacks). Mirrors the Python plugin's fallback to Event.author.
+  abstract Optional<String> fallbackAgentName();
+
   static Builder builder() {
     return new AutoValue_EventData.Builder().setStatus("OK").setExtraAttributes(ImmutableMap.of());
   }
@@ -74,6 +78,8 @@ abstract class EventData {
     abstract Builder setExtraAttributes(Map<String, Object> value);
 
     abstract Builder setTraceIdOverride(String value);
+
+    abstract Builder setFallbackAgentName(String value);
 
     abstract EventData build();
   }

--- a/core/src/main/java/com/google/adk/plugins/agentanalytics/JsonFormatter.java
+++ b/core/src/main/java/com/google/adk/plugins/agentanalytics/JsonFormatter.java
@@ -24,6 +24,7 @@ import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.auto.value.AutoValue;
 import com.google.common.base.Utf8;
+import com.google.common.collect.ImmutableSet;
 import java.util.IdentityHashMap;
 import java.util.Map;
 import java.util.Set;
@@ -36,6 +37,23 @@ final class JsonFormatter {
   static final ObjectMapper mapper = new ObjectMapper().findAndRegisterModules();
   static final String TRUNCATION_SUFFIX = "...[truncated]";
   static final String CYCLE_DETECTED_MESSAGE = "[cycle detected]";
+  static final String MAX_DEPTH_MESSAGE = "[max depth exceeded]";
+  static final String REDACTED_MESSAGE = "[REDACTED]";
+  // Guard against unbounded recursion on deeply nested (non-cyclic) payloads.
+  static final int MAX_TRUNCATE_DEPTH = 200;
+
+  // Keys whose values are redacted before logging. Mirrors the Python BQAA plugin's
+  // _SENSITIVE_KEYS (OAuth tokens / secrets); matching is case-insensitive, plus any
+  // key prefixed with "temp:" (ADK temporary session state).
+  private static final ImmutableSet<String> SENSITIVE_KEYS =
+      ImmutableSet.of(
+          "client_secret", "access_token", "refresh_token", "id_token", "api_key", "password");
+  private static final String TEMP_KEY_PREFIX = "temp:";
+
+  private static boolean isSensitiveKey(String key) {
+    String lower = key.toLowerCase(java.util.Locale.ROOT);
+    return SENSITIVE_KEYS.contains(lower) || lower.startsWith(TEMP_KEY_PREFIX);
+  }
 
   @AutoValue
   abstract static class TruncationResult {
@@ -55,12 +73,14 @@ final class JsonFormatter {
     }
     try {
       if (obj instanceof JsonNode jsonNode) {
-        return recursiveSmartTruncate(jsonNode, maxLength, newSetFromMap(new IdentityHashMap<>()));
+        return recursiveSmartTruncate(
+            jsonNode, maxLength, newSetFromMap(new IdentityHashMap<>()), 0);
       }
       return recursiveSmartTruncate(
-          mapper.valueToTree(obj), maxLength, newSetFromMap(new IdentityHashMap<>()));
+          mapper.valueToTree(obj), maxLength, newSetFromMap(new IdentityHashMap<>()), 0);
     } catch (IllegalArgumentException e) {
-      // Fallback for types that mapper can't handle directly as a tree
+      // Fallback for types that mapper can't handle directly as a tree.
+      logger.fine("smartTruncate falling back to string conversion: " + e.getMessage());
       return truncateWithStatus(safeToString(obj), maxLength);
     }
   }
@@ -87,7 +107,10 @@ final class JsonFormatter {
   }
 
   private static TruncationResult recursiveSmartTruncate(
-      JsonNode node, int maxLength, Set<JsonNode> visited) {
+      JsonNode node, int maxLength, Set<JsonNode> visited, int depth) {
+    if (depth > MAX_TRUNCATE_DEPTH) {
+      return TruncationResult.create(mapper.valueToTree(MAX_DEPTH_MESSAGE), true);
+    }
     if (node.isContainerNode()) {
       if (visited.contains(node)) {
         return TruncationResult.create(mapper.valueToTree(CYCLE_DETECTED_MESSAGE), true);
@@ -106,7 +129,14 @@ final class JsonFormatter {
         ObjectNode newNode = mapper.createObjectNode();
         Set<Map.Entry<String, JsonNode>> properties = node.properties();
         for (Map.Entry<String, JsonNode> entry : properties) {
-          TruncationResult res = recursiveSmartTruncate(entry.getValue(), maxLength, visited);
+          // Redact sensitive values without descending into them. Per parity with the
+          // Python plugin, redaction does not set the is_truncated flag.
+          if (isSensitiveKey(entry.getKey())) {
+            newNode.set(entry.getKey(), mapper.valueToTree(REDACTED_MESSAGE));
+            continue;
+          }
+          TruncationResult res =
+              recursiveSmartTruncate(entry.getValue(), maxLength, visited, depth + 1);
           newNode.set(entry.getKey(), res.node());
           isTruncated = isTruncated || res.isTruncated();
         }
@@ -114,7 +144,7 @@ final class JsonFormatter {
       } else if (node.isArray()) {
         ArrayNode newNode = mapper.createArrayNode();
         for (JsonNode element : node) {
-          TruncationResult res = recursiveSmartTruncate(element, maxLength, visited);
+          TruncationResult res = recursiveSmartTruncate(element, maxLength, visited, depth + 1);
           newNode.add(res.node());
           isTruncated = isTruncated || res.isTruncated();
         }

--- a/core/src/main/java/com/google/adk/plugins/agentanalytics/PluginState.java
+++ b/core/src/main/java/com/google/adk/plugins/agentanalytics/PluginState.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.google.adk.plugins.agentanalytics;
 
 import static com.google.adk.plugins.agentanalytics.BigQueryUtils.getVersionHeaderValue;
@@ -266,8 +282,9 @@ class PluginState {
               BatchProcessor processor = removeProcessor(invocationId);
               if (processor != null) {
                 processor.flush();
-                foldDropStats(processor);
                 processor.close();
+                // Fold after close() so rows dropped during the final drain are also counted.
+                foldDropStats(processor);
               }
               TraceManager traceManager = removeTraceManager(invocationId);
               if (traceManager != null) {
@@ -327,8 +344,9 @@ class PluginState {
         .doFinally(
             () -> {
               for (BatchProcessor processor : getBatchProcessors()) {
-                foldDropStats(processor);
                 processor.close();
+                // Fold after close() so rows dropped during the final drain are also counted.
+                foldDropStats(processor);
               }
               for (TraceManager traceManager : getTraceManagers()) {
                 traceManager.clearStack();

--- a/core/src/main/java/com/google/adk/plugins/agentanalytics/PluginState.java
+++ b/core/src/main/java/com/google/adk/plugins/agentanalytics/PluginState.java
@@ -20,6 +20,7 @@ import com.google.common.collect.ImmutableMap;
 import io.reactivex.rxjava3.core.Completable;
 import java.io.IOException;
 import java.util.Collection;
+import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ArrayBlockingQueue;
@@ -64,6 +65,11 @@ class PluginState {
   private final Parser parser;
   private final ConcurrentHashMap<String, Set<CompletableFuture<Void>>> pendingTasks =
       new ConcurrentHashMap<>();
+  // Drop counters accumulated from BatchProcessors that have already been closed/removed, so the
+  // aggregate survives per-invocation processor churn.
+  private final AtomicLong droppedQueueFull = new AtomicLong();
+  private final AtomicLong droppedAppendError = new AtomicLong();
+  private final AtomicLong droppedSerializationError = new AtomicLong();
 
   PluginState(BigQueryLoggerConfig config) throws IOException {
     this.config = config;
@@ -106,7 +112,7 @@ class PluginState {
   boolean isProcessed(String invocationId) {
     boolean isProcessed = processedInvocations.getIfPresent(invocationId) != null;
     if (isProcessed) {
-      logger.info("Invocation ID: " + invocationId + "  already processed");
+      logger.fine("Invocation ID: " + invocationId + "  already processed");
     }
     return isProcessed;
   }
@@ -142,6 +148,9 @@ class PluginState {
           .setTraceId(BigQueryUtils.getVersionHeaderValue() + ":" + UUID.randomUUID())
           .setRetrySettings(retrySettings)
           .setWriterSchema(BigQuerySchema.getArrowSchema())
+          // Route Storage Write append RPCs to the dataset's region. Without this, appends to any
+          // location other than the US multi-region can fail with stream-not-found errors.
+          .setLocation(config.location())
           .build();
     } catch (Exception e) {
       throw new VerifyException("Failed to create StreamWriter for " + streamName, e);
@@ -236,7 +245,7 @@ class PluginState {
           Completable.fromCompletionStage(
               CompletableFuture.allOf(tasks.toArray(new CompletableFuture<?>[0])));
     }
-    logger.info("Waiting for pending tasks to complete for invocation ID: " + invocationId);
+    logger.fine("Waiting for pending tasks to complete for invocation ID: " + invocationId);
     return tasksState
         .timeout(config.shutdownTimeout().toMillis(), MILLISECONDS)
         .doOnError(
@@ -257,15 +266,43 @@ class PluginState {
               BatchProcessor processor = removeProcessor(invocationId);
               if (processor != null) {
                 processor.flush();
+                foldDropStats(processor);
                 processor.close();
               }
               TraceManager traceManager = removeTraceManager(invocationId);
               if (traceManager != null) {
                 traceManager.clearStack();
               }
-              logger.info("Removing pending tasks for invocation ID: " + invocationId);
+              logger.fine("Removing pending tasks for invocation ID: " + invocationId);
               pendingTasks.remove(invocationId);
             });
+  }
+
+  private void foldDropStats(BatchProcessor processor) {
+    Map<String, Long> stats = processor.getDropStats();
+    droppedQueueFull.addAndGet(stats.getOrDefault("queue_full", 0L));
+    droppedAppendError.addAndGet(stats.getOrDefault("append_error", 0L));
+    droppedSerializationError.addAndGet(stats.getOrDefault("serialization_error", 0L));
+  }
+
+  /**
+   * Aggregated dropped-row counters across closed and still-live BatchProcessors. Non-zero values
+   * indicate analytics rows that never reached BigQuery.
+   */
+  ImmutableMap<String, Long> getDropStats() {
+    long queueFull = droppedQueueFull.get();
+    long appendError = droppedAppendError.get();
+    long serializationError = droppedSerializationError.get();
+    for (BatchProcessor processor : getBatchProcessors()) {
+      Map<String, Long> stats = processor.getDropStats();
+      queueFull += stats.getOrDefault("queue_full", 0L);
+      appendError += stats.getOrDefault("append_error", 0L);
+      serializationError += stats.getOrDefault("serialization_error", 0L);
+    }
+    return ImmutableMap.of(
+        "queue_full", queueFull,
+        "append_error", appendError,
+        "serialization_error", serializationError);
   }
 
   Completable close() {
@@ -290,6 +327,7 @@ class PluginState {
         .doFinally(
             () -> {
               for (BatchProcessor processor : getBatchProcessors()) {
+                foldDropStats(processor);
                 processor.close();
               }
               for (TraceManager traceManager : getTraceManagers()) {

--- a/core/src/main/java/com/google/adk/plugins/agentanalytics/TraceManager.java
+++ b/core/src/main/java/com/google/adk/plugins/agentanalytics/TraceManager.java
@@ -43,8 +43,10 @@ import java.util.logging.Logger;
 public final class TraceManager {
   private static final Logger logger = Logger.getLogger(TraceManager.class.getName());
 
+  static final String DEFAULT_ROOT_AGENT_NAME = "_bq_analytics_root_agent_name";
+
   private final ConcurrentLinkedDeque<SpanRecord> records = new ConcurrentLinkedDeque<>();
-  private String rootAgentName = "_bq_analytics_root_agent_name";
+  private String rootAgentName = DEFAULT_ROOT_AGENT_NAME;
   private String activeInvocationId = "_bq_analytics_active_invocation_id";
 
   private final Tracer tracer;
@@ -103,8 +105,26 @@ public final class TraceManager {
   }
 
   public void initTrace(InvocationContext context) {
-    String rootAgentName = context.agent().rootAgent().name();
-    this.rootAgentName = rootAgentName;
+    var rootAgent = context.agent().rootAgent();
+    if (rootAgent != null && rootAgent.name() != null) {
+      this.rootAgentName = rootAgent.name();
+    }
+  }
+
+  /**
+   * Sets the root agent name from the invocation context if it is still the sentinel default.
+   * Null-safe: workflow-driven callbacks with no current agent leave the sentinel in place for a
+   * later event to resolve.
+   */
+  public void initTraceIfNeeded(InvocationContext context) {
+    if (!DEFAULT_ROOT_AGENT_NAME.equals(rootAgentName)) {
+      return;
+    }
+    try {
+      initTrace(context);
+    } catch (RuntimeException e) {
+      // Leave the sentinel; a subsequent event may be able to resolve the root agent.
+    }
   }
 
   public String getTraceId(InvocationContext context) {
@@ -173,7 +193,7 @@ public final class TraceManager {
       if (currentInv.equals(activeInvocationId)) {
         return;
       }
-      logger.info("Clearing stale span records from previous invocation.");
+      logger.fine("Clearing stale span records from previous invocation.");
       clearStack();
     }
 

--- a/core/src/main/java/com/google/adk/plugins/agentanalytics/TraceManager.java
+++ b/core/src/main/java/com/google/adk/plugins/agentanalytics/TraceManager.java
@@ -24,7 +24,6 @@ import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanContext;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.context.Context;
-import io.opentelemetry.sdk.trace.ReadableSpan;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Iterator;
@@ -243,22 +242,6 @@ public final class TraceManager {
             .map(SpanRecord::spanId)
             .orElse(null);
     return SpanIds.create(spanId, parentId);
-  }
-
-  Optional<SpanIds> getAmbientSpanAndParent() {
-    Span ambient = Span.current();
-    if (!ambient.getSpanContext().isValid()) {
-      return Optional.empty();
-    }
-    String spanId = ambient.getSpanContext().getSpanId();
-    String parentSpanId = null;
-    if (ambient instanceof ReadableSpan readableSpan) {
-      SpanContext parentCtx = readableSpan.getParentSpanContext();
-      if (parentCtx != null && parentCtx.isValid()) {
-        parentSpanId = parentCtx.getSpanId();
-      }
-    }
-    return Optional.of(SpanIds.create(spanId, parentSpanId));
   }
 
   public Optional<String> getCurrentSpanId() {

--- a/core/src/test/java/com/google/adk/plugins/agentanalytics/BigQueryAgentAnalyticsPluginTest.java
+++ b/core/src/test/java/com/google/adk/plugins/agentanalytics/BigQueryAgentAnalyticsPluginTest.java
@@ -29,6 +29,7 @@ import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -545,6 +546,7 @@ public class BigQueryAgentAnalyticsPluginTest {
     Event event =
         Event.builder()
             .author("agent_author")
+            .actions(EventActions.builder().stateDelta(ImmutableMap.of("key", "new_value")).build())
             .content(Content.fromParts(Part.fromText("event content")))
             .build();
 
@@ -556,8 +558,20 @@ public class BigQueryAgentAnalyticsPluginTest {
     assertEquals("agent_name", row.get("agent"));
     ObjectNode attributes = (ObjectNode) row.get("attributes");
     assertEquals("agent_author", attributes.get("author").asText());
+    assertEquals("new_value", attributes.get("state_delta").get("key").asText());
     assertTrue(row.get("content").toString().contains("event content"));
     assertEquals(false, row.get("is_truncated"));
+  }
+
+  @Test
+  public void onEventCallback_emptyStateDelta_doesNotEmitStateDelta() throws Exception {
+    Event event = Event.builder().author("agent_author").build();
+
+    plugin.onEventCallback(mockInvocationContext, event).blockingSubscribe();
+
+    assertNull(
+        "No STATE_DELTA row should be emitted for an empty state delta",
+        state.getBatchProcessor("invocation_id").queue.poll());
   }
 
   @Test
@@ -580,10 +594,6 @@ public class BigQueryAgentAnalyticsPluginTest {
                 .getPendingTasksForInvocation("invocation_id")
                 .toArray(new CompletableFuture<?>[0]))
         .join();
-
-    Map<String, Object> stateDeltaRow = state.getBatchProcessor("invocation_id").queue.poll();
-    assertNotNull(stateDeltaRow);
-    assertEquals("STATE_DELTA", stateDeltaRow.get("event_type"));
 
     Map<String, Object> a2aRow = state.getBatchProcessor("invocation_id").queue.poll();
     assertNotNull("A2A_INTERACTION row not found in queue", a2aRow);
@@ -623,10 +633,6 @@ public class BigQueryAgentAnalyticsPluginTest {
                 .getPendingTasksForInvocation("invocation_id")
                 .toArray(new CompletableFuture<?>[0]))
         .join();
-
-    Map<String, Object> stateDeltaRow = state.getBatchProcessor("invocation_id").queue.poll();
-    assertNotNull(stateDeltaRow);
-    assertEquals("STATE_DELTA", stateDeltaRow.get("event_type"));
 
     Map<String, Object> agentResponseRow = state.getBatchProcessor("invocation_id").queue.poll();
     assertNotNull("AGENT_RESPONSE row not found in queue", agentResponseRow);
@@ -670,10 +676,6 @@ public class BigQueryAgentAnalyticsPluginTest {
                 .toArray(new CompletableFuture<?>[0]))
         .join();
 
-    Map<String, Object> stateDeltaRow = state.getBatchProcessor("invocation_id").queue.poll();
-    assertNotNull(stateDeltaRow);
-    assertEquals("STATE_DELTA", stateDeltaRow.get("event_type"));
-
     Map<String, Object> nextRow = state.getBatchProcessor("invocation_id").queue.poll();
     assertNull("No AGENT_RESPONSE row should be emitted", nextRow);
   }
@@ -698,10 +700,6 @@ public class BigQueryAgentAnalyticsPluginTest {
                 .toArray(new CompletableFuture<?>[0]))
         .join();
 
-    Map<String, Object> stateDeltaRow = state.getBatchProcessor("invocation_id").queue.poll();
-    assertNotNull(stateDeltaRow);
-    assertEquals("STATE_DELTA", stateDeltaRow.get("event_type"));
-
     Map<String, Object> nextRow = state.getBatchProcessor("invocation_id").queue.poll();
     assertNull("No AGENT_RESPONSE row should be emitted", nextRow);
   }
@@ -724,9 +722,6 @@ public class BigQueryAgentAnalyticsPluginTest {
                 .getPendingTasksForInvocation("invocation_id")
                 .toArray(new CompletableFuture<?>[0]))
         .join();
-
-    Map<String, Object> stateDeltaRow = state.getBatchProcessor("invocation_id").queue.poll();
-    assertNotNull(stateDeltaRow);
 
     Map<String, Object> a2aRow = state.getBatchProcessor("invocation_id").queue.poll();
     assertNotNull("A2A_INTERACTION row not found in queue", a2aRow);
@@ -780,10 +775,6 @@ public class BigQueryAgentAnalyticsPluginTest {
                 .getPendingTasksForInvocation("invocation_id")
                 .toArray(new CompletableFuture<?>[0]))
         .join();
-
-    // Consume STATE_DELTA
-    Map<String, Object> stateDeltaRow = customState.getBatchProcessor("invocation_id").queue.poll();
-    assertNotNull(stateDeltaRow);
 
     // Get AGENT_RESPONSE
     Map<String, Object> agentResponseRow =
@@ -1171,6 +1162,55 @@ public class BigQueryAgentAnalyticsPluginTest {
     assertNotNull(contentParts.getSubFields().get("storage_mode"));
 
     verify(mockBigQuery).update(any(Table.class));
+  }
+
+  @Test
+  public void maybeUpgradeSchema_warnsOnStructModeDrift() throws Exception {
+    Table mockTable = mock(Table.class);
+    when(mockTable.getTableId()).thenReturn(TableId.of("project", "dataset", "table"));
+    when(mockTable.getLabels()).thenReturn(ImmutableMap.of());
+
+    // Existing table has 'content_parts' as a NULLABLE STRUCT instead of the expected REPEATED
+    ImmutableList<com.google.cloud.bigquery.Field> initialFields =
+        BigQuerySchema.getEventsSchema().getFields().stream()
+            .map(
+                f ->
+                    f.getName().equals("content_parts")
+                        ? f.toBuilder()
+                            .setMode(com.google.cloud.bigquery.Field.Mode.NULLABLE)
+                            .build()
+                        : f)
+            .collect(toImmutableList());
+
+    StandardTableDefinition tableDefinition =
+        StandardTableDefinition.newBuilder()
+            .setSchema(com.google.cloud.bigquery.Schema.of(initialFields))
+            .build();
+    when(mockTable.getDefinition()).thenReturn(tableDefinition);
+
+    Logger logger = Logger.getLogger(BigQueryUtils.class.getName());
+    Handler mockLogHandler = mock(Handler.class);
+    logger.addHandler(mockLogHandler);
+    try {
+      BigQueryUtils.maybeUpgradeSchema(mockBigQuery, mockTable);
+    } finally {
+      logger.removeHandler(mockLogHandler);
+    }
+
+    ArgumentCaptor<LogRecord> captor = ArgumentCaptor.forClass(LogRecord.class);
+    verify(mockLogHandler, atLeastOnce()).publish(captor.capture());
+    assertTrue(
+        "Should have warned about STRUCT mode drift on content_parts",
+        captor.getAllValues().stream()
+            .anyMatch(
+                record ->
+                    Objects.equals(record.getLevel(), Level.WARNING)
+                        && record
+                            .getMessage()
+                            .contains("Incompatible schema drift on column 'content_parts'")));
+
+    // Mode drift alone is not auto-upgradeable, so no table update should be attempted.
+    verify(mockBigQuery, never()).update(any(Table.class));
   }
 
   @Test

--- a/core/src/test/java/com/google/adk/plugins/agentanalytics/BigQueryLoggerConfigTest.java
+++ b/core/src/test/java/com/google/adk/plugins/agentanalytics/BigQueryLoggerConfigTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.adk.plugins.agentanalytics;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class BigQueryLoggerConfigTest {
+
+  private static BigQueryLoggerConfig.Builder validBuilder() {
+    return BigQueryLoggerConfig.builder().projectId("test-project");
+  }
+
+  @Test
+  public void build_validConfig_succeeds() {
+    BigQueryLoggerConfig config = validBuilder().build();
+    assertEquals("test-project", config.projectId());
+    assertEquals(1, config.batchSize());
+    assertEquals(10000, config.queueMaxSize());
+  }
+
+  @Test
+  public void build_nonPositiveBatchSize_throws() {
+    assertThrows(IllegalArgumentException.class, () -> validBuilder().batchSize(0).build());
+  }
+
+  @Test
+  public void build_nonPositiveQueueMaxSize_throws() {
+    assertThrows(IllegalArgumentException.class, () -> validBuilder().queueMaxSize(0).build());
+  }
+
+  @Test
+  public void build_nonPositiveMaxContentLength_throws() {
+    assertThrows(IllegalArgumentException.class, () -> validBuilder().maxContentLength(-1).build());
+  }
+}

--- a/core/src/test/java/com/google/adk/plugins/agentanalytics/JsonFormatterTest.java
+++ b/core/src/test/java/com/google/adk/plugins/agentanalytics/JsonFormatterTest.java
@@ -272,4 +272,68 @@ public class JsonFormatterTest {
     assertTrue(result.isTruncated());
     assertEquals("[cycle detected]", result.node().get("child").asText());
   }
+
+  @Test
+  public void smartTruncate_redactsSensitiveTopLevelKeys() {
+    ImmutableMap<String, Object> map =
+        ImmutableMap.of("api_key", "sk-secret", "password", "hunter2", "keep", "value");
+    JsonFormatter.TruncationResult result = JsonFormatter.smartTruncate(map, 5000);
+
+    JsonNode node = result.node();
+    assertEquals("[REDACTED]", node.get("api_key").asText());
+    assertEquals("[REDACTED]", node.get("password").asText());
+    assertEquals("value", node.get("keep").asText());
+    // Redaction must not flip the truncation flag.
+    assertFalse(result.isTruncated());
+  }
+
+  @Test
+  public void smartTruncate_redactsCaseInsensitiveAndTempPrefixKeys() {
+    ImmutableMap<String, Object> map =
+        ImmutableMap.of("Access_Token", "abc", "temp:scratch", "xyz", "keep", "ok");
+    JsonNode node = JsonFormatter.smartTruncate(map, 5000).node();
+
+    assertEquals("[REDACTED]", node.get("Access_Token").asText());
+    assertEquals("[REDACTED]", node.get("temp:scratch").asText());
+    assertEquals("ok", node.get("keep").asText());
+  }
+
+  @Test
+  public void smartTruncate_redactsNestedSensitiveKeys() {
+    ImmutableMap<String, Object> map =
+        ImmutableMap.of("outer", ImmutableMap.of("client_secret", "s", "ok", "v"));
+    JsonNode node = JsonFormatter.smartTruncate(map, 5000).node();
+
+    assertEquals("[REDACTED]", node.get("outer").get("client_secret").asText());
+    assertEquals("v", node.get("outer").get("ok").asText());
+  }
+
+  @Test
+  public void smartTruncate_depthGuard_replacesDeepSubtreeWithSentinel() {
+    java.util.Map<String, Object> root = new java.util.HashMap<>();
+    java.util.Map<String, Object> cur = root;
+    for (int i = 0; i < 300; i++) {
+      java.util.Map<String, Object> next = new java.util.HashMap<>();
+      cur.put("child", next);
+      cur = next;
+    }
+
+    JsonFormatter.TruncationResult result = JsonFormatter.smartTruncate(root, 5000);
+    assertTrue(result.isTruncated());
+
+    JsonNode node = result.node();
+    boolean foundSentinel = false;
+    for (int i = 0; i < 400; i++) {
+      JsonNode child = node.get("child");
+      if (child == null) {
+        break;
+      }
+      if (child.isTextual() && JsonFormatter.MAX_DEPTH_MESSAGE.equals(child.asText())) {
+        foundSentinel = true;
+        break;
+      }
+      node = child;
+    }
+    assertTrue("Expected the max-depth sentinel in the deep chain", foundSentinel);
+  }
 }

--- a/core/src/test/java/com/google/adk/plugins/agentanalytics/TraceManagerTest.java
+++ b/core/src/test/java/com/google/adk/plugins/agentanalytics/TraceManagerTest.java
@@ -227,4 +227,19 @@ public class TraceManagerTest {
     traceManager.clearStack();
     assertTrue(traceManager.getCurrentSpanAndParent().spanId().isEmpty());
   }
+
+  @Test
+  public void initTraceIfNeeded_setsRootAgentNameFromContext() {
+    assertEquals(TraceManager.DEFAULT_ROOT_AGENT_NAME, traceManager.getRootAgentName());
+    traceManager.initTraceIfNeeded(mockContext);
+    assertEquals("test-agent", traceManager.getRootAgentName());
+  }
+
+  @Test
+  public void initTraceIfNeeded_nullAgent_keepsSentinel() {
+    InvocationContext ctx = mock(InvocationContext.class);
+    when(ctx.agent()).thenReturn(null);
+    traceManager.initTraceIfNeeded(ctx);
+    assertEquals(TraceManager.DEFAULT_ROOT_AGENT_NAME, traceManager.getRootAgentName());
+  }
 }


### PR DESCRIPTION
## Summary

Addresses preview-readiness gaps in the Java BigQuery Agent Analytics (BQAA) plugin tracked in google/adk-java#1316, bringing it closer to parity with the Python plugin and hardening the write path.

> [!IMPORTANT]
> This change was **not built or tested locally** (the full Maven build was not run in the authoring environment). Please rely on CI and review. Unit tests for the new behaviors still need to be added — see "Tests to add" below. Findings were verified by direct source review against the issue-pinned SHA `ce6af87`, which is byte-identical to current `main` for this package.

Fixes #1316 (partially — remaining deferred items listed below).

## P1 — preview blockers

- **Secret redaction** (`JsonFormatter`): sensitive keys (`client_secret`, `access_token`, `refresh_token`, `id_token`, `api_key`, `password`, and any `temp:*` key) are now redacted to `[REDACTED]` during truncation, matching the Python plugin's `_SENSITIVE_KEYS`. Case-insensitive; redaction does not set the `is_truncated` flag (parity). This covers tool args/results, session state, usage metadata, and custom-tag paths that flow through `smartTruncate`.
- **Empty `STATE_DELTA` guard** (`onEventCallback`): a `STATE_DELTA` row is only emitted when `event.actions().stateDelta()` is non-empty, matching Python (no row for empty deltas).
- **Table bootstrap made production-safe** (`ensureTableExists` / `ensureTableExistsOnce`):
  - New tables are created with **DAY time-partitioning on `timestamp`** (parity with Python; enables partition pruning), in addition to the existing clustering.
  - `tableEnsured` is now set **only after a successful setup**, so a transient first-run failure (auth blip, missing dataset, quota) is retried on later events instead of permanently disabling table create/upgrade for the plugin instance.
  - Concurrent-create (`already exists`) is treated as success rather than a hard failure.
- **`root_agent_name` is populated** (`TraceManager.initTraceIfNeeded`, called from `getAttributes`): `attributes.root_agent_name` now resolves to the real root agent name instead of the sentinel default. Null-safe.
- **No-current-agent guard** (`resolveAgentName`): the `agent` column is resolved defensively; workflow-driven callbacks with no current agent fall back to `"unknown"` instead of NPE-dropping the row.

## P2 — reliability hardening

- **Drop accounting** (`BatchProcessor` + `PluginState` + `getDropStats()`): rows lost to a full queue, append errors, or serialization errors are now counted and exposed via `plugin.getDropStats()` (`queue_full` / `append_error` / `serialization_error`). Counters survive per-invocation processor churn by folding into plugin-level totals at close.
- **Storage Write regional routing**: the `StreamWriter` is now built with `.setLocation(config.location())` so append RPCs route to the dataset's region (previously only the control-plane client set location; non-US/EU appends risked stream-not-found).
- **JVM shutdown hook**: public construction paths register a best-effort drain (`state.close()` bounded by `shutdownTimeout`) so a host that never calls `close()` still flushes queued rows at exit. The package-private test constructor does **not** register a hook (avoids hook leakage in tests).
- **Schema auto-upgrade always diffs** (`maybeUpgradeSchema`): removed the version-label-only early return that Python deliberately avoids — a table stamped with the current label but missing columns is now reconciled. Incompatible non-STRUCT type drift is logged (was silently ignored, later surfacing as opaque append failures).

## P3 — operational polish

- **Config validation**: `batchSize`, `queueMaxSize`, and `maxContentLength` are validated as positive in `build()`.
- **View DDL identifier validation**: `createAnalyticsViews` refuses to interpolate a project/dataset/table/viewPrefix that isn't a safe identifier (guards the string-formatted DDL).
- **Recursion depth guard** in `recursiveSmartTruncate` (prevents `StackOverflowError` on pathological nesting) + a log line on the string-fallback path.
- **Hot-path INFO logs lowered to FINE** (`isProcessed`, pending-task wait/removal, stale-span clearing, table-exists).
- **`EventData.java`**: added the missing Apache license header and fixed stale `_log_event` Javadoc.

## Deferred (intentionally not in this PR)

These need behavior/parity decisions and tests I did not want to ship blind:

- **Preserve the BQAA internal span tree under ambient OpenTelemetry** (#1316 P1 item): still prefers ambient span IDs. Changing this alters correlation semantics and needs tests.
- **Full ADK `attributes.adk` envelope parity** (#1316 P2): route/render/rewind metadata, source-event node/branch/scope, long-running pair keys.
- **Long-running (non-HITL) tool resume → `TOOL_COMPLETED` with `pause_kind`/`function_call_id` pair keys** (#1316 P1).
- **Fully off-thread first-event table ensure**: `ensureTableExists` is still synchronous on the first event's callback. Moving it off-thread safely needs append-gating so early rows aren't lost; deferred to avoid an untested concurrency change. (Note for whoever picks this up: snapshot any mutable `InvocationContext`/`Session` data before crossing threads.)
- **Default table/view naming decision** (`agent_analytics.events` + `createViews=false` vs Python `agent_events` + `create_views=True`): a product/docs decision, not a code fix.

Plugin-owned OTel span export (#1316 comment) is related to the span-tree item and is deferred with it.

## Tests to add

- Redaction across nested maps, tool args/results, session state, custom tags; `is_truncated` unaffected by redaction.
- Empty `state_delta` produces no `STATE_DELTA` row.
- Table creation sets DAY partitioning + clustering; failed first-run setup is retried on later events.
- `getDropStats()` increments on queue-full / append-error / serialization-error paths.
- Schema upgrade reconciles a same-label table that is missing a column.
- Config builder rejects non-positive `batchSize`/`queueMaxSize`/`maxContentLength`.
- Shutdown hook drains queued rows when `close()` is not called explicitly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
