### PR TITLE
fix: preserve raw tool parameter schemas in chat completions

### DIFF
--- a/core/src/main/java/com/google/adk/models/chat/ChatCompletionsRequest.java
+++ b/core/src/main/java/com/google/adk/models/chat/ChatCompletionsRequest.java
@@ -603,7 +603,11 @@ public final class ChatCompletionsRequest {
             FunctionDefinition def = new FunctionDefinition();
             def.name = fd.name().orElse("");
             def.description = fd.description().orElse("");
-            if (fd.parameters().isPresent()) {
+            if (fd.parametersJsonSchema().isPresent()) {
+              def.parameters =
+                  objectMapper.convertValue(
+                      fd.parametersJsonSchema().get(), new TypeReference<Map<String, Object>>() {});
+            } else if (fd.parameters().isPresent()) {
               def.parameters =
                   objectMapper.convertValue(
                       fd.parameters().get(), new TypeReference<Map<String, Object>>() {});

--- a/core/src/main/java/com/google/adk/models/chat/ChatCompletionsRequest.java
+++ b/core/src/main/java/com/google/adk/models/chat/ChatCompletionsRequest.java
@@ -607,6 +607,9 @@ public final class ChatCompletionsRequest {
               def.parameters =
                   objectMapper.convertValue(
                       fd.parametersJsonSchema().get(), new TypeReference<Map<String, Object>>() {});
+              if (!def.parameters.containsKey("properties")) {
+                def.parameters.put("properties", ImmutableMap.of());
+              }
             } else if (fd.parameters().isPresent()) {
               def.parameters =
                   objectMapper.convertValue(

--- a/core/src/test/java/com/google/adk/models/chat/ChatCompletionsRequestTest.java
+++ b/core/src/test/java/com/google/adk/models/chat/ChatCompletionsRequestTest.java
@@ -37,6 +37,7 @@ import com.google.genai.types.Part;
 import com.google.genai.types.Schema;
 import com.google.genai.types.Tool;
 import com.google.genai.types.ToolConfig;
+import io.modelcontextprotocol.spec.McpSchema.JsonSchema;
 import java.util.AbstractMap;
 import java.util.Base64;
 import java.util.List;
@@ -645,6 +646,34 @@ public final class ChatCompletionsRequestTest {
 
     assertThat(request.tools).hasSize(1);
     assertThat(request.tools.get(0).function.parameters).isEqualTo(jsonSchema);
+  }
+
+  @Test
+  public void testFromLlmRequest_withZeroArgumentParametersJsonSchema() throws Exception {
+    JsonSchema jsonSchema = new JsonSchema("object", null, null, null, null, null);
+    FunctionDeclaration function =
+        FunctionDeclaration.builder()
+            .name("zero_argument_tool")
+            .parametersJsonSchema(jsonSchema)
+            .build();
+    Tool tool = Tool.builder().functionDeclarations(ImmutableList.of(function)).build();
+    GenerateContentConfig config =
+        GenerateContentConfig.builder().tools(ImmutableList.of(tool)).build();
+    LlmRequest llmRequest =
+        LlmRequest.builder()
+            .model("openai-compatible-model")
+            .config(config)
+            .contents(ImmutableList.of())
+            .build();
+
+    ChatCompletionsRequest request = ChatCompletionsRequest.fromLlmRequest(llmRequest, false);
+
+    assertThat(request.tools).hasSize(1);
+    Map<String, Object> params = (Map<String, Object>) request.tools.get(0).function.parameters;
+    assertThat(params.get("type")).isEqualTo("object");
+    @SuppressWarnings("unchecked")
+    Map<String, Object> props = (Map<String, Object>) params.get("properties");
+    assertThat(props).isEmpty();
   }
 
   @Test

--- a/core/src/test/java/com/google/adk/models/chat/ChatCompletionsRequestTest.java
+++ b/core/src/test/java/com/google/adk/models/chat/ChatCompletionsRequestTest.java
@@ -614,6 +614,40 @@ public final class ChatCompletionsRequestTest {
   }
 
   @Test
+  public void testFromLlmRequest_withParametersJsonSchema() throws Exception {
+    Map<String, Object> jsonSchema =
+        ImmutableMap.of(
+            "type",
+            "object",
+            "properties",
+            ImmutableMap.of("jobId", ImmutableMap.of("$ref", "#/$defs/jobId")),
+            "required",
+            ImmutableList.of("jobId"),
+            "$defs",
+            ImmutableMap.of("jobId", ImmutableMap.of("type", "string")));
+    FunctionDeclaration function =
+        FunctionDeclaration.builder()
+            .name("analyze_premerge_failures_by_job")
+            .parametersJsonSchema(jsonSchema)
+            .build();
+
+    Tool tool = Tool.builder().functionDeclarations(ImmutableList.of(function)).build();
+    GenerateContentConfig config =
+        GenerateContentConfig.builder().tools(ImmutableList.of(tool)).build();
+    LlmRequest llmRequest =
+        LlmRequest.builder()
+            .model("openai-compatible-model")
+            .config(config)
+            .contents(ImmutableList.of())
+            .build();
+
+    ChatCompletionsRequest request = ChatCompletionsRequest.fromLlmRequest(llmRequest, false);
+
+    assertThat(request.tools).hasSize(1);
+    assertThat(request.tools.get(0).function.parameters).isEqualTo(jsonSchema);
+  }
+
+  @Test
   public void testFromLlmRequest_normalizesSchemaTypeToLowerCase() throws Exception {
     Schema param1Schema = Schema.builder().type("STRING").build();
 

--- a/core/src/test/java/com/google/adk/models/chat/ChatCompletionsRequestTest.java
+++ b/core/src/test/java/com/google/adk/models/chat/ChatCompletionsRequestTest.java
@@ -616,16 +616,11 @@ public final class ChatCompletionsRequestTest {
 
   @Test
   public void testFromLlmRequest_withParametersJsonSchema() throws Exception {
-    Map<String, Object> jsonSchema =
-        ImmutableMap.of(
-            "type",
-            "object",
-            "properties",
-            ImmutableMap.of("jobId", ImmutableMap.of("$ref", "#/$defs/jobId")),
-            "required",
-            ImmutableList.of("jobId"),
-            "$defs",
-            ImmutableMap.of("jobId", ImmutableMap.of("type", "string")));
+    Map<String, Object> properties =
+        ImmutableMap.of("jobId", ImmutableMap.of("$ref", "#/$defs/jobId"));
+    Map<String, Object> defs = ImmutableMap.of("jobId", ImmutableMap.of("type", "string"));
+    JsonSchema jsonSchema =
+        new JsonSchema("object", properties, ImmutableList.of("jobId"), null, defs, null);
     FunctionDeclaration function =
         FunctionDeclaration.builder()
             .name("analyze_premerge_failures_by_job")
@@ -645,7 +640,17 @@ public final class ChatCompletionsRequestTest {
     ChatCompletionsRequest request = ChatCompletionsRequest.fromLlmRequest(llmRequest, false);
 
     assertThat(request.tools).hasSize(1);
-    assertThat(request.tools.get(0).function.parameters).isEqualTo(jsonSchema);
+    assertThat(request.tools.get(0).function.parameters)
+        .isEqualTo(
+            ImmutableMap.of(
+                "type",
+                "object",
+                "properties",
+                properties,
+                "required",
+                ImmutableList.of("jobId"),
+                "$defs",
+                defs));
   }
 
   @Test


### PR DESCRIPTION
Fixes #1426

## Summary

- use `FunctionDeclaration.parametersJsonSchema` when building OpenAI-compatible tool declarations
- preserve the complete raw JSON Schema, including `required`, `$ref`, and `$defs`
- retain the existing typed `parameters` conversion and zero-argument fallback

This mirrors the raw-schema fallback already used by the Claude connector in #1342.

## Reproduction

Before the fix, the focused regression test was run three times. Every run failed with the same result: the output contained only an empty `properties` map, while `jobId`, `required`, and `$defs` were missing.

After the fix, `ChatCompletionsRequestTest` passes and the emitted tool schema equals the MCP-style raw schema.

## Validation

- `JAVA_HOME=/opt/homebrew/opt/openjdk@17/libexec/openjdk.jdk/Contents/Home ./mvnw -pl core -Dtest=ChatCompletionsRequestTest test`
- `JAVA_HOME=/opt/homebrew/opt/openjdk@17/libexec/openjdk.jdk/Contents/Home ./mvnw -pl core test`
- main test set: 1,769 tests, 0 failures, 0 errors, 24 skipped
- all additional Surefire profile tests passed; Maven finished with `BUILD SUCCESS`
- Google Java Format ran with 0 remaining reformats

No screenshot is needed because the regression test asserts the exact outbound tool schema object.
