### PR TITLE
feat: expose turnComplete for live content

### DIFF
--- a/core/src/main/java/com/google/adk/agents/LiveRequest.java
+++ b/core/src/main/java/com/google/adk/agents/LiveRequest.java
@@ -46,6 +46,16 @@ public abstract class LiveRequest extends JsonBaseModel {
   public abstract Optional<Content> content();
 
   /**
+   * Returns whether sending {@link #content()} should complete the current turn.
+   *
+   * <p>If unset, content sends complete the turn to preserve the existing behavior.
+   *
+   * @return An optional boolean indicating whether the current turn should be completed.
+   */
+  @JsonProperty("turnComplete")
+  public abstract Optional<Boolean> turnComplete();
+
+  /**
    * Returns the blob of the request.
    *
    * <p>If set, send the blob to the model in realtime mode.
@@ -82,6 +92,9 @@ public abstract class LiveRequest extends JsonBaseModel {
 
     @JsonProperty("content")
     public abstract Builder content(@Nullable Content content);
+
+    @JsonProperty("turnComplete")
+    public abstract Builder turnComplete(@Nullable Boolean turnComplete);
 
     @JsonProperty("blob")
     public abstract Builder blob(@Nullable Blob blob);

--- a/core/src/main/java/com/google/adk/agents/LiveRequestQueue.java
+++ b/core/src/main/java/com/google/adk/agents/LiveRequestQueue.java
@@ -38,7 +38,17 @@ public final class LiveRequestQueue {
   }
 
   public void content(Content content) {
-    processor.onNext(LiveRequest.builder().content(content).build());
+    content(content, true);
+  }
+
+  /**
+   * Sends content to the model with explicit control over whether it completes the current turn.
+   *
+   * @param content the content to send
+   * @param turnComplete whether the model should begin responding after receiving the content
+   */
+  public void content(Content content, boolean turnComplete) {
+    processor.onNext(LiveRequest.builder().content(content).turnComplete(turnComplete).build());
   }
 
   public void realtime(Blob blob) {

--- a/core/src/main/java/com/google/adk/flows/llmflows/BaseLlmFlow.java
+++ b/core/src/main/java/com/google/adk/flows/llmflows/BaseLlmFlow.java
@@ -632,7 +632,9 @@ public abstract class BaseLlmFlow implements BaseFlow {
                               .concatMapCompletable(
                                   request -> {
                                     if (request.content().isPresent()) {
-                                      return connection.sendContent(request.content().get());
+                                      return connection.sendContent(
+                                          request.content().get(),
+                                          request.turnComplete().orElse(true));
                                     } else if (request.blob().isPresent()) {
                                       return connection.sendRealtime(request.blob().get());
                                     }

--- a/core/src/main/java/com/google/adk/models/BaseLlmConnection.java
+++ b/core/src/main/java/com/google/adk/models/BaseLlmConnection.java
@@ -42,6 +42,18 @@ public interface BaseLlmConnection {
   Completable sendContent(Content content);
 
   /**
+   * Sends user content to the model and controls whether it completes the current turn.
+   *
+   * <p>Implementations that do not support incomplete turns retain the existing behavior.
+   *
+   * @param content the content to send
+   * @param turnComplete whether the model should begin responding after receiving the content
+   */
+  default Completable sendContent(Content content, boolean turnComplete) {
+    return sendContent(content);
+  }
+
+  /**
    * Sends a chunk of audio or a frame of video to the model in realtime.
    *
    * <p>The model may not respond immediately upon receiving the blob. It will do voice activity

--- a/core/src/main/java/com/google/adk/models/GeminiLlmConnection.java
+++ b/core/src/main/java/com/google/adk/models/GeminiLlmConnection.java
@@ -253,6 +253,11 @@ public final class GeminiLlmConnection implements BaseLlmConnection {
 
   @Override
   public Completable sendContent(Content content) {
+    return sendContent(content, true);
+  }
+
+  @Override
+  public Completable sendContent(Content content, boolean turnComplete) {
     Objects.requireNonNull(content, "content cannot be null");
 
     List<FunctionResponse> functionResponses = extractFunctionResponses(content);
@@ -260,7 +265,7 @@ public final class GeminiLlmConnection implements BaseLlmConnection {
       return sendClientContentInternal(
           LiveSendClientContentParameters.builder()
               .turns(ImmutableList.of(content))
-              .turnComplete(true)
+              .turnComplete(turnComplete)
               .build());
     }
     return sendToolResponseInternal(

--- a/core/src/test/java/com/google/adk/agents/LiveRequestQueueTest.java
+++ b/core/src/test/java/com/google/adk/agents/LiveRequestQueueTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.adk.agents;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.genai.types.Content;
+import com.google.genai.types.Part;
+import io.reactivex.rxjava3.subscribers.TestSubscriber;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public final class LiveRequestQueueTest {
+
+  private static final Content CONTENT = Content.fromParts(Part.fromText("context"));
+
+  @Test
+  public void content_defaultsToCompletingTurn() {
+    LiveRequestQueue queue = new LiveRequestQueue();
+    TestSubscriber<LiveRequest> subscriber = queue.get().test();
+
+    queue.content(CONTENT);
+
+    subscriber.assertValueCount(1);
+    LiveRequest request = subscriber.values().get(0);
+    assertThat(request.content()).hasValue(CONTENT);
+    assertThat(request.turnComplete()).hasValue(true);
+  }
+
+  @Test
+  public void content_withTurnCompleteFalse_preservesValue() {
+    LiveRequestQueue queue = new LiveRequestQueue();
+    TestSubscriber<LiveRequest> subscriber = queue.get().test();
+
+    queue.content(CONTENT, false);
+
+    subscriber.assertValueCount(1);
+    LiveRequest request = subscriber.values().get(0);
+    assertThat(request.content()).hasValue(CONTENT);
+    assertThat(request.turnComplete()).hasValue(false);
+  }
+
+  @Test
+  public void liveRequest_jsonRoundTrip_preservesTurnComplete() {
+    LiveRequest request = LiveRequest.builder().content(CONTENT).turnComplete(false).build();
+
+    LiveRequest restored = LiveRequest.fromJsonString(request.toJson());
+
+    assertThat(restored.content()).hasValue(CONTENT);
+    assertThat(restored.turnComplete()).hasValue(false);
+  }
+}


### PR DESCRIPTION
## Summary

- expose `turnComplete` on queued Live content requests
- add `LiveRequestQueue.content(Content, boolean)` while preserving the existing default behavior
- propagate the flag through `BaseLlmFlow` and `BaseLlmConnection`
- forward the value to Gemini's `LiveSendClientContentParameters`
- cover the legacy default, explicit `false`, and JSON round-trip behavior

## Motivation

Gemini Live supports sending multiple content messages as one user turn. A caller can send intermediate content with `turnComplete=false`, then mark the final content with `turnComplete=true`.

ADK Java did not expose this capability. `LiveRequest` had no turn-completion field, `BaseLlmFlow` called only `sendContent(Content)`, and `GeminiLlmConnection` always set `turnComplete(true)`. As a result, applications could not append content to an open Live turn without asking the model to process a completed turn.

## Implementation

`LiveRequest` now carries an optional `turnComplete` value. `LiveRequestQueue` provides an additive overload:

```java
requestQueue.content(content, false);
```

The existing method remains equivalent to `content(content, true)`, so current callers keep the same behavior.

`BaseLlmConnection` adds a default `sendContent(Content, boolean)` overload that delegates to the original method. This allows existing custom connection implementations to continue compiling and running. `GeminiLlmConnection` overrides the overload and forwards the value to the lower-level Live API.

Pure `FunctionResponse` content continues to use the existing tool-response path; the new flag applies to normal client content.

## User impact

Applications can now send multiple content messages within one Live user turn:

```java
requestQueue.content(firstContent, false);
requestQueue.content(finalContent, true);
```

Existing `requestQueue.content(content)` calls remain unchanged.

## Validation

- `./mvnw -pl core -Dtest=LiveRequestQueueTest test`
- `./mvnw test`

Closes #1200.
