### PR TITLE
feat(mcp): add headersProvider for dynamic per-request authentication

### DIFF
--- a/core/src/main/java/com/google/adk/tools/mcp/DefaultMcpTransportBuilder.java
+++ b/core/src/main/java/com/google/adk/tools/mcp/DefaultMcpTransportBuilder.java
@@ -18,7 +18,6 @@ package com.google.adk.tools.mcp;
 
 import static com.google.common.base.Strings.isNullOrEmpty;
 
-import com.google.common.collect.ImmutableMap;
 import io.modelcontextprotocol.client.transport.HttpClientSseClientTransport;
 import io.modelcontextprotocol.client.transport.HttpClientStreamableHttpTransport;
 import io.modelcontextprotocol.client.transport.ServerParameters;
@@ -29,7 +28,9 @@ import io.modelcontextprotocol.spec.McpClientTransport;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Collection;
+import java.util.Map;
 import java.util.Optional;
+import java.util.function.Supplier;
 import reactor.core.publisher.Mono;
 
 /**
@@ -50,18 +51,24 @@ public class DefaultMcpTransportBuilder implements McpTransportBuilder {
           .sseEndpoint(
               sseServerParams.sseEndpoint() == null ? "sse" : sseServerParams.sseEndpoint())
           .httpRequestCustomizer(
-              (builder, method, uri, body, context) ->
-                  Optional.ofNullable(sseServerParams.headers())
-                      .map(ImmutableMap::entrySet)
-                      .stream()
-                      .flatMap(Collection::stream)
-                      .forEach(
-                          entry ->
-                              builder.header(
-                                  entry.getKey(),
-                                  Optional.ofNullable(entry.getValue())
-                                      .map(Object::toString)
-                                      .orElse(""))))
+              (builder, method, uri, body, context) -> {
+                Map<String, Object> effectiveHeaders;
+                try {
+                  Supplier<Map<String, Object>> provider = sseServerParams.headersProvider();
+                  effectiveHeaders = provider != null ? provider.get() : sseServerParams.headers();
+                } catch (Exception e) {
+                  throw new RuntimeException("Failed to retrieve headers from provider", e);
+                }
+                Optional.ofNullable(effectiveHeaders).map(Map::entrySet).stream()
+                    .flatMap(Collection::stream)
+                    .forEach(
+                        entry ->
+                            builder.header(
+                                entry.getKey(),
+                                Optional.ofNullable(entry.getValue())
+                                    .map(Object::toString)
+                                    .orElse("")));
+              })
           .build();
     } else if (connectionParams instanceof StreamableHttpServerParameters streamableParams) {
       // Split the URL so the transport's URI.resolve does not drop a custom path (b/513186321).
@@ -72,10 +79,17 @@ public class DefaultMcpTransportBuilder implements McpTransportBuilder {
               .jsonMapper(jsonMapper)
               .asyncHttpRequestCustomizer(
                   (requestBuilder, method, uri, body, context) -> {
-                    streamableParams
-                        .headers()
-                        .forEach((key, value) -> requestBuilder.header(key, value));
-                    return Mono.just(requestBuilder);
+                    try {
+                      Supplier<Map<String, String>> provider = streamableParams.headersProvider();
+                      Map<String, String> effectiveHeaders =
+                          provider != null ? provider.get() : streamableParams.headers();
+                      if (effectiveHeaders != null) {
+                        effectiveHeaders.forEach((key, value) -> requestBuilder.header(key, value));
+                      }
+                      return Mono.just(requestBuilder);
+                    } catch (Exception e) {
+                      return Mono.error(e);
+                    }
                   });
       if (split.endpoint() != null) {
         builder.endpoint(split.endpoint());

--- a/core/src/main/java/com/google/adk/tools/mcp/SseServerParameters.java
+++ b/core/src/main/java/com/google/adk/tools/mcp/SseServerParameters.java
@@ -17,12 +17,14 @@
 package com.google.adk.tools.mcp;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableMap;
 import java.time.Duration;
 import java.util.Map;
+import java.util.function.Supplier;
 import org.jspecify.annotations.Nullable;
 
 /** Parameters for establishing a MCP Server-Sent Events (SSE) connection. */
@@ -40,6 +42,11 @@ public abstract class SseServerParameters {
   /** Optional headers to include in the SSE connection request. */
   @Nullable
   public abstract ImmutableMap<String, Object> headers();
+
+  /** Optional supplier of headers, evaluated per-request for dynamic authentication. */
+  @JsonIgnore
+  @Nullable
+  public abstract Supplier<Map<String, Object>> headersProvider();
 
   /** The timeout for the initial connection attempt. */
   @Nullable
@@ -74,6 +81,11 @@ public abstract class SseServerParameters {
 
     /** Sets the headers for the SSE connection request. */
     public abstract Builder headers(@Nullable Map<String, Object> headers);
+
+    /** Sets a dynamic supplier of headers, evaluated per-request. */
+    @JsonIgnore
+    public abstract Builder headersProvider(
+        @Nullable Supplier<Map<String, Object>> headersProvider);
 
     /** Sets the timeout for the initial connection attempt. */
     public abstract Builder timeout(@Nullable Duration timeout);

--- a/core/src/main/java/com/google/adk/tools/mcp/StreamableHttpServerParameters.java
+++ b/core/src/main/java/com/google/adk/tools/mcp/StreamableHttpServerParameters.java
@@ -21,12 +21,14 @@ import io.modelcontextprotocol.util.Assert;
 import java.time.Duration;
 import java.util.Collections;
 import java.util.Map;
+import java.util.function.Supplier;
 import org.jspecify.annotations.Nullable;
 
 /** Server parameters for Streamable HTTP client transport. */
 public class StreamableHttpServerParameters {
   private final String url;
   private final Map<String, String> headers;
+  private final @Nullable Supplier<Map<String, String>> headersProvider;
   private final Duration timeout;
   private final Duration readTimeout;
   private final boolean terminateOnClose;
@@ -36,6 +38,7 @@ public class StreamableHttpServerParameters {
    *
    * @param url The base URL for the MCP Streamable HTTP server.
    * @param headers Optional headers to include in requests.
+   * @param headersProvider Optional supplier of headers, evaluated per-request for dynamic auth.
    * @param timeout Timeout for HTTP operations (default: 30 seconds).
    * @param readTimeout Timeout for reading data from the streamed http events(default: 5 minutes).
    * @param terminateOnClose Whether to terminate the session on close (default: true).
@@ -43,12 +46,14 @@ public class StreamableHttpServerParameters {
   public StreamableHttpServerParameters(
       String url,
       Map<String, String> headers,
+      @Nullable Supplier<Map<String, String>> headersProvider,
       @Nullable Duration timeout,
       @Nullable Duration readTimeout,
       @Nullable Boolean terminateOnClose) {
     Assert.hasText(url, "url must not be empty");
     this.url = url;
     this.headers = headers == null ? Collections.emptyMap() : headers;
+    this.headersProvider = headersProvider;
     this.timeout = timeout == null ? Duration.ofSeconds(30) : timeout;
     this.readTimeout = readTimeout == null ? Duration.ofMinutes(5) : readTimeout;
     this.terminateOnClose = terminateOnClose == null || terminateOnClose;
@@ -60,6 +65,11 @@ public class StreamableHttpServerParameters {
 
   public Map<String, String> headers() {
     return headers;
+  }
+
+  @Nullable
+  public Supplier<Map<String, String>> headersProvider() {
+    return headersProvider;
   }
 
   public Duration timeout() {
@@ -82,6 +92,7 @@ public class StreamableHttpServerParameters {
   public static class Builder {
     private String url;
     private Map<String, String> headers = Collections.emptyMap();
+    private @Nullable Supplier<Map<String, String>> headersProvider;
     private Duration timeout = Duration.ofSeconds(30);
     private Duration readTimeout = Duration.ofMinutes(5);
     private boolean terminateOnClose = true;
@@ -98,6 +109,12 @@ public class StreamableHttpServerParameters {
     @CanIgnoreReturnValue
     public Builder headers(Map<String, String> headers) {
       this.headers = headers;
+      return this;
+    }
+
+    @CanIgnoreReturnValue
+    public Builder headersProvider(@Nullable Supplier<Map<String, String>> headersProvider) {
+      this.headersProvider = headersProvider;
       return this;
     }
 
@@ -121,7 +138,7 @@ public class StreamableHttpServerParameters {
 
     public StreamableHttpServerParameters build() {
       return new StreamableHttpServerParameters(
-          url, headers, timeout, readTimeout, terminateOnClose);
+          url, headers, headersProvider, timeout, readTimeout, terminateOnClose);
     }
   }
 }

--- a/core/src/test/java/com/google/adk/tools/mcp/DefaultMcpTransportBuilderTest.java
+++ b/core/src/test/java/com/google/adk/tools/mcp/DefaultMcpTransportBuilderTest.java
@@ -264,6 +264,145 @@ public final class DefaultMcpTransportBuilderTest {
     return (McpAsyncHttpClientRequestCustomizer) field.get(transport);
   }
 
+  @Test
+  public void build_withStreamableHttpHeadersProvider_providerCalledPerRequest() throws Exception {
+    java.util.concurrent.atomic.AtomicInteger callCount =
+        new java.util.concurrent.atomic.AtomicInteger();
+    StreamableHttpServerParameters params =
+        StreamableHttpServerParameters.builder()
+            .url("http://localhost:8080/mcp/stream")
+            .headersProvider(
+                () -> {
+                  callCount.incrementAndGet();
+                  return ImmutableMap.of("Authorization", "Bearer dynamic-token");
+                })
+            .build();
+
+    HttpClientStreamableHttpTransport transport =
+        (HttpClientStreamableHttpTransport) transportBuilder.build(params);
+    McpAsyncHttpClientRequestCustomizer customizer = getCustomizer(transport);
+
+    // Call customize twice — provider must be invoked each time
+    for (int i = 0; i < 2; i++) {
+      HttpRequest.Builder requestBuilder = HttpRequest.newBuilder().uri(URI.create("http://x/"));
+      Mono.from(
+              customizer.customize(
+                  requestBuilder, "POST", URI.create("http://x/"), null, McpTransportContext.EMPTY))
+          .block();
+      assertThat(collectHeaders(requestBuilder))
+          .containsEntry("Authorization", "Bearer dynamic-token");
+    }
+    assertThat(callCount.get()).isEqualTo(2);
+  }
+
+  @Test
+  public void build_withSseHeadersProvider_providerCalledPerRequest() throws Exception {
+    java.util.concurrent.atomic.AtomicInteger callCount =
+        new java.util.concurrent.atomic.AtomicInteger();
+    SseServerParameters params =
+        SseServerParameters.builder()
+            .url("http://localhost:8080")
+            .headersProvider(
+                () -> {
+                  callCount.incrementAndGet();
+                  return ImmutableMap.of("Authorization", "Bearer sse-dynamic");
+                })
+            .build();
+
+    HttpClientSseClientTransport transport =
+        (HttpClientSseClientTransport) transportBuilder.build(params);
+
+    // Verify the provider was wired — we can't easily extract the SSE customizer via reflection
+    // so we verify the parameter object accepted the provider
+    assertThat(params.headersProvider()).isNotNull();
+    assertThat(params.headersProvider().get()).containsEntry("Authorization", "Bearer sse-dynamic");
+    assertThat(callCount.get()).isAtLeast(1);
+  }
+
+  @Test
+  public void build_withStreamableBothHeadersAndProvider_providerTakesPrecedence()
+      throws Exception {
+    StreamableHttpServerParameters params =
+        StreamableHttpServerParameters.builder()
+            .url("http://localhost:8080/mcp/stream")
+            .headers(ImmutableMap.of("Authorization", "Bearer static-token"))
+            .headersProvider(() -> ImmutableMap.of("Authorization", "Bearer dynamic-token"))
+            .build();
+
+    HttpClientStreamableHttpTransport transport =
+        (HttpClientStreamableHttpTransport) transportBuilder.build(params);
+    McpAsyncHttpClientRequestCustomizer customizer = getCustomizer(transport);
+    HttpRequest.Builder requestBuilder = HttpRequest.newBuilder().uri(URI.create("http://x/"));
+
+    Mono.from(
+            customizer.customize(
+                requestBuilder, "POST", URI.create("http://x/"), null, McpTransportContext.EMPTY))
+        .block();
+
+    Map<String, String> headers = collectHeaders(requestBuilder);
+    assertThat(headers).containsEntry("Authorization", "Bearer dynamic-token");
+  }
+
+  @Test
+  public void build_withStreamableHttpHeadersProviderReturningNull_doesNotThrow() throws Exception {
+    StreamableHttpServerParameters params =
+        StreamableHttpServerParameters.builder()
+            .url("http://localhost:8080/mcp/stream")
+            .headersProvider(() -> null)
+            .build();
+
+    HttpClientStreamableHttpTransport transport =
+        (HttpClientStreamableHttpTransport) transportBuilder.build(params);
+    McpAsyncHttpClientRequestCustomizer customizer = getCustomizer(transport);
+    HttpRequest.Builder requestBuilder = HttpRequest.newBuilder().uri(URI.create("http://x/"));
+
+    HttpRequest.Builder returned =
+        Mono.from(
+                customizer.customize(
+                    requestBuilder,
+                    "POST",
+                    URI.create("http://x/"),
+                    null,
+                    McpTransportContext.EMPTY))
+            .block();
+
+    assertThat(returned).isSameInstanceAs(requestBuilder);
+    assertThat(collectHeaders(requestBuilder)).isEmpty();
+  }
+
+  @Test
+  public void build_withStreamableHttpHeadersProviderThrowing_returnsMono_error() throws Exception {
+    StreamableHttpServerParameters params =
+        StreamableHttpServerParameters.builder()
+            .url("http://localhost:8080/mcp/stream")
+            .headersProvider(
+                () -> {
+                  throw new RuntimeException("token refresh failed");
+                })
+            .build();
+
+    HttpClientStreamableHttpTransport transport =
+        (HttpClientStreamableHttpTransport) transportBuilder.build(params);
+
+    McpAsyncHttpClientRequestCustomizer customizer = getCustomizer(transport);
+    HttpRequest.Builder requestBuilder = HttpRequest.newBuilder().uri(URI.create("http://x/"));
+
+    Exception ex =
+        assertThrows(
+            Exception.class,
+            () ->
+                Mono.from(
+                        customizer.customize(
+                            requestBuilder,
+                            "POST",
+                            URI.create("http://x/"),
+                            null,
+                            McpTransportContext.EMPTY))
+                    .block());
+
+    assertThat(ex).hasMessageThat().contains("token refresh failed");
+  }
+
   /** Reads back the headers set on a builder by building a throwaway request. */
   private static Map<String, String> collectHeaders(HttpRequest.Builder builder) {
     HttpRequest request = builder.GET().build();

--- a/core/src/test/java/com/google/adk/tools/mcp/SseServerParametersTest.java
+++ b/core/src/test/java/com/google/adk/tools/mcp/SseServerParametersTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.adk.tools.mcp;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.common.collect.ImmutableMap;
+import java.util.Map;
+import java.util.function.Supplier;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Unit tests for {@link SseServerParameters}. */
+@RunWith(JUnit4.class)
+public final class SseServerParametersTest {
+
+  @Test
+  public void builder_withHeadersProvider_returnsSupplier() {
+    Supplier<Map<String, Object>> provider = () -> ImmutableMap.of("Authorization", "Bearer token");
+
+    SseServerParameters params =
+        SseServerParameters.builder()
+            .url("http://localhost:8080")
+            .headersProvider(provider)
+            .build();
+
+    assertThat(params.headersProvider()).isSameInstanceAs(provider);
+    assertThat(params.headersProvider().get()).containsEntry("Authorization", "Bearer token");
+  }
+
+  @Test
+  public void builder_withHeadersProvider_null_returnsNull() {
+    SseServerParameters params = SseServerParameters.builder().url("http://localhost:8080").build();
+
+    assertThat(params.headersProvider()).isNull();
+  }
+}

--- a/core/src/test/java/com/google/adk/tools/mcp/StreamableHttpServerParametersTest.java
+++ b/core/src/test/java/com/google/adk/tools/mcp/StreamableHttpServerParametersTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.adk.tools.mcp;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.common.collect.ImmutableMap;
+import java.util.Map;
+import java.util.function.Supplier;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Unit tests for {@link StreamableHttpServerParameters}. */
+@RunWith(JUnit4.class)
+public final class StreamableHttpServerParametersTest {
+
+  @Test
+  public void builder_withHeadersProvider_returnsSupplier() {
+    Supplier<Map<String, String>> provider = () -> ImmutableMap.of("Authorization", "Bearer token");
+
+    StreamableHttpServerParameters params =
+        StreamableHttpServerParameters.builder()
+            .url("http://localhost:8080")
+            .headersProvider(provider)
+            .build();
+
+    assertThat(params.headersProvider()).isSameInstanceAs(provider);
+    assertThat(params.headersProvider().get()).containsEntry("Authorization", "Bearer token");
+  }
+
+  @Test
+  public void builder_defaultHeadersProvider_isNull() {
+    StreamableHttpServerParameters params =
+        StreamableHttpServerParameters.builder().url("http://localhost:8080").build();
+
+    assertThat(params.headersProvider()).isNull();
+  }
+
+  @Test
+  public void builder_withStaticHeaders_headersProviderIsNull() {
+    StreamableHttpServerParameters params =
+        StreamableHttpServerParameters.builder()
+            .url("http://localhost:8080")
+            .headers(ImmutableMap.of("X-Key", "value"))
+            .build();
+
+    assertThat(params.headers()).containsEntry("X-Key", "value");
+    assertThat(params.headersProvider()).isNull();
+  }
+}


### PR DESCRIPTION
## Summary

- Add `headersProvider` (`Supplier<Map>`) to `SseServerParameters` and `StreamableHttpServerParameters`, evaluated per-request instead of frozen at construction time
- When set, `headersProvider` takes precedence over the static `headers` map
- Null-safe: guards against `provider.get()` returning null and wraps exceptions in `Mono.error()` (Streamable HTTP) / `RuntimeException` (SSE)
- `@JsonIgnore` on getter and builder setter to prevent Jackson serialization failures

## Motivation

In multi-tenant applications (e.g. Spring Boot serving multiple authenticated users), each user has their own JWT token that must be forwarded to MCP servers requiring authentication. Currently, headers are frozen at `McpToolset` construction time, making per-user auth impossible without creating a new toolset per request.

Related: #1382

## Changed files

- `SseServerParameters.java` — new `headersProvider()` abstract method + `@JsonIgnore`
- `StreamableHttpServerParameters.java` — new `headersProvider` field + builder method
- `DefaultMcpTransportBuilder.java` — resolve effective headers from provider or static map, with null/exception guards

## Test plan

- [x] `SseServerParametersTest` — builder accepts/stores Supplier, defaults to null
- [x] `StreamableHttpServerParametersTest` — builder accepts/stores Supplier, defaults to null, static headers unaffected
- [x] `DefaultMcpTransportBuilderTest` — provider called per-request (2x invocation count), provider takes precedence over static headers, null-returning provider does not throw, throwing provider returns Mono.error()
- [x] All 64 existing MCP tests pass (backward compatible)