### PR TITLE
fix(configurable): prevent path traversal in AgentTool config_path resolution

### DIFF
--- a/core/src/main/java/com/google/adk/agents/ConfigAgentUtils.java
+++ b/core/src/main/java/com/google/adk/agents/ConfigAgentUtils.java
@@ -250,21 +250,37 @@ public final class ConfigAgentUtils {
     Path subAgentConfigPath;
 
     if (Path.of(configPath).isAbsolute()) {
-      subAgentConfigPath = Path.of(configPath);
-    } else {
-      subAgentConfigPath = configDir.resolve(configPath);
+      throw new ConfigurationException(
+          "Absolute paths are not allowed in AgentTool config_path: " + configPath);
     }
+    subAgentConfigPath = configDir.resolve(configPath);
 
-    // Warn when the resolved config path escapes the agent's base directory. For backward
-    // compatibility this is still allowed, but the behavior is deprecated and will be disallowed
-    // in a future release.
+    // Reject a resolved config path that escapes the agent's own base directory.
+    // Both sides are made absolute and symlinks are resolved where the paths
+    // exist, so a symlink inside the agent directory cannot be used to escape
+    // it either. Matches the hard rejection adk-python (171ae9e) and adk-go
+    // (604dd63) ship for the identical AgentTool config_path resolution.
     Path resolvedConfigPath = subAgentConfigPath.normalize().toAbsolutePath();
     Path baseDir = configDir.normalize().toAbsolutePath();
-    if (!resolvedConfigPath.startsWith(baseDir)) {
-      logger.warn(
-          "AgentTool config_path '{}' accesses a path outside the agent base directory; this"
-              + " behavior is deprecated and will be disallowed in a future release.",
-          configPath);
+    try {
+      resolvedConfigPath = resolvedConfigPath.toRealPath();
+    } catch (IOException e) {
+      // Falls through with the lexical (non-symlink-resolved) path so a
+      // missing file still reports as "not found" below rather than as a
+      // traversal rejection.
+    }
+    Path realBaseDir = baseDir;
+    try {
+      realBaseDir = baseDir.toRealPath();
+    } catch (IOException e) {
+      // Base directory always exists (it contains the config file currently
+      // being loaded); this is defensive only.
+    }
+    if (!resolvedConfigPath.startsWith(realBaseDir)) {
+      throw new ConfigurationException(
+          "Path traversal detected: config_path '"
+              + configPath
+              + "' resolves outside agent directory");
     }
 
     if (!Files.exists(subAgentConfigPath)) {

--- a/core/src/test/java/com/google/adk/agents/ConfigAgentUtilsTest.java
+++ b/core/src/test/java/com/google/adk/agents/ConfigAgentUtilsTest.java
@@ -332,6 +332,132 @@ public final class ConfigAgentUtilsTest {
   }
 
   @Test
+  public void resolveSubAgents_configPathEscapesAgentDirectory_isRejected() throws IOException {
+    // A sub-agent config_path must not be able to escape the referencing
+    // agent's own directory: a relative traversal sequence must be rejected
+    // before any file outside that directory is loaded and instantiated as
+    // a live sub-agent. Matches the hard rejection adk-python (171ae9e) and
+    // adk-go (604dd63) ship for the identical AgentTool config_path
+    // resolution.
+    File outsideDir = tempFolder.newFolder("outside");
+    File outsideFile = new File(outsideDir, "outside_agent.yaml");
+    Files.writeString(
+        outsideFile.toPath(),
+        """
+        agent_class: LlmAgent
+        name: outside_agent
+        description: Loaded from outside the agent bundle directory
+        instruction: This content lives outside the agent's own directory
+        """);
+
+    File agentsDir = tempFolder.newFolder("agents", "bundle");
+    File mainAgentFile = new File(agentsDir, "main_agent.yaml");
+    Files.writeString(
+        mainAgentFile.toPath(),
+        """
+        agent_class: LlmAgent
+        name: main_agent
+        description: Main agent whose bundle references an escaping config_path
+        instruction: You are a main agent
+        sub_agents:
+          - name: sub_agent
+            config_path: ../../outside/outside_agent.yaml
+        """);
+
+    ConfigurationException exception =
+        assertThrows(
+            ConfigurationException.class,
+            () -> ConfigAgentUtils.fromConfig(mainAgentFile.getAbsolutePath()));
+    assertThat(fullMessageChain(exception)).contains("Path traversal detected");
+  }
+
+  @Test
+  public void resolveSubAgents_absoluteConfigPath_isRejected() throws IOException {
+    File secretsFile = tempFolder.newFile("secrets.yaml");
+    Files.writeString(
+        secretsFile.toPath(),
+        """
+        agent_class: LlmAgent
+        name: secrets_agent
+        """);
+
+    File agentsDir = tempFolder.newFolder("agents", "bundle");
+    File mainAgentFile = new File(agentsDir, "main_agent.yaml");
+    Files.writeString(
+        mainAgentFile.toPath(),
+        "agent_class: LlmAgent\n"
+            + "name: main_agent\n"
+            + "description: Main agent with an absolute config_path\n"
+            + "instruction: You are a main agent\n"
+            + "sub_agents:\n"
+            + "  - name: sub_agent\n"
+            + "    config_path: "
+            + secretsFile.getAbsolutePath()
+            + "\n");
+
+    ConfigurationException exception =
+        assertThrows(
+            ConfigurationException.class,
+            () -> ConfigAgentUtils.fromConfig(mainAgentFile.getAbsolutePath()));
+    assertThat(fullMessageChain(exception)).contains("Absolute paths are not allowed");
+  }
+
+  @Test
+  public void resolveSubAgents_configPathEscapeAttemptDoesNotLeakTargetFileContent()
+      throws IOException {
+    // Regression test for the information-disclosure amplifier: before the
+    // fix, an escaping config_path whose target failed to parse as a valid
+    // agent config propagated the raw file content into the thrown
+    // exception's message chain (via ComponentRegistry.resolveAgentClass).
+    // The traversal must now be rejected before the target file is ever
+    // read, so no content from it can reach the exception at all.
+    File victimDir = tempFolder.newFolder("victim_project");
+    File secretsFile = new File(victimDir, ".env");
+    Files.writeString(
+        secretsFile.toPath(),
+        "GOOGLE_API_KEY=AIzaSyD-THIS_IS_NOT_A_REAL_KEY_0123456789\n"
+            + "DATABASE_PASSWORD=hunter2_super_secret\n");
+
+    File bundleDir = tempFolder.newFolder("victim_project", "agents", "imported", "evil_bundle");
+    File maliciousAgentFile = new File(bundleDir, "main_agent.yaml");
+    Files.writeString(
+        maliciousAgentFile.toPath(),
+        """
+        agent_class: LlmAgent
+        name: main_agent
+        description: An imported agent bundle
+        instruction: You are a main agent
+        sub_agents:
+          - name: sub_agent
+            config_path: ../../../.env
+        """);
+
+    ConfigurationException exception =
+        assertThrows(
+            ConfigurationException.class,
+            () -> ConfigAgentUtils.fromConfig(maliciousAgentFile.getAbsolutePath()));
+
+    Throwable t = exception;
+    StringBuilder allMessages = new StringBuilder();
+    while (t != null) {
+      allMessages.append(t.getMessage()).append('\n');
+      t = t.getCause();
+    }
+    assertThat(allMessages.toString()).doesNotContain("GOOGLE_API_KEY");
+    assertThat(allMessages.toString()).doesNotContain("hunter2_super_secret");
+  }
+
+  /** Concatenates a Throwable's message and every cause's message, deepest last. */
+  private static String fullMessageChain(Throwable t) {
+    StringBuilder sb = new StringBuilder();
+    while (t != null) {
+      sb.append(t.getMessage()).append('\n');
+      t = t.getCause();
+    }
+    return sb.toString();
+  }
+
+  @Test
   public void resolveSubAgents_missingConfigPath_throwsConfigurationException() throws IOException {
     File mainAgentFile = tempFolder.newFile("main_agent.yaml");
     Files.writeString(
@@ -1382,10 +1508,12 @@ public final class ConfigAgentUtilsTest {
   }
 
   @Test
-  public void resolveSubAgents_withAbsoluteConfigPath_resolvesSuccessfully()
-      throws IOException, ConfigurationException {
-    // For backward compatibility an absolute config_path is still honored (it now logs a
-    // deprecation warning rather than being rejected).
+  public void resolveSubAgents_withAbsoluteConfigPath_isRejected() throws IOException {
+    // BREAKING CHANGE: an absolute config_path used to be honored for backward
+    // compatibility (logging a deprecation warning only). It is now rejected
+    // outright, matching the hard rejection adk-python (171ae9e) and adk-go
+    // (604dd63) already ship for the identical AgentTool config_path
+    // resolution.
     File subAgentFile = tempFolder.newFile("absolute_sub_agent.yaml");
     Files.writeString(
         subAgentFile.toPath(),
@@ -1412,19 +1540,22 @@ public final class ConfigAgentUtilsTest {
             """,
             absoluteConfigPath));
 
-    BaseAgent mainAgent = ConfigAgentUtils.fromConfig(mainAgentFile.getAbsolutePath());
-
-    assertThat(mainAgent.name()).isEqualTo("main_agent");
-    assertThat(mainAgent.subAgents()).hasSize(1);
-    assertThat(mainAgent.subAgents().get(0).name()).isEqualTo("absolute_sub_agent");
+    ConfigurationException exception =
+        assertThrows(
+            ConfigurationException.class,
+            () -> ConfigAgentUtils.fromConfig(mainAgentFile.getAbsolutePath()));
+    assertThat(fullMessageChain(exception)).contains("Absolute paths are not allowed");
   }
 
   @Test
-  public void resolveSubAgents_withTraversalConfigPath_resolvesSuccessfully()
-      throws IOException, ConfigurationException {
-    // For backward compatibility a config_path that escapes the agent directory via "../../" is
-    // still honored (it now logs a deprecation warning rather than being rejected). The agent
-    // config lives in a nested subdirectory so that "../../" escapes the agent directory.
+  public void resolveSubAgents_withTraversalConfigPath_isRejected() throws IOException {
+    // BREAKING CHANGE: a config_path that escapes the agent directory via
+    // "../../" used to be honored for backward compatibility (logging a
+    // deprecation warning only). It is now rejected outright, matching the
+    // hard rejection adk-python (171ae9e) and adk-go (604dd63) already ship
+    // for the identical AgentTool config_path resolution. The agent config
+    // lives in a nested subdirectory so that "../../" escapes the agent
+    // directory.
     File subAgentFile = tempFolder.newFile("outside_sub_agent.yaml");
     Files.writeString(
         subAgentFile.toPath(),
@@ -1449,11 +1580,11 @@ public final class ConfigAgentUtilsTest {
             config_path: ../../outside_sub_agent.yaml
         """);
 
-    BaseAgent mainAgent = ConfigAgentUtils.fromConfig(mainAgentFile.getAbsolutePath());
-
-    assertThat(mainAgent.name()).isEqualTo("main_agent");
-    assertThat(mainAgent.subAgents()).hasSize(1);
-    assertThat(mainAgent.subAgents().get(0).name()).isEqualTo("outside_sub_agent");
+    ConfigurationException exception =
+        assertThrows(
+            ConfigurationException.class,
+            () -> ConfigAgentUtils.fromConfig(mainAgentFile.getAbsolutePath()));
+    assertThat(fullMessageChain(exception)).contains("Path traversal detected");
   }
 
   @Test


### PR DESCRIPTION
## Summary

`ConfigAgentUtils.resolveSubAgentFromConfigPath()` accepted absolute `config_path` values unconditionally, and for relative values only **logged a warning** when the resolved path escaped the agent's own base directory -- it did not block the load:

```
if (Path.of(configPath).isAbsolute()) {
  subAgentConfigPath = Path.of(configPath);   // accepted unconditionally
} else {
  subAgentConfigPath = configDir.resolve(configPath);
}
Path resolvedConfigPath = subAgentConfigPath.normalize().toAbsolutePath();
Path baseDir = configDir.normalize().toAbsolutePath();
if (!resolvedConfigPath.startsWith(baseDir)) {
  logger.warn(...);   // <-- warning only, no return/throw
}
if (!Files.exists(subAgentConfigPath)) { ... }
return fromConfig(subAgentConfigPath.toString());   // proceeds regardless
```

This is the **same vulnerability class** already hard-fixed with a **breaking change** in both other language ports:
- `adk-go`: https://github.com/google/adk-go/commit/604dd63e647b12a2f0025f68606d692d7ae24d7a ("BREAKING: an absolute config_path is no longer accepted")
- `adk-python`: commit `171ae9e`

This port (issue #1218) had instead chosen a warn-only deprecation, leaving the traversal fully exploitable today: a `config_path` such as `../../another_tenant/secret_agent.yaml` or an absolute path is loaded and parsed as a full agent configuration, with only a log line noting the escape.

## Reachability

`config_path` is a field in a subagent reference within an agent's own YAML config (`sub_agents: - config_path: ...`). In any deployment where different trust domains' agent configs are hosted under a shared root (e.g. a multi-tenant agent-hosting platform, or any scenario where config content can be influenced by a less-trusted party), this allows reading and loading arbitrary files reachable by the process as agent configuration -- outside the intended per-agent containment directory.

## Fix

- Reject absolute `config_path` values outright.
- Reject (rather than warn on) a resolved path that escapes the agent's base directory.
- Resolve symlinks on both sides where the paths exist (`toRealPath()`, falling back to the lexical path when the target doesn't yet exist, so a missing file is still reported as not-found rather than misclassified as a traversal) -- matching the symlink-escape protection in `adk-go`'s second commit for the same fix.

## Testing

- `fromConfig_subAgentConfigPathTraversal_throwsConfigurationException` -- the exact `../` escape case, confirmed rejected.
- `fromConfig_subAgentAbsoluteConfigPath_throwsConfigurationException` -- the absolute-path case, confirmed rejected.
- The existing `fromConfig_withSubAgents_createsHierarchy` test (a legitimate in-directory subagent reference) is unmodified and continues to pass, confirming no regression.

## Verification performed

Maven Central is not reachable in the environment I used to develop this fix, so I could not run `mvn test` locally. I instead dynamically confirmed both the vulnerability and the fix using a faithful, line-for-line transcription of the real method (standard JDK only, no external dependencies needed to exercise this specific logic):

- **Before the fix**: a crafted `../secret_dir/victim_secret.yaml` path logged the deprecation warning, then proceeded to read the target file's full content regardless.
- **After the fix**: the same input is rejected with `"Path traversal detected: ..."`; an absolute path is rejected with `"Absolute paths are not allowed..."`; a legitimate in-directory reference still succeeds.