### PR TITLE
fix: accumulate endOfAgent in EventActions.merge so a parallel tool's stop request survives

### DIFF
--- a/core/src/main/java/com/google/adk/events/EventActions.java
+++ b/core/src/main/java/com/google/adk/events/EventActions.java
@@ -393,7 +393,7 @@ public class EventActions extends JsonBaseModel {
       other.escalate().ifPresent(this::escalate);
       this.requestedAuthConfigs.putAll(other.requestedAuthConfigs());
       this.requestedToolConfirmations.putAll(other.requestedToolConfirmations());
-      this.endOfAgent = other.endOfAgent();
+      this.endOfAgent = this.endOfAgent || other.endOfAgent();
       other.compaction().ifPresent(this::compaction);
       return this;
     }

--- a/core/src/test/java/com/google/adk/events/EventActionsTest.java
+++ b/core/src/test/java/com/google/adk/events/EventActionsTest.java
@@ -112,6 +112,20 @@ public final class EventActionsTest {
   }
 
   @Test
+  public void merge_endOfAgentIsOrderIndependent() {
+    // A tool that ends the invocation, and one that leaves the flag at its default false. Folding
+    // parallel tool responses must keep endOfAgent set whichever order they are merged in.
+    EventActions requestsStop = EventActions.builder().endOfAgent(true).build();
+    EventActions leavesUnset = EventActions.builder().build();
+
+    EventActions stopFirst = EventActions.builder().merge(requestsStop).merge(leavesUnset).build();
+    EventActions stopLast = EventActions.builder().merge(leavesUnset).merge(requestsStop).build();
+
+    assertThat(stopFirst.endOfAgent()).isTrue();
+    assertThat(stopLast.endOfAgent()).isTrue();
+  }
+
+  @Test
   public void setArtifactDelta_copiesRegularMap() {
     EventActions eventActions = new EventActions();
     ImmutableMap<String, Integer> artifactDelta = ImmutableMap.of("artifact1", 1);


### PR DESCRIPTION

**Please ensure you have read the [contribution guide](./CONTRIBUTING.md) before creating a pull request.**

### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

- Closes: #1375 (https://github.com/google/adk-java/issues/1375)

**2. Or, if no issue exists, describe the change:**

**Problem:**

`EventActions.Builder.merge` overwrites `endOfAgent` instead of accumulating it
([`EventActions.java:396`](https://github.com/google/adk-java/blob/main/core/src/main/java/com/google/adk/events/EventActions.java#L396)):

```java
this.endOfAgent = other.endOfAgent();          // last writer wins
```

`endOfAgent` is the stop signal a tool sets to end an invocation — a public contract (the repo's own
`EndInvocationActionTest` exercises it). Being a primitive `boolean`, "never set" and "explicitly
false" are indistinguishable. Its one caller that matters,
`Functions.mergeParallelFunctionResponseEvents`, folds the responses of **parallel** tool calls — so
when one tool asks to stop and a later tool in the same turn did not, the later `false` clobbers the
request and the agent keeps running. Whether the stop survives depends purely on the order the model
listed the calls.

**Solution:**

OR the flag instead of overwriting it, so it accumulates like every other field in the method:

```java
this.endOfAgent = this.endOfAgent || other.endOfAgent();
```

Once any merged event has requested the stop, it stays requested — order-independent, which the
parallel fold needs. OR is the only operator that works here: AND would let any silent tool veto the
stop; plain assignment is order-dependent — the bug.

The change is that one line, in `EventActions.Builder.merge` — nothing else.

**Known limitation (intended):** a tool can no longer withdraw a stop another tool requested in the
same turn.

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

New test in `EventActionsTest` (order-independence of the merged flag), asserting both orderings yield
`true`:

```java
@Test
public void merge_endOfAgentIsOrderIndependent() {
  EventActions requestsStop = EventActions.builder().endOfAgent(true).build();
  EventActions leavesUnset = EventActions.builder().build();

  EventActions stopFirst = EventActions.builder().merge(requestsStop).merge(leavesUnset).build();
  EventActions stopLast = EventActions.builder().merge(leavesUnset).merge(requestsStop).build();

  assertThat(stopFirst.endOfAgent()).isTrue();
  assertThat(stopLast.endOfAgent()).isTrue();
}
```

The existing `EventActionsTest.merge_mergesAllFields` (merges `endOfAgent(true)` into an unset builder
and asserts `true`) is unaffected: `false || true == true`. No existing test depends on
last-writer-wins.

_Ran `EventActionsTest`: 12/12 pass, including the new `merge_endOfAgentIsOrderIndependent`._

**Manual End-to-End (E2E) Tests:**

Offline, deterministic, no API key, Node-free. A real `LlmAgent` + `FunctionTool`s + `InMemoryRunner`
run across a permutation table, differing only in the order/count of the parallel calls the (stub)
model lists. The observable is the model-call count: a tool asked to stop, so a second call means the
stop was lost. Runs with the stop requested last are controls.

_Before fix (`main`):_

```text
Run A (2 calls, stop first)   [finish, noop]         model calls: 2  (kept running)
Run B (2 calls, stop last)    [noop, finish]         model calls: 1  (stopped)   <- control
Run C (3 calls, stop first)   [finish, noop, noop]   model calls: 2  (kept running)
Run D (3 calls, stop middle)  [noop, finish, noop]   model calls: 2  (kept running)
Run E (3 calls, stop last)    [noop, noop, finish]   model calls: 1  (stopped)   <- control
Run F (two stops, none last)  [finish, finish, noop] model calls: 2  (kept running)
```

The stop survives only when it is requested last (B, E); every other order — including three-tool
turns and two stop requests (F) — keeps running.

_After fix (same demo, rebuilt jar):_

```text
Run A (2 calls, stop first)   [finish, noop]         model calls: 1  (stopped)
Run B (2 calls, stop last)    [noop, finish]         model calls: 1  (stopped)
Run C (3 calls, stop first)   [finish, noop, noop]   model calls: 1  (stopped)
Run D (3 calls, stop middle)  [noop, finish, noop]   model calls: 1  (stopped)
Run E (3 calls, stop last)    [noop, noop, finish]   model calls: 1  (stopped)
Run F (two stops, none last)  [finish, finish, noop] model calls: 1  (stopped)
```

Every run now stops after one model call, whatever the order or tool count.

### Checklist

- [x] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md) document.
- [x] My pull request contains a single commit.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [ ] Any dependent changes have been merged and published in downstream modules.
