### PR TITLE
fix(mcp): McpToolset.fromConfig ignoring stdioServerParams

### DIFF
--- a/core/src/main/java/com/google/adk/tools/mcp/McpToolset.java
+++ b/core/src/main/java/com/google/adk/tools/mcp/McpToolset.java
@@ -25,6 +25,7 @@ import com.google.adk.agents.ReadonlyContext;
 import com.google.adk.tools.BaseTool;
 import com.google.adk.tools.BaseToolset;
 import com.google.adk.tools.ToolPredicate;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.primitives.Booleans;
 import io.modelcontextprotocol.client.McpSyncClient;
@@ -416,10 +417,7 @@ public class McpToolset implements BaseToolset {
       }
 
       List<String> toolNames = mcpToolsetConfig.toolFilter();
-      Object connectionParameters =
-          Optional.<Object>ofNullable(mcpToolsetConfig.stdioConnectionParams())
-              .or(() -> Optional.ofNullable(mcpToolsetConfig.sseServerParams()))
-              .orElse(mcpToolsetConfig.stdioConnectionParams());
+      Object connectionParameters = resolveConnectionParameters(mcpToolsetConfig);
 
       // Create McpToolset with McpSessionManager having appropriate connection parameters
       if (toolNames != null) {
@@ -430,5 +428,21 @@ public class McpToolset implements BaseToolset {
     } catch (IllegalArgumentException e) {
       throw new ConfigurationException("Failed to parse McpToolsetConfig from ToolArgsConfig", e);
     }
+  }
+
+  /**
+   * Resolves the single connection-parameters object from an already-validated config. {@code
+   * stdioServerParams} is converted to the MCP SDK {@link ServerParameters}, the type {@link
+   * DefaultMcpTransportBuilder} accepts; the other variants pass through unchanged.
+   */
+  @VisibleForTesting
+  static Object resolveConnectionParameters(McpToolsetConfig mcpToolsetConfig) {
+    return Optional.<Object>ofNullable(mcpToolsetConfig.stdioConnectionParams())
+        .or(() -> Optional.ofNullable(mcpToolsetConfig.sseServerParams()))
+        .or(
+            () ->
+                Optional.ofNullable(mcpToolsetConfig.stdioServerParams())
+                    .map(StdioServerParameters::toServerParameters))
+        .orElseThrow(() -> new IllegalStateException("Validated MCP connection params missing."));
   }
 }

--- a/core/src/test/java/com/google/adk/tools/mcp/McpToolsetTest.java
+++ b/core/src/test/java/com/google/adk/tools/mcp/McpToolsetTest.java
@@ -31,6 +31,7 @@ import com.google.adk.tools.mcp.McpToolset.McpToolsetConfig;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.modelcontextprotocol.client.McpSyncClient;
+import io.modelcontextprotocol.client.transport.ServerParameters;
 import io.modelcontextprotocol.json.McpJsonDefaults;
 import io.modelcontextprotocol.json.McpJsonMapper;
 import io.modelcontextprotocol.spec.McpSchema;
@@ -368,5 +369,46 @@ public class McpToolsetTest {
     assertThat(tools).isEmpty();
     verify(mockMcpSessionManager, times(3)).createSession();
     verify(mockMcpSyncClient, times(3)).listTools();
+  }
+
+  @Test
+  public void resolveConnectionParameters_stdioServerParams_convertsToSdkServerParameters() {
+    McpToolsetConfig config = new McpToolsetConfig();
+    config.setStdioServerParams(StdioServerParameters.builder().command("my-command").build());
+
+    Object resolved = McpToolset.resolveConnectionParameters(config);
+
+    // Regression, Finding 1: this branch used to resolve to null (stdioServerParams was never
+    // consulted), deferring the failure to an NPE in DefaultMcpTransportBuilder.build(null).
+    assertThat(resolved).isInstanceOf(ServerParameters.class);
+  }
+
+  @Test
+  public void resolveConnectionParameters_sseServerParams_passesThrough() {
+    McpToolsetConfig config = new McpToolsetConfig();
+    SseServerParameters sseParams =
+        SseServerParameters.builder().url("http://localhost:8080").build();
+    config.setSseServerParams(sseParams);
+
+    assertThat(McpToolset.resolveConnectionParameters(config)).isSameInstanceAs(sseParams);
+  }
+
+  @Test
+  public void resolveConnectionParameters_stdioConnectionParams_passesThrough() {
+    McpToolsetConfig config = new McpToolsetConfig();
+    StdioConnectionParameters connectionParams =
+        StdioConnectionParameters.builder()
+            .serverParams(StdioServerParameters.builder().command("my-command").build())
+            .build();
+    config.setStdioConnectionParams(connectionParams);
+
+    assertThat(McpToolset.resolveConnectionParameters(config)).isSameInstanceAs(connectionParams);
+  }
+
+  @Test
+  public void resolveConnectionParameters_nothingSet_throwsIllegalStateException() {
+    assertThrows(
+        IllegalStateException.class,
+        () -> McpToolset.resolveConnectionParameters(new McpToolsetConfig()));
   }
 }


### PR DESCRIPTION

**Please ensure you have read the [contribution guide](./CONTRIBUTING.md) before creating a pull request.**

### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**
- Closes: [#1359](https://github.com/google/adk-java/issues/1359)

**2. Or, if no issue exists, describe the change:**

**Problem:**
When an agent config defines an MCP Toolset using `stdioServerParams` (config-driven), `McpToolset.fromConfig` correctly validates the config but then fails to use the provided parameters. It falls back to `stdioConnectionParams()`, which is null. This leads to a `NullPointerException` at session creation time inside `DefaultMcpTransportBuilder`.

**Solution:**
Extracted the connection-parameter resolution from `fromConfig` into a new `@VisibleForTesting` helper, `McpToolset.resolveConnectionParameters()`, and added the missing `stdioServerParams` branch, mapping via `StdioServerParameters::toServerParameters` (the type the underlying MCP SDK transport builder accepts). The chain now ends in `orElseThrow` so a broken invariant fails explicitly at `fromConfig` time instead of deferring to a `NullPointerException` at session creation.

```java
  @VisibleForTesting
  static Object resolveConnectionParameters(McpToolsetConfig mcpToolsetConfig) {
    return Optional.<Object>ofNullable(mcpToolsetConfig.stdioConnectionParams())
        .or(() -> Optional.ofNullable(mcpToolsetConfig.sseServerParams()))
        .or(
            () ->
                Optional.ofNullable(mcpToolsetConfig.stdioServerParams())
                    .map(StdioServerParameters::toServerParameters))
        .orElseThrow(() -> new IllegalStateException("Validated MCP connection params missing."));
  }
```

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

_Please include a summary of passed java test results._
All **22** tests in `McpToolsetTest.java` pass locally (18 existing + 4 new). The following **4 tests** were newly added to directly cover the extracted `resolveConnectionParameters` method — the core of the fix:
- `resolveConnectionParameters_stdioServerParams_convertsToSdkServerParameters` — verifies the formerly-dead `stdioServerParams` branch now resolves to `ServerParameters`
- `resolveConnectionParameters_sseServerParams_passesThrough`
- `resolveConnectionParameters_stdioConnectionParams_passesThrough`
- `resolveConnectionParameters_nothingSet_throwsIllegalStateException`

**Manual End-to-End (E2E) Tests:**

Verified the fix using a standalone end-to-end demo application that exercises the config-driven agent flow:
1. Ran the demo which leverages a config-driven `LlmAgent` (configured via `root_agent.yaml`) to load a local file system MCP server via `stdioServerParams`. The MCP server is a Node-free Java implementation (`JavaFileMcpServer`) to remove any Node.js dependency.
2. Verified that the agent correctly establishes the MCP stdio connection, loads the `listFiles` and `readFile` tools from the MCP server, and successfully executes a multi-step tool-calling exchange (one user turn, multiple function-call round trips) over the live connection.
3. Confirmed that the tools successfully read the local filesystem and the model generates a final response without throwing the `NullPointerException`.

**Before fix (NPE — server never launched):**
```text
18:33:56.311 [main] INFO com.google.adk.tools.mcp.McpToolset -- MCP session is null, initializing.
java.lang.NullPointerException: Cannot invoke "Object.getClass()" because "connectionParams" is null
	at com.google.adk.tools.mcp.DefaultMcpTransportBuilder.build(DefaultMcpTransportBuilder.java:72)
	at com.google.adk.tools.mcp.McpSessionManager.initializeSession(McpSessionManager.java:78)
	at com.google.adk.tools.mcp.McpSessionManager.createSession(McpSessionManager.java:56)
```

### Checklist

- [x] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md) document.
- [x] My pull request contains a single commit.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [x] Any dependent changes have been merged and published in downstream modules.

### Additional context

The fix was verified end-to-end using a Node-free Java MCP server (`JavaFileMcpServer`) that replaces the usual `npx @modelcontextprotocol/server-filesystem`, removing any Node.js dependency for reproduction.
