### PR TITLE
fix(artifacts): do not derive a save's version number from a failed listing

### DIFF
--- a/core/src/main/java/com/google/adk/artifacts/GcsArtifactService.java
+++ b/core/src/main/java/com/google/adk/artifacts/GcsArtifactService.java
@@ -254,25 +254,10 @@ public final class GcsArtifactService implements BaseArtifactService {
       String appName, String userId, String sessionId, String filename) {
     return Single.fromCallable(
         () -> {
-          String prefix = getBlobPrefix(appName, userId, sessionId, filename);
           try {
-            return Streams.stream(
-                    storageClient.list(bucketName, BlobListOption.prefix(prefix)).iterateAll())
-                .map(Blob::getName)
-                .map(
-                    name -> {
-                      int versionDelimiterIndex = name.lastIndexOf('/');
-                      return versionDelimiterIndex != -1
-                              && versionDelimiterIndex < name.length() - 1
-                          ? Optional.of(name.substring(versionDelimiterIndex + 1))
-                          : Optional.<String>empty();
-                    })
-                .flatMap(Optional::stream)
-                .map(Integer::parseInt)
-                .sorted()
-                .collect(ImmutableList.toImmutableList());
+            return readVersions(appName, userId, sessionId, filename);
           } catch (StorageException e) {
-            return ImmutableList.of();
+            return ImmutableList.<Integer>of();
           }
         });
   }
@@ -314,7 +299,7 @@ public final class GcsArtifactService implements BaseArtifactService {
 
   private Single<SaveResult> saveArtifactAndReturnBlob(
       String appName, String userId, String sessionId, String filename, Part artifact) {
-    return listVersions(appName, userId, sessionId, filename)
+    return Single.fromCallable(() -> versionsBeforeSaving(appName, userId, sessionId, filename))
         .map(versions -> versions.isEmpty() ? 0 : max(versions) + 1)
         .flatMap(
             nextVersion ->
@@ -350,5 +335,65 @@ public final class GcsArtifactService implements BaseArtifactService {
                         throw new VerifyException("Failed to save artifact to GCS", e);
                       }
                     }));
+  }
+
+  /**
+   * Reads the versions stored for an artifact, letting a storage failure propagate.
+   *
+   * <p>An empty result from this method therefore means the artifact has no versions, never that
+   * the listing could not be performed. Each caller decides what a failure means for it: {@link
+   * #listVersions} reports it as "no versions", while {@link #saveArtifactAndReturnBlob} must not,
+   * because it derives the next version number from the result and would otherwise write over an
+   * object that already exists.
+   *
+   * @param appName Application name.
+   * @param userId User ID.
+   * @param sessionId Session ID.
+   * @param filename Artifact filename.
+   * @return sorted version numbers found under the artifact's prefix.
+   * @throws StorageException if the listing could not be performed.
+   */
+  private ImmutableList<Integer> readVersions(
+      String appName, String userId, String sessionId, String filename) {
+    String prefix = getBlobPrefix(appName, userId, sessionId, filename);
+    return Streams.stream(
+            storageClient.list(bucketName, BlobListOption.prefix(prefix)).iterateAll())
+        .map(Blob::getName)
+        .map(
+            name -> {
+              int versionDelimiterIndex = name.lastIndexOf('/');
+              return versionDelimiterIndex != -1 && versionDelimiterIndex < name.length() - 1
+                  ? Optional.of(name.substring(versionDelimiterIndex + 1))
+                  : Optional.<String>empty();
+            })
+        .flatMap(Optional::stream)
+        .map(Integer::parseInt)
+        .sorted()
+        .collect(ImmutableList.toImmutableList());
+  }
+
+  /**
+   * Reads the versions that already exist, for a save that is about to derive the next version
+   * number from them.
+   *
+   * <p>The write that follows carries no precondition, so treating a failed listing as "no
+   * versions" would compute version 0 and replace whatever is already stored under that name, while
+   * reporting success to the caller. Surfacing the failure instead is the same choice {@link
+   * #listArtifactKeys} and {@link #deleteArtifact} already make for the same operation.
+   *
+   * @param appName Application name.
+   * @param userId User ID.
+   * @param sessionId Session ID.
+   * @param filename Artifact filename.
+   * @return sorted version numbers already stored for the artifact.
+   * @throws VerifyException if the versions could not be listed.
+   */
+  private ImmutableList<Integer> versionsBeforeSaving(
+      String appName, String userId, String sessionId, String filename) {
+    try {
+      return readVersions(appName, userId, sessionId, filename);
+    } catch (StorageException e) {
+      throw new VerifyException("Failed to list artifact versions from GCS", e);
+    }
   }
 }

