### PR TITLE
Enforce session ownership in VertexAiSessionService.listEvents

### DIFF
--- a/core/src/main/java/com/google/adk/sessions/VertexAiSessionService.java
+++ b/core/src/main/java/com/google/adk/sessions/VertexAiSessionService.java
@@ -165,7 +165,26 @@ public final class VertexAiSessionService implements BaseSessionService {
   @Override
   public Single<ListEventsResponse> listEvents(String appName, String userId, String sessionId) {
     validateSessionId(sessionId);
-    return listEventsInternal(appName, sessionId, /* filter= */ null);
+    String reasoningEngineId = parseReasoningEngineId(appName);
+    return client
+        .getSession(reasoningEngineId, sessionId)
+        .flatMapSingle(
+            getSessionResponseMap -> {
+              // Enforce ownership using the owner reported by the backend, not the
+              // requested user id, mirroring the check getSession/deleteSession use.
+              // Deny as empty so existence is not revealed to a non-owner.
+              String ownerUserId =
+                  Optional.ofNullable(getSessionResponseMap.get("userId"))
+                      .map(JsonNode::asText)
+                      .orElse(null);
+              if (!userId.equals(ownerUserId)) {
+                return Single.just(ListEventsResponse.builder().build());
+              }
+              return listEventsInternal(appName, sessionId, /* filter= */ null);
+            })
+        // No session found at all (rather than an ownership mismatch): behave the
+        // same as before, returning an empty response instead of erroring.
+        .defaultIfEmpty(ListEventsResponse.builder().build());
   }
 
   private Single<ListEventsResponse> listEventsInternal(

--- a/core/src/test/java/com/google/adk/sessions/VertexAiSessionServiceTest.java
+++ b/core/src/test/java/com/google/adk/sessions/VertexAiSessionServiceTest.java
@@ -423,6 +423,17 @@ public class VertexAiSessionServiceTest {
   }
 
   @Test
+  public void listEvents_wrongUser_returnsEmpty() {
+    // Session "1" belongs to "user" and has an event in eventMap (MOCK_EVENT_STRING).
+    // A different user must not be able to read those events - mirrors
+    // getSession_wrongUser_returnsEmpty above, applied to listEvents.
+    ListEventsResponse response =
+        vertexAiSessionService.listEvents("123", "attacker", "1").blockingGet();
+
+    assertThat(response.events()).isEmpty();
+  }
+
+  @Test
   public void deleteSession_wrongUser_deniedAndSessionKept() {
     // The ownership error surfaces on subscription, so hoist the Completable out.
     Completable deletion = vertexAiSessionService.deleteSession("123", "attacker", "1");


### PR DESCRIPTION
## Summary
Commit d1b1d92 (#1323) added an ownership check to `getSession` and `deleteSession` - fetch the session, compare the backend-reported owner to the caller's `userId`, deny as not-found on mismatch. The same check was not applied to `listEvents`.

## Impact
`listEvents` returns a session's full event stream (conversation content, tool calls, state deltas) addressed solely by `sessionId`, with no ownership check. The Vertex backend session-events sub-resource does not enforce per-caller ownership on its own (per the existing comments on the getSession/deleteSession checks in this same file), so any authenticated caller who knows or guesses another user's `sessionId` can read that user's full conversation history via `listEvents` - the same disclosure class d1b1d92 fixed for `getSession`/`deleteSession`, left open here. `listEvents` is public API (`BaseSessionService` interface), not an internal helper.

## Fix
`listEvents` now fetches the session and applies the same ownership check `getSession`/`deleteSession` already use before returning events, denying as an empty response (not an error) on mismatch - consistent with `getSession`'s not-found-style denial rather than `deleteSession`'s exception-based one, since `listEvents`' existing contract already returns an empty response for a nonexistent/eventless session.

## Testing
Added `listEvents_wrongUser_returnsEmpty`, mirroring the existing `getSession_wrongUser_returnsEmpty` test in the same file. Verified locally: the new test fails against the unfixed code (confirming it genuinely exercises the gap) and passes with the fix; full `VertexAiSessionServiceTest` suite passes with no regressions.