### PR TITLE
fix(flows): compare branch paths on segment boundaries, not raw string prefixes

### DIFF
--- a/core/src/main/java/com/google/adk/flows/llmflows/Contents.java
+++ b/core/src/main/java/com/google/adk/flows/llmflows/Contents.java
@@ -482,9 +482,13 @@ public final class Contents implements RequestProcessor {
   private static boolean isEventBelongsToBranch(@Nullable String invocationBranch, Event event) {
     @Nullable String eventBranch = event.branch().orElse(null);
 
+    // Branches are dot-joined agent names, so a raw prefix match would make "root.agent_10" belong
+    // to the branch "root.agent_1". Require either an exact match, or a prefix that ends on a
+    // segment boundary.
     return Strings.isNullOrEmpty(invocationBranch)
         || Strings.isNullOrEmpty(eventBranch)
-        || invocationBranch.startsWith(eventBranch);
+        || invocationBranch.equals(eventBranch)
+        || invocationBranch.startsWith(eventBranch + ".");
   }
 
   /**

--- a/core/src/test/java/com/google/adk/flows/llmflows/ContentsTest.java
+++ b/core/src/test/java/com/google/adk/flows/llmflows/ContentsTest.java
@@ -1300,6 +1300,61 @@ public final class ContentsTest {
     var unused = contentsProcessor.processRequest(context, initialRequest).blockingGet();
   }
 
+  @Test
+  public void processRequest_siblingBranchSharesNamePrefix_excludesSiblingEvent() {
+    Event siblingEvent =
+        createBranchedAgentEvent("agent_1", "e1", "sibling output", "root.agent_1");
+
+    List<Content> result =
+        runContentsProcessorOnBranch(ImmutableList.of(siblingEvent), "agent_10", "root.agent_10");
+
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  public void processRequest_sameBranch_includesEvent() {
+    Event ownEvent = createBranchedAgentEvent("agent_10", "e1", "own output", "root.agent_10");
+
+    List<Content> result =
+        runContentsProcessorOnBranch(ImmutableList.of(ownEvent), "agent_10", "root.agent_10");
+
+    assertThat(result).isEqualTo(eventsToContents(ImmutableList.of(ownEvent)));
+  }
+
+  @Test
+  public void processRequest_ancestorBranch_includesEvent() {
+    Event ancestorEvent = createBranchedAgentEvent("agent_10", "e1", "ancestor output", "root");
+
+    List<Content> result =
+        runContentsProcessorOnBranch(ImmutableList.of(ancestorEvent), "agent_10", "root.agent_10");
+
+    assertThat(result).isEqualTo(eventsToContents(ImmutableList.of(ancestorEvent)));
+  }
+
+  @Test
+  public void processRequest_eventWithoutBranch_includesEvent() {
+    Event userEvent = createUserEvent("u1", "user input");
+
+    List<Content> result =
+        runContentsProcessorOnBranch(ImmutableList.of(userEvent), "agent_10", "root.agent_10");
+
+    assertThat(result).isEqualTo(eventsToContents(ImmutableList.of(userEvent)));
+  }
+
+  @Test
+  public void processRequest_noInvocationBranch_includesBranchedEvent() {
+    Event siblingEvent =
+        createBranchedAgentEvent("agent_1", "e1", "sibling output", "root.agent_1");
+
+    List<Content> result =
+        runContentsProcessorOnBranch(ImmutableList.of(siblingEvent), "agent_10", null);
+
+    assertThat(result)
+        .containsExactly(
+            Content.fromParts(
+                Part.fromText("For context:"), Part.fromText("[agent_1] said: sibling output")));
+  }
+
   private static Event createUserEvent(String id, String text) {
     return Event.builder()
         .id(id)
@@ -1340,6 +1395,18 @@ public final class ContentsTest {
         .content(
             Content.builder().role("model").parts(ImmutableList.of(Part.fromText(text))).build())
         .invocationId("invocationId")
+        .build();
+  }
+
+  private static Event createBranchedAgentEvent(
+      String agent, String id, String text, String branch) {
+    return Event.builder()
+        .id(id)
+        .author(agent)
+        .content(
+            Content.builder().role("model").parts(ImmutableList.of(Part.fromText(text))).build())
+        .invocationId("invocationId")
+        .branch(branch)
         .build();
   }
 
@@ -1519,6 +1586,31 @@ public final class ContentsTest {
             .session(session)
             .sessionService(sessionService)
             .runConfig(RunConfig.builder().groupFunctionResponsesInHistory(true).build())
+            .build();
+
+    LlmRequest initialRequest = LlmRequest.builder().build();
+    RequestProcessor.RequestProcessingResult result =
+        contentsProcessor.processRequest(context, initialRequest).blockingGet();
+    return result.updatedRequest().contents();
+  }
+
+  private List<Content> runContentsProcessorOnBranch(
+      List<Event> events, String agentName, String invocationBranch) {
+    LlmAgent agent =
+        LlmAgent.builder()
+            .name(agentName)
+            .includeContents(LlmAgent.IncludeContents.DEFAULT)
+            .build();
+    Session session =
+        sessionService.createSession("test-app", "test-user", null, "test-session").blockingGet();
+    session.events().addAll(events);
+    InvocationContext context =
+        InvocationContext.builder()
+            .invocationId("test-invocation")
+            .agent(agent)
+            .session(session)
+            .sessionService(sessionService)
+            .branch(invocationBranch)
             .build();
 
     LlmRequest initialRequest = LlmRequest.builder().build();


### PR DESCRIPTION

**Please ensure you have read the [contribution guide](./CONTRIBUTING.md) before creating a pull request.**

### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

- Closes: #1414 (https://github.com/google/adk-java/issues/1414)

**2. Or, if no issue exists, describe the change:**

**Problem:**

`Contents.isEventBelongsToBranch` gates which past events an agent sees, using a raw
`invocationBranch.startsWith(eventBranch)`. A branch is a path of agent-name segments — `BaseAgent`
builds it as `branch + "." + name()` — so the test matches inside a segment:
`"root.agent_10".startsWith("root.agent_1")` is `true`. Peer agents whose names share a prefix
(`agent_1`/`agent_10`, `search`/`search_v2`) therefore see each other's output, which is what
`Event.branch()`'s javadoc says branches exist to prevent. The leaked event arrives re-authored as a
user-role message, with no error or warning.

**Solution:**

Require an exact match, or a prefix that ends on a segment boundary:

```java
return Strings.isNullOrEmpty(invocationBranch)
    || Strings.isNullOrEmpty(eventBranch)
    || invocationBranch.equals(eventBranch)
    || invocationBranch.startsWith(eventBranch + ".");
```

Ancestor and same-branch events stay visible; only the within-segment match is removed, and the
null/empty short-circuits are unchanged.

| File | Change |
|---|---|
| `core/src/main/java/…/flows/llmflows/Contents.java` | the comparison above, plus a comment naming the case |
| `core/src/test/java/…/flows/llmflows/ContentsTest.java` | 5 tests |

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

The first test fails on `main`; the other four pass before and after, pinning every remaining arm of
the predicate so the filter is visibly not tightened further:

| Test | Asserts |
|---|---|
| `processRequest_siblingBranchSharesNamePrefix_excludesSiblingEvent` | `agent_10` on `root.agent_10` does not see an `agent_1` event on `root.agent_1` |
| `processRequest_sameBranch_includesEvent` | an exact branch match stays visible |
| `processRequest_ancestorBranch_includesEvent` | a genuine ancestor (`root`) stays visible |
| `processRequest_eventWithoutBranch_includesEvent` | an unbranched event (user input) stays visible on any branch |
| `processRequest_noInvocationBranch_includesBranchedEvent` | an invocation with no branch still sees branched events |

On `main` the first one fails with the peer's output present, and note the form it arrives in:

```text
expected to be empty
but was : [Content{parts=[Part{text=For context:},
                          Part{text=[agent_1] said: sibling output}], role=user}]
```

**Manual End-to-End (E2E) Tests:**

A real `ParallelAgent` with two `LlmAgent` sub-agents on `gemini-3.5-flash`, run before and after the
change. Each agent's secret code lives in its own `instruction` (system instruction, never
`contents`) and carries a per-run token, so a code reaching a sibling can only have come from leaked
history. A second pair with no shared name prefix runs as a control.

Before:

```text
--- Colliding names - agent_1 and agent_10 ---
  agent_10 was shown it     : true
  agent_10 repeated it      : true
  agent_10's model read     : [Begin., Begin., NONE, For context:, [agent_1] said: SECRET-FROM-agent_1-4A8D0189, ...]
  agent_10's model answered : [NONE, SECRET-FROM-agent_1-4A8D0189]
--- Control - agent_1 and agent_2 ---
  agent_2 was shown it      : false
```

After:

```text
--- Colliding names - agent_1 and agent_10 ---
  agent_10 was shown it     : false
  agent_10 repeated it      : false
  agent_10's model answered : [NONE, NONE]
--- Control - agent_1 and agent_2 ---
  agent_2 was shown it      : false
```

The colliding pair now reads exactly like the control. 

### Checklist

- [x] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md) document.
- [x] My pull request contains a single commit.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [ ] Any dependent changes have been merged and published in downstream modules.
