### PR TITLE
fix(models): treat a part-less candidate as an error, not a success

### DIFF
--- a/core/src/main/java/com/google/adk/models/LlmResponse.java
+++ b/core/src/main/java/com/google/adk/models/LlmResponse.java
@@ -191,8 +191,22 @@ public abstract class LlmResponse extends JsonBaseModel {
       if (candidatesOpt.isPresent() && !candidatesOpt.get().isEmpty()) {
         Candidate candidate = candidatesOpt.get().get(0);
         this.finishReason(candidate.finishReason().orElse(null));
-        if (candidate.content().isPresent()) {
-          this.content(candidate.content().get());
+        // A blocked or truncated candidate still carries a content object, so its presence says
+        // nothing about whether the model produced anything. Decide on the parts instead, and let a
+        // candidate that stopped normally with nothing to say remain a successful, empty turn.
+        boolean hasParts =
+            candidate
+                .content()
+                .flatMap(Content::parts)
+                .map(parts -> !parts.isEmpty())
+                .orElse(false);
+        boolean stopped =
+            candidate
+                .finishReason()
+                .map(reason -> reason.knownEnum() == FinishReason.Known.STOP)
+                .orElse(false);
+        if (hasParts || stopped) {
+          this.content(candidate.content().orElse(null));
           this.groundingMetadata(candidate.groundingMetadata().orElse(null));
         } else {
           candidate.finishReason().ifPresent(this::errorCode);

--- a/core/src/test/java/com/google/adk/models/LlmResponseTest.java
+++ b/core/src/test/java/com/google/adk/models/LlmResponseTest.java
@@ -23,9 +23,11 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.adk.JsonBaseModel;
 import com.google.common.collect.ImmutableList;
+import com.google.genai.types.Candidate;
 import com.google.genai.types.Content;
 import com.google.genai.types.FinishReason;
 import com.google.genai.types.FunctionCall;
+import com.google.genai.types.GenerateContentResponse;
 import com.google.genai.types.GenerateContentResponseUsageMetadata;
 import com.google.genai.types.Part;
 import com.google.genai.types.Transcription;
@@ -249,5 +251,135 @@ public final class LlmResponseTest {
     assertThat(deserializedResponse.errorMessage()).isEmpty();
     assertThat(deserializedResponse.interrupted()).isEmpty();
     assertThat(deserializedResponse.usageMetadata()).isEmpty();
+  }
+
+  private LlmResponse createFromCandidate(Candidate candidate) {
+    return LlmResponse.create(
+        GenerateContentResponse.builder().candidates(ImmutableList.of(candidate)).build());
+  }
+
+  /** The shape a blocked or budget-exhausted candidate arrives in: content present, no parts. */
+  private Content emptyModelContent() {
+    return Content.builder().role("model").build();
+  }
+
+  @Test
+  public void testCreate_partlessCandidateOutOfTokens_isReportedAsError() {
+    LlmResponse response =
+        createFromCandidate(
+            Candidate.builder()
+                .content(emptyModelContent())
+                .finishReason(new FinishReason(FinishReason.Known.MAX_TOKENS))
+                .build());
+
+    assertThat(response.errorCode()).hasValue(new FinishReason(FinishReason.Known.MAX_TOKENS));
+    assertThat(response.finishReason()).hasValue(new FinishReason(FinishReason.Known.MAX_TOKENS));
+    assertThat(response.content()).isEmpty();
+  }
+
+  @Test
+  public void testCreate_partlessCandidateBlocked_reportsFinishMessageAsError() {
+    LlmResponse response =
+        createFromCandidate(
+            Candidate.builder()
+                .content(emptyModelContent())
+                .finishReason(new FinishReason(FinishReason.Known.SAFETY))
+                .finishMessage("Blocked by safety filters.")
+                .build());
+
+    assertThat(response.errorCode()).hasValue(new FinishReason(FinishReason.Known.SAFETY));
+    assertThat(response.errorMessage()).hasValue("Blocked by safety filters.");
+    assertThat(response.content()).isEmpty();
+  }
+
+  @Test
+  public void testCreate_candidateWithEmptyPartsList_isReportedAsError() {
+    LlmResponse response =
+        createFromCandidate(
+            Candidate.builder()
+                .content(Content.builder().role("model").parts(ImmutableList.of()).build())
+                .finishReason(new FinishReason(FinishReason.Known.MAX_TOKENS))
+                .build());
+
+    assertThat(response.errorCode()).hasValue(new FinishReason(FinishReason.Known.MAX_TOKENS));
+    assertThat(response.content()).isEmpty();
+  }
+
+  @Test
+  public void testCreate_candidateWithEmptyTextPart_isReportedAsSuccess() {
+    Content content =
+        Content.builder().role("model").parts(ImmutableList.of(Part.fromText(""))).build();
+
+    LlmResponse response =
+        createFromCandidate(
+            Candidate.builder()
+                .content(content)
+                .finishReason(new FinishReason(FinishReason.Known.MAX_TOKENS))
+                .build());
+
+    assertThat(response.errorCode()).isEmpty();
+    assertThat(response.errorMessage()).isEmpty();
+    assertThat(response.content()).hasValue(content);
+  }
+
+  @Test
+  public void testCreate_partlessCandidateStoppedNormally_isReportedAsSuccess() {
+    Content content = emptyModelContent();
+
+    LlmResponse response =
+        createFromCandidate(
+            Candidate.builder()
+                .content(content)
+                .finishReason(new FinishReason(FinishReason.Known.STOP))
+                .build());
+
+    assertThat(response.errorCode()).isEmpty();
+    assertThat(response.errorMessage()).isEmpty();
+    assertThat(response.content()).hasValue(content);
+  }
+
+  @Test
+  public void testCreate_truncatedCandidateWithText_isReportedAsSuccess() {
+    Content content = createSampleContent("The bicycle began as the");
+
+    LlmResponse response =
+        createFromCandidate(
+            Candidate.builder()
+                .content(content)
+                .finishReason(new FinishReason(FinishReason.Known.MAX_TOKENS))
+                .build());
+
+    assertThat(response.errorCode()).isEmpty();
+    assertThat(response.errorMessage()).isEmpty();
+    assertThat(response.content()).hasValue(content);
+  }
+
+  /**
+   * A candidate that produced nothing and reported no reason has no failure to raise, so no error
+   * code is set. The part-less content object is not carried over either — it holds nothing, and
+   * this pins the behavior so a later change to the predicate cannot alter it unnoticed.
+   */
+  @Test
+  public void testCreate_partlessCandidateWithoutFinishReason_reportsNeitherContentNorError() {
+    LlmResponse response =
+        createFromCandidate(Candidate.builder().content(emptyModelContent()).build());
+
+    assertThat(response.errorCode()).isEmpty();
+    assertThat(response.errorMessage()).isEmpty();
+    assertThat(response.finishReason()).isEmpty();
+    assertThat(response.content()).isEmpty();
+  }
+
+  /** A turn that ended normally is not an error, even when the candidate carries no content. */
+  @Test
+  public void testCreate_contentlessCandidateStoppedNormally_isReportedAsSuccess() {
+    LlmResponse response =
+        createFromCandidate(
+            Candidate.builder().finishReason(new FinishReason(FinishReason.Known.STOP)).build());
+
+    assertThat(response.errorCode()).isEmpty();
+    assertThat(response.errorMessage()).isEmpty();
+    assertThat(response.finishReason()).hasValue(new FinishReason(FinishReason.Known.STOP));
+    assertThat(response.content()).isEmpty();
   }
 }


### PR DESCRIPTION

**Please ensure you have read the [contribution guide](./CONTRIBUTING.md) before creating a pull request.**

### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

- Closes: [#1416](https://github.com/google/adk-java/issues/1416)

**2. Or, if no issue exists, describe the change:**

**Problem:**

`LlmResponse.Builder.response(GenerateContentResponse)` decides success by testing whether the
candidate's content object is present, never whether it holds anything. A candidate cut off
mid-generation arrives with `content` present and part-less (`"content": {}` on the wire), so
`candidate.content().isPresent()` sends it down the success branch: `errorCode` and `errorMessage`
stay empty, and `finishMessage` is discarded. The caller receives an empty answer that reads exactly
like a model with nothing to say.

`errorCode` is documented as *"Error code if the response is an error"*, yet the result carries
`finishReason=MAX_TOKENS` with `errorCode` empty.

**Solution:**

One predicate. Decide on whether the candidate produced **parts**, and treat a `STOP` with nothing to
say as a legitimate empty turn:

```java
Candidate candidate = candidatesOpt.get().get(0);
this.finishReason(candidate.finishReason().orElse(null));
boolean hasParts =
    candidate.content().flatMap(Content::parts).map(parts -> !parts.isEmpty()).orElse(false);
boolean stopped =
    candidate.finishReason().map(reason -> reason.knownEnum() == FinishReason.Known.STOP).orElse(false);
if (hasParts || stopped) {
  this.content(candidate.content().orElse(null));
  this.groundingMetadata(candidate.groundingMetadata().orElse(null));
} else {
  candidate.finishReason().ifPresent(this::errorCode);
  candidate.finishMessage().ifPresent(this::errorMessage);
}
```

**Two rows of behavior change, both in this branch:**

| Candidate | Before | After |
|---|---|---|
| content present, no parts, non-`STOP` reason | success, empty content, reason dropped | `errorCode` + `errorMessage` from the candidate |
| **no content, `finishReason=STOP`** | `errorCode=STOP` — a normal turn marked as an error | plain success |

Everything else is untouched: parts present is still a success whatever the reason, a part-less
`STOP` still succeeds, a blocked prompt still becomes `errorCode` from `blockReason`, and the
no-candidates path is unchanged.

| File | Change |
|---|---|
| `core/src/main/java/…/models/LlmResponse.java` | the predicate above |
| `core/src/test/java/…/models/LlmResponseTest.java` | 8 tests |

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

Eight in `LlmResponseTest`. The four marked as failing were confirmed failing on unmodified `main`
before the change, by reverting `LlmResponse.java` alone and re-running:

| Test | Candidate | Asserts | On `main` |
|---|---|---|---|
| `testCreate_partlessCandidateOutOfTokens_isReportedAsError` | part-less, `MAX_TOKENS` | `errorCode` from the finish reason, no content | ❌ fails |
| `testCreate_partlessCandidateBlocked_reportsFinishMessageAsError` | part-less, `SAFETY` | `errorCode` + `errorMessage` from `finishMessage` | ❌ fails |
| `testCreate_candidateWithEmptyPartsList_isReportedAsError` | empty `parts` list, `MAX_TOKENS` | an empty list is treated the same as no list | ❌ fails |
| `testCreate_contentlessCandidateStoppedNormally_isReportedAsSuccess` | no content, `STOP` | success — a normal turn is not an error | ❌ fails |
| `testCreate_candidateWithEmptyTextPart_isReportedAsSuccess` | one empty-text part, `MAX_TOKENS` | success — an empty part is still a part | ✅ passes |
| `testCreate_partlessCandidateStoppedNormally_isReportedAsSuccess` | part-less, `STOP` | success, content preserved | ✅ passes |
| `testCreate_partlessCandidateWithoutFinishReason_reportsNeitherContentNorError` | part-less, no finish reason | no error code — nothing to raise, and no content carried | ✅ passes |
| `testCreate_truncatedCandidateWithText_isReportedAsSuccess` | parts with text, `MAX_TOKENS` | success, content preserved | ✅ passes |

The four that already pass are the guards. They describe behavior this change must leave alone, so
they only break if the classification is inverted rather than tightened.

**Manual End-to-End (E2E) Tests:**

- [x] A real `LlmAgent` on `gemini-3.1-flash-lite` with `maxOutputTokens=24` and
  `thinkingBudget=2048` returns a part-less `MAX_TOKENS` candidate on demand. Before the change it is
  reported as a success and the caller receives an empty answer; after it, the same response carries
  `errorCode=MAX_TOKENS`. A control arm on an ordinary budget answers normally in both runs, and a
  truncated-but-non-empty answer stays a success in both.

### Checklist

- [x] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md) document.
- [x] My pull request contains a single commit.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [ ] Any dependent changes have been merged and published in downstream modules.

