### PR TITLE
Fix: live connection drops all but the last parallel function call

### DIFF
--- a/core/src/main/java/com/google/adk/models/GeminiLlmConnection.java
+++ b/core/src/main/java/com/google/adk/models/GeminiLlmConnection.java
@@ -47,6 +47,7 @@ import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Predicate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -201,16 +202,24 @@ public final class GeminiLlmConnection implements BaseLlmConnection {
     LlmResponse.Builder builder = LlmResponse.builder();
     toolCall
         .functionCalls()
-        .ifPresent(
-            calls -> {
-              for (FunctionCall call : calls) {
-                builder.content(
-                    Content.builder()
-                        .parts(ImmutableList.of(Part.builder().functionCall(call).build()))
-                        .build());
-              }
-            });
+        .filter(Predicate.not(List::isEmpty))
+        .map(GeminiLlmConnection::toModelContent)
+        .ifPresent(builder::content);
     return builder.partial(false).turnComplete(false).build();
+  }
+
+  /**
+   * Wraps all function calls from a single tool-call message into one {@code "model"} content.
+   *
+   * <p>Every call must be kept (a message may carry multiple parallel calls) and the role is
+   * required so the content is not later discarded as empty.
+   */
+  private static Content toModelContent(List<FunctionCall> functionCalls) {
+    ImmutableList<Part> parts =
+        functionCalls.stream()
+            .map(call -> Part.builder().functionCall(call).build())
+            .collect(toImmutableList());
+    return Content.builder().role("model").parts(parts).build();
   }
 
   private static LlmResponse createUsageMetadataResponse(UsageMetadata usageMetadata) {

--- a/core/src/test/java/com/google/adk/models/GeminiLlmConnectionTest.java
+++ b/core/src/test/java/com/google/adk/models/GeminiLlmConnectionTest.java
@@ -19,6 +19,7 @@ package com.google.adk.models;
 import static com.google.common.truth.Truth.assertThat;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.genai.types.Content;
 import com.google.genai.types.FunctionCall;
 import com.google.genai.types.GenerateContentResponseUsageMetadata;
@@ -167,8 +168,85 @@ public final class GeminiLlmConnectionTest {
     assertThat(response.content().get().parts()).isPresent();
     assertThat(response.content().get().parts().get()).hasSize(1);
     assertThat(response.content().get().parts().get().get(0).functionCall()).hasValue(functionCall);
+    assertThat(response.content().get().role()).hasValue("model");
     assertThat(response.partial()).hasValue(false);
     assertThat(response.turnComplete()).hasValue(false);
+  }
+
+  @Test
+  public void convertToServerResponse_withMultipleParallelToolCalls_keepsAllFunctionCalls() {
+    FunctionCall getWeather = FunctionCall.builder().name("getWeather").build();
+    FunctionCall getTime = FunctionCall.builder().name("getTime").build();
+    LiveServerToolCall toolCall =
+        LiveServerToolCall.builder().functionCalls(ImmutableList.of(getWeather, getTime)).build();
+
+    LiveServerMessage message = LiveServerMessage.builder().toolCall(toolCall).build();
+
+    TestObserver<LlmResponse> testObserver = new TestObserver<>();
+
+    GeminiLlmConnection.convertToServerResponse(message).subscribe(testObserver);
+
+    testObserver.assertValueCount(1);
+    testObserver.assertComplete();
+    LlmResponse response = testObserver.values().get(0);
+    assertThat(response.content()).isPresent();
+    // Regression for the parallel-call drop: both calls must survive, not just the last one.
+    assertThat(response.content().get().parts()).isPresent();
+    assertThat(response.content().get().parts().get()).hasSize(2);
+    assertThat(response.content().get().parts().get().get(0).functionCall()).hasValue(getWeather);
+    assertThat(response.content().get().parts().get().get(1).functionCall()).hasValue(getTime);
+    // Role must be set so the content is not later discarded as empty.
+    assertThat(response.content().get().role()).hasValue("model");
+    assertThat(response.partial()).hasValue(false);
+    assertThat(response.turnComplete()).hasValue(false);
+  }
+
+  @Test
+  public void convertToServerResponse_withParallelCallsToSameTool_keepsAllFunctionCalls() {
+    // A single toolCall message can carry several calls to the *same* tool (e.g. the same tool for
+    // two different arguments); all of them must survive, not just the last.
+    FunctionCall paris =
+        FunctionCall.builder()
+            .name("getWeather")
+            .args(ImmutableMap.<String, Object>of("city", "Paris"))
+            .build();
+    FunctionCall london =
+        FunctionCall.builder()
+            .name("getWeather")
+            .args(ImmutableMap.<String, Object>of("city", "London"))
+            .build();
+    LiveServerToolCall toolCall =
+        LiveServerToolCall.builder().functionCalls(ImmutableList.of(paris, london)).build();
+
+    LiveServerMessage message = LiveServerMessage.builder().toolCall(toolCall).build();
+
+    TestObserver<LlmResponse> testObserver = new TestObserver<>();
+
+    GeminiLlmConnection.convertToServerResponse(message).subscribe(testObserver);
+
+    testObserver.assertValueCount(1);
+    testObserver.assertComplete();
+    LlmResponse response = testObserver.values().get(0);
+    assertThat(response.content().get().parts().get()).hasSize(2);
+    assertThat(response.content().get().parts().get().get(0).functionCall()).hasValue(paris);
+    assertThat(response.content().get().parts().get().get(1).functionCall()).hasValue(london);
+    assertThat(response.content().get().role()).hasValue("model");
+  }
+
+  @Test
+  public void convertToServerResponse_withEmptyToolCall_emitsResponseWithoutContent() {
+    LiveServerToolCall toolCall =
+        LiveServerToolCall.builder().functionCalls(ImmutableList.of()).build();
+    LiveServerMessage message = LiveServerMessage.builder().toolCall(toolCall).build();
+
+    TestObserver<LlmResponse> testObserver = new TestObserver<>();
+
+    GeminiLlmConnection.convertToServerResponse(message).subscribe(testObserver);
+
+    testObserver.assertValueCount(1);
+    testObserver.assertComplete();
+    // No calls -> no content set (matches the original behaviour for an empty list).
+    assertThat(testObserver.values().get(0).content()).isEmpty();
   }
 
   @Test


### PR DESCRIPTION

**Please ensure you have read the [contribution guide](./CONTRIBUTING.md) before creating a pull request.**

### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

- Closes: #1357 (https://github.com/google/adk-java/issues/1357)

**2. Or, if no issue exists, describe the change:**

**Problem:**
On the live/BIDI path, when the Gemini Live API returns multiple function calls in
a single `toolCall` message (parallel tool calling), only the **last** call is
executed. `GeminiLlmConnection.createToolCallResponse` rebuilds the response
`Content` **inside** the loop over the calls, so each iteration overwrites the
previous content and only the final `FunctionCall` survives. The earlier calls are
dropped before the `Event` is built, never receive a `functionResponse`, and the
constructed content also lacks a `role` (so it can later be discarded as empty).
The result is a mismatched tool exchange and a live turn that stalls waiting for a
response that is never produced. The non-live `runAsync` path is unaffected.

**Solution:**
Collect **all** function calls from the `toolCall` message into a single
`role = "model"` `Content` (one `Part` per call) instead of overwriting the content
on each iteration:

```java
// GeminiLlmConnection (after)
private static LlmResponse createToolCallResponse(LiveServerToolCall toolCall) {
  LlmResponse.Builder builder = LlmResponse.builder();
  toolCall
      .functionCalls()
      .filter(Predicate.not(List::isEmpty))
      .map(GeminiLlmConnection::toModelContent)
      .ifPresent(builder::content);
  return builder.partial(false).turnComplete(false).build();
}

private static Content toModelContent(List<FunctionCall> functionCalls) {
  ImmutableList<Part> parts =
      functionCalls.stream()
          .map(call -> Part.builder().functionCall(call).build())
          .collect(toImmutableList());
  return Content.builder().role("model").parts(parts).build();
}
```

This preserves every call in the message (different tools or the same tool repeated),
so `handleFunctionCallsLive` can execute all of them and emit a `functionResponse` for
each, and sets the required `role` — matching the non-live `runAsync` path. The
`filter` keeps the original behaviour for an empty `functionCalls` list (no content).
(Single-call turns were already fine — one loop iteration has nothing to overwrite —
which is why the bug stayed latent.)

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

Added tests to `GeminiLlmConnectionTest` covering the full range of what a single
`toolCall` message can carry:

- `convertToServerResponse_withMultipleParallelToolCalls_keepsAllFunctionCalls` —
  two calls to **different** tools; both survive, in order, with `role == "model"`.
- `convertToServerResponse_withParallelCallsToSameTool_keepsAllFunctionCalls` — two
  calls to the **same** tool with different args; both survive.
- `convertToServerResponse_withEmptyToolCall_emitsResponseWithoutContent` — an empty
  `functionCalls` list produces no content (preserving the original behaviour).

The existing single-call test
(`convertToServerResponse_withToolCall_mapsContentWithFunctionCall`) continues to
pass (now also asserting `role == "model"`). Before the fix, the two multi-call tests
fail (`parts` has size 1, not 2).

```text
JUnit version 4.13.2
..............
Time: 0.416
OK (14 tests)
```

**Manual End-to-End (E2E) Tests:**

Verified with a live agent that has two independent tools (`getWeather`, `getTime`),
driven via `runLive` and prompted to call both in one turn (Gemini Developer API key,
no Vertex; a `bidiGenerateContent` model such as `gemini-3.1-flash-live-preview`).
With `DEBUG` logging on `GeminiLlmConnection`, the raw Live server message carries
both calls:

```text
Received server message: {"toolCall":{"functionCalls":[
  {"args":{"city":"Paris"},"name":"getWeather"},
  {"args":{"timezone":"Europe/London"},"name":"getTime"}]}}
```

- **Before the fix:** the `Event` ADK builds from that message contains only the last
  call (`getTime`); `getWeather` receives no `functionResponse`, so the turn never
  completes — the model waits for the missing response and the session hangs
  (`java.util.concurrent.TimeoutException`).
- **After the fix:** both calls appear in the model-role `Event`, both tools run,
  both `functionResponse`s are produced, and the turn completes normally.

### Checklist

- [x] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md) document.
- [x] My pull request contains a single commit.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [ ] Any dependent changes have been merged and published in downstream modules.

### Additional context
The drop happens at the connection layer, before any ADK `Event` is built, so it is
invisible from the `Event` stream alone — the surviving last call looks like a normal
single tool call, and the resulting hang surfaces only as a `TimeoutException`.
Diagnosing it therefore means inspecting the raw Live server `toolCall` message
(logged at `DEBUG`), which shows both calls. Multiple calls per `toolCall` message is
by design: `LiveServerToolCall.functionCalls()` is a `List`, and
`handleFunctionCallsLive` already fans out over all calls and merges the results —
only `createToolCallResponse` failed to keep them.
