### PR TITLE
fix: prevent dropping grounding-only responses in BaseLlmFlow

### DIFF
--- a/core/src/main/java/com/google/adk/flows/llmflows/BaseLlmFlow.java
+++ b/core/src/main/java/com/google/adk/flows/llmflows/BaseLlmFlow.java
@@ -746,7 +746,8 @@ public abstract class BaseLlmFlow implements BaseFlow {
         && (context.runConfig().streamingMode() != StreamingMode.BIDI
             || updatedResponse.usageMetadata().isEmpty())
         && updatedResponse.inputTranscription().isEmpty()
-        && updatedResponse.outputTranscription().isEmpty()) {
+        && updatedResponse.outputTranscription().isEmpty()
+        && updatedResponse.groundingMetadata().isEmpty()) {
       return processorEvents;
     }
 

--- a/core/src/test/java/com/google/adk/flows/llmflows/BaseLlmFlowTest.java
+++ b/core/src/test/java/com/google/adk/flows/llmflows/BaseLlmFlowTest.java
@@ -48,6 +48,7 @@ import com.google.genai.types.FinishReason;
 import com.google.genai.types.FunctionCall;
 import com.google.genai.types.FunctionDeclaration;
 import com.google.genai.types.GenerateContentResponseUsageMetadata;
+import com.google.genai.types.GroundingMetadata;
 import com.google.genai.types.Part;
 import com.google.genai.types.Transcription;
 import io.opentelemetry.context.Context;
@@ -1001,5 +1002,41 @@ public final class BaseLlmFlowTest {
     assertThat(thrown)
         .hasMessageThat()
         .contains("Object in tools list is not of a supported type: java.lang.String");
+  }
+
+  @Test
+  public void postprocess_onlyGroundingMetadata_returnsEvent() {
+    GroundingMetadata groundingMetadata =
+        GroundingMetadata.builder()
+            .webSearchQueries(ImmutableList.of("What is the capital of France?"))
+            .build();
+
+    LlmResponse llmResponse = LlmResponse.builder().groundingMetadata(groundingMetadata).build();
+
+    InvocationContext invocationContext =
+        createInvocationContext(createTestAgent(createTestLlm(llmResponse)));
+    BaseLlmFlow baseLlmFlow = createBaseLlmFlowWithoutProcessors();
+    Event baseEvent =
+        Event.builder()
+            .invocationId(invocationContext.invocationId())
+            .author(invocationContext.agent().name())
+            .build();
+
+    // 2. Act: Run the post-processor
+    List<Event> events =
+        baseLlmFlow
+            .postprocess(
+                invocationContext,
+                baseEvent,
+                LlmRequest.builder().build(),
+                llmResponse,
+                Context.current())
+            .toList()
+            .blockingGet();
+
+    assertThat(events).hasSize(1);
+    Event event = getOnlyElement(events);
+    assertThat(event.content()).isEmpty();
+    assertThat(event.groundingMetadata()).hasValue(groundingMetadata);
   }
 }


### PR DESCRIPTION
**Please ensure you have read the [contribution guide](./CONTRIBUTING.md) before creating a pull request.**

**Problem:**
ADK Java `BaseLlmFlow` drops a model response that has grounding metadata but no content, because the "skip empty response" guard in `buildPostprocessingEvents` does not check `groundingMetadata`. adk-python keeps such responses. This is a Python-parity gap that can silently lose grounding metadata (e.g. Google Search / citation grounding) on responses that carry no other content.

**Solution:**
Added `&& updatedResponse.groundingMetadata().isEmpty()` to the skip condition in `buildPostprocessingEvents`. This ensures that grounding-only response (no content) should produce one emitted event. Also added unit

### Testing Plan

_Please describe the tests that you ran to verify your changes. This is required
for all PRs that are not small documentation or typo fixes._

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

Added the `postprocess_onlyGroundingMetadata_returnsEvent` regression test in `BaseLlmFlowTest.java`. This test simulates a live API chunk by injecting a `LlmResponse` payload containing only `GroundingMetadata`. It successfully verifies that the postprocess method emits the event (returning a list of size 1) instead of incorrectly dropping it.



### Checklist

- [x] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md) document.
- [x] My pull request contains a single commit.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.