--- a/core/src/test/java/com/google/adk/artifacts/GcsArtifactServiceTest.java
+++ b/core/src/test/java/com/google/adk/artifacts/GcsArtifactServiceTest.java
@@ -20,6 +20,7 @@ import static org.junit.Assert.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -452,6 +453,7 @@ public class GcsArtifactServiceTest {
   @Test
   public void listVersions_storageException_returnsEmptyList() {
     String prefix = String.format("%s/%s/%s/%s/", APP_NAME, USER_ID, SESSION_ID, FILENAME);
+
     when(mockStorage.list(BUCKET_NAME, BlobListOption.prefix(prefix)))
         .thenThrow(new StorageException(500, "Induced error"));
 
@@ -459,6 +461,46 @@ public class GcsArtifactServiceTest {
         service.listVersions(APP_NAME, USER_ID, SESSION_ID, FILENAME).blockingGet();
 
     assertThat(versions).isEmpty();
+  }
+
+  @Test
+  public void save_listStorageException_propagates() {
+    Part artifact = Part.fromBytes(new byte[] {4, 5}, "image/png");
+    when(mockStorage.list(eq(BUCKET_NAME), any(BlobListOption.class)))
+        .thenThrow(new StorageException(500, "Induced error"));
+
+    VerifyException thrown =
+        assertThrows(
+            VerifyException.class,
+            () ->
+                service
+                    .saveArtifact(APP_NAME, USER_ID, SESSION_ID, FILENAME, artifact)
+                    .blockingGet());
+
+    // The cause is the whole point: an operator has to be able to see which call failed and why.
+    assertThat(thrown).hasCauseThat().isInstanceOf(StorageException.class);
+    verify(mockStorage).list(eq(BUCKET_NAME), any(BlobListOption.class));
+  }
+
+  /**
+   * The listing failing is not itself the harm. Deriving a version number from the empty list it
+   * used to return is: the save computed version 0 and replaced whatever was already stored under
+   * that name. This asserts no write is attempted at all.
+   */
+  @Test
+  public void save_listStorageException_doesNotWrite() {
+    Part artifact = Part.fromBytes(new byte[] {4, 5}, "image/png");
+    when(mockStorage.list(eq(BUCKET_NAME), any(BlobListOption.class)))
+        .thenThrow(new StorageException(500, "Induced error"));
+
+    assertThrows(
+        VerifyException.class,
+        () ->
+            service.saveArtifact(APP_NAME, USER_ID, SESSION_ID, FILENAME, artifact).blockingGet());
+
+    // Asserts the listing was reached, so this cannot pass by failing earlier for another reason.
+    verify(mockStorage).list(eq(BUCKET_NAME), any(BlobListOption.class));
+    verify(mockStorage, never()).create(any(BlobInfo.class), any(byte[].class));
   }
 
   @Test


### PR DESCRIPTION

**Please ensure you have read the [contribution guide](./CONTRIBUTING.md) before creating a pull request.**

### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

- Closes: [#1418](https://github.com/google/adk-java/issues/1418)

**2. Or, if no issue exists, describe the change:**

**Problem:**

`GcsArtifactService.listVersions` returns an empty list when the listing raises `StorageException`.
`saveArtifactAndReturnBlob` derives the next version number from that result
(`versions.isEmpty() ? 0 : max(versions) + 1`) and writes with no precondition. At the point where
the version number is chosen, an empty list can mean either that the artifact has no versions or
that the listing did not complete — so a 503, a 429, a timeout or IAM propagation makes the save
compute version 0 and write over the object already stored at version 0, while returning success and
version `0` to the caller.

`listArtifactKeys` issues the same `storageClient.list(bucketName, BlobListOption.prefix(...))` call
and surfaces a failure as `VerifyException`. `listVersions` is the one whose result selects the blob
name a save writes to.

**Solution:**

Separate the listing from the decision about what a failed listing means. The query moves into a
private `readVersions` that lets `StorageException` propagate, and each caller applies its own
policy: `listVersions` catches it and returns an empty list as before, the save path catches it and
throws. Four pieces:

| # | Piece | What it is |
|---|---|---|
| 1 | `readVersions` — new private method | the old body of `listVersions`, moved verbatim; the stream pipeline is unchanged |
| 2 | `listVersions` — public, behavior unchanged | call `readVersions`, catch `StorageException`, return `ImmutableList.of()` |
| 3 | `versionsBeforeSaving` — new private method | call `readVersions`, catch `StorageException`, throw `VerifyException("Failed to list artifact versions from GCS", e)` — the same form `listArtifactKeys` already uses for this operation, naming what failed |
| 4 | `saveArtifactAndReturnBlob` — one line | was `listVersions(...)`, now `Single.fromCallable(() -> versionsBeforeSaving(...))`; everything after it is untouched |

```java
private ImmutableList<Integer> versionsBeforeSaving(
    String appName, String userId, String sessionId, String filename) {
  try {
    return readVersions(appName, userId, sessionId, filename);
  } catch (StorageException e) {
    throw new VerifyException("Failed to list artifact versions from GCS", e);
  }
}
```

`listVersions` has three callers besides the save path — `loadArtifact`, `deleteArtifact`, and
`ArtifactController` in the `dev` module — so removing the catch outright would change
all of them as well. Leaving it in place keeps the diff to the one caller that overwrites stored
data: those three behave exactly as before, and `listVersions_storageException_returnsEmptyList`
passes untouched. That is a scoping choice, not a claim that the empty list is right for them; the
issue lists them as related and uncovered. If you would rather the catch went away and those callers
moved with it, say so and I will make that change instead.

| File | Change |
|---|---|
| `core/src/main/java/…/artifacts/GcsArtifactService.java` | the four pieces above, `+81/-18` |
| `core/src/test/java/…/artifacts/GcsArtifactServiceTest.java` | 2 tests |

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

`GcsArtifactServiceTest`: **Tests run: 26, Failures: 0, Errors: 0, Skipped: 0.** Both new tests were
confirmed failing on unmodified `main` by reverting `GcsArtifactService.java` alone and re-running —
`Tests run: 26, Failures: 2`, exactly these two:

| Test | Asserts | On `main` |
|---|---|---|
| `save_listStorageException_propagates` | the save raises `VerifyException`, with `hasCauseThat().isInstanceOf(StorageException.class)` so the underlying failure stays visible | ❌ fails |
| `save_listStorageException_doesNotWrite` | `verify(mockStorage, never()).create(...)` | ❌ fails |

Both also `verify(mockStorage).list(...)`, so neither can pass by failing earlier for an unrelated
reason.

**Manual End-to-End (E2E) Tests:**

- [x] Run against a real GCS bucket, two arms. Both save `PAYLOAD-A` through a fully-permissioned
  client, then save `PAYLOAD-B` to the same filename — arm 1 through an identity denied
  `storage.objects.list`, arm 2 through a client that can list. The bucket is inspected afterwards
  with a privileged credential, since the restricted identity cannot list.

| | before | after |
|---|---|---|
| save 1, healthy client | v0 = `PAYLOAD-A` | v0 = `PAYLOAD-A` |
| save 2, client under test | reports v0, success | raises; the cause names `storage.objects.list` |
| bucket after | 1 object = `PAYLOAD-B` | 1 object = `PAYLOAD-A` |
| `loadArtifact(0)` | `PAYLOAD-B` | `PAYLOAD-A` |

The control arm is unchanged by the fix in both runs — versions `[0, 1]`, both objects kept — so the
two arms differ only in which client performs the second save.

### Checklist

- [x] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md) document.
- [x] My pull request contains a single commit.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [ ] Any dependent changes have been merged and published in downstream modules.
