### PR TITLE
fix: convert functionResponse parts to Spring AI ToolResponseMessage

### DIFF
--- a/contrib/spring-ai/src/main/java/com/google/adk/models/springai/MessageConverter.java
+++ b/contrib/spring-ai/src/main/java/com/google/adk/models/springai/MessageConverter.java
@@ -22,6 +22,7 @@ import com.google.adk.models.LlmRequest;
 import com.google.adk.models.LlmResponse;
 import com.google.genai.types.Content;
 import com.google.genai.types.FunctionCall;
+import com.google.genai.types.FunctionResponse;
 import com.google.genai.types.GenerateContentResponseUsageMetadata;
 import com.google.genai.types.Part;
 import java.net.URI;
@@ -261,10 +262,15 @@ public class MessageConverter {
       if (part.text().isPresent()) {
         textBuilder.append(part.text().get());
       } else if (part.functionResponse().isPresent()) {
-        // TODO: Spring AI 1.1.0 ToolResponseMessage constructors are protected
-        // For now, we skip tool responses in user messages
-        // This will need to be addressed in a future update when Spring AI provides
-        // a public API for creating ToolResponseMessage
+        FunctionResponse functionResponse = part.functionResponse().get();
+        String id = functionResponse.id().orElse("");
+        String name = functionResponse.name().orElse("");
+        String responseData = toJson(functionResponse.response().orElse(Map.of()));
+
+        ToolResponseMessage.ToolResponse toolResponse =
+            new ToolResponseMessage.ToolResponse(id, name, responseData);
+        toolResponseMessages.add(
+            ToolResponseMessage.builder().responses(List.of(toolResponse)).build());
       } else if (part.inlineData().isPresent()) {
         // Handle inline media data (images, audio, video, etc.)
         com.google.genai.types.Blob blob = part.inlineData().get();
@@ -298,7 +304,9 @@ public class MessageConverter {
     }
 
     List<Message> messages = new ArrayList<>();
-    messages.add(UserMessage.builder().text(textBuilder.toString()).media(mediaList).build());
+    if (textBuilder.length() > 0 || !mediaList.isEmpty() || toolResponseMessages.isEmpty()) {
+      messages.add(UserMessage.builder().text(textBuilder.toString()).media(mediaList).build());
+    }
     messages.addAll(toolResponseMessages);
 
     return messages;

--- a/contrib/spring-ai/src/test/java/com/google/adk/models/springai/MessageConverterTest.java
+++ b/contrib/spring-ai/src/test/java/com/google/adk/models/springai/MessageConverterTest.java
@@ -37,6 +37,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.ai.chat.messages.AssistantMessage;
 import org.springframework.ai.chat.messages.Message;
 import org.springframework.ai.chat.messages.SystemMessage;
+import org.springframework.ai.chat.messages.ToolResponseMessage;
 import org.springframework.ai.chat.messages.UserMessage;
 import org.springframework.ai.chat.metadata.ChatResponseMetadata;
 import org.springframework.ai.chat.metadata.DefaultUsage;
@@ -184,19 +185,18 @@ class MessageConverterTest {
     Prompt prompt = messageConverter.toLlmPrompt(request);
 
     // Currently only UserMessage is created (function response is skipped)
-    assertThat(prompt.getInstructions()).hasSize(1);
+    assertThat(prompt.getInstructions()).hasSize(2);
 
     Message userMessage = prompt.getInstructions().get(0);
     assertThat(userMessage).isInstanceOf(UserMessage.class);
     assertThat(((UserMessage) userMessage).getText()).isEqualTo("What's the weather?");
 
-    // When Spring AI provides public API for ToolResponseMessage, uncomment:
-    // Message toolResponseMessage = prompt.getInstructions().get(1);
-    // assertThat(toolResponseMessage).isInstanceOf(ToolResponseMessage.class);
-    // ToolResponseMessage toolResponse = (ToolResponseMessage) toolResponseMessage;
-    // assertThat(toolResponse.getResponses()).hasSize(1);
-    // ToolResponseMessage.ToolResponse response = toolResponse.getResponses().get(0);
-    // assertThat(response.name()).isEqualTo("get_weather");
+    Message toolResponseMessage = prompt.getInstructions().get(1);
+    assertThat(toolResponseMessage).isInstanceOf(ToolResponseMessage.class);
+    ToolResponseMessage toolResponse = (ToolResponseMessage) toolResponseMessage;
+    assertThat(toolResponse.getResponses()).hasSize(1);
+    ToolResponseMessage.ToolResponse response = toolResponse.getResponses().get(0);
+    assertThat(response.name()).isEqualTo("get_weather");
   }
 
   @Test


### PR DESCRIPTION
**Please ensure you have read the [contribution guide](./CONTRIBUTING.md) before creating a pull request.**

### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

- Closes: #1423



**Problem:**
When using Spring AI as the model provider in ADK and a tool call is executed, the tool execution result (FunctionResponse part inside ADK Content) was dropped during Prompt construction in MessageConverter.java. On the second request to the LLM, the prompt sent an AssistantMessage containing tool_calls followed by a user message missing the matching tool_call_id response messages. This caused provider API validation failures across LLM providers (e.g., OpenAI HTTP 400 Bad Request: "An assistant message with 'tool_calls' must be followed by tool messages responding to each 'tool_call_id'"). Furthermore, MessageConverter generated empty UserMessage("") instances on tool response turns, causing additional validation failures on strict providers

**Solution:**
1. Updated MessageConverter.java (handleUserContent) to convert part.functionResponse() into Spring AI ToolResponseMessage
2. Updated handleUserContent logic so that a UserMessage is only created when non-empty text/media exists or when toolResponseMessages.isEmpty(), preventing empty UserMessage("") instances during tool response turns
3. Updated MessageConverterTest.java to assert ToolResponseMessage generation

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

_Please include a summary of passed java test results._

**Manual End-to-End (E2E) Tests:**

Executed multi-turn tool execution flow with a Spring AI hello-time-agent sample using mock and live model drivers before and after fix to confirm fix works as expected or not.

### Checklist

- [x] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md) document.
- [x] My pull request contains a single commit.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [x] Any dependent changes have been merged and published in downstream modules.



