### PR TITLE
fix: avoid setting Part.partMetadata when metadata is empty

### DIFF
--- a/a2a/src/main/java/com/google/adk/a2a/converters/PartConverter.java
+++ b/a2a/src/main/java/com/google/adk/a2a/converters/PartConverter.java
@@ -87,9 +87,11 @@ public final class PartConverter {
       com.google.genai.types.Part.Builder partBuilder =
           com.google.genai.types.Part.builder().text(textPart.getText());
       if (textPart.getMetadata() != null) {
-        partBuilder.partMetadata(textPart.getMetadata());
         if (Objects.equals(textPart.getMetadata().get("thought"), true)) {
           partBuilder.thought(true);
+        }
+        if (!textPart.getMetadata().isEmpty()) {
+          partBuilder.partMetadata(textPart.getMetadata());
         }
       }
       return partBuilder.build();
@@ -122,7 +124,7 @@ public final class PartConverter {
                       .fileUri(fileWithUri.uri())
                       .mimeType(fileWithUri.mimeType())
                       .build());
-      if (metadata != null) {
+      if (metadata != null && !metadata.isEmpty()) {
         builder.partMetadata(metadata);
       }
       return builder.build();
@@ -137,7 +139,7 @@ public final class PartConverter {
       com.google.genai.types.Part.Builder builder =
           com.google.genai.types.Part.builder()
               .inlineData(Blob.builder().data(decoded).mimeType(fileWithBytes.mimeType()).build());
-      if (metadata != null) {
+      if (metadata != null && !metadata.isEmpty()) {
         builder.partMetadata(metadata);
       }
       return builder.build();

--- a/a2a/src/test/java/com/google/adk/a2a/converters/PartConverterTest.java
+++ b/a2a/src/test/java/com/google/adk/a2a/converters/PartConverterTest.java
@@ -484,6 +484,27 @@ public class PartConverterTest {
   }
 
   @Test
+  public void toGenaiPart_withTextPartEmptyMetadata_doesNotSetPartMetadata() {
+    TextPart textPart = new TextPart("Hello", ImmutableMap.of());
+
+    Part result = PartConverter.toGenaiPart(textPart);
+
+    assertThat(result.text()).hasValue("Hello");
+    assertThat(result.partMetadata()).isEmpty();
+  }
+
+  @Test
+  public void toGenaiPart_withFilePartEmptyMetadata_doesNotSetPartMetadata() {
+    FilePart filePart =
+        new FilePart(
+            new FileWithUri("text/plain", "file.txt", "http://file.txt"), ImmutableMap.of());
+
+    Part result = PartConverter.toGenaiPart(filePart);
+
+    assertThat(result.partMetadata()).isEmpty();
+  }
+
+  @Test
   public void toGenaiPart_withTextPartMetadata_propagatesMetadata() {
     TextPart textPart = new TextPart("Hello", ImmutableMap.of("key", "value"));
 


### PR DESCRIPTION
**Please ensure you have read the [contribution guide](./CONTRIBUTING.md) before creating a pull request.**

### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

- Closes: #1421


**Problem:**
In `PartConverter.java`, `toGenaiPart()` and `convertFilePartToGenAiPart()` unconditionally set `Part.Builder#partMetadata(...)` whenever the A2A part's metadata map was non-null (`textPart.getMetadata() != null` and `filePart.getMetadata() != null`). Because `PartConverter.fromGenaiPart()` initializes A2A parts with default empty metadata maps (`{}`), any round-tripped or converted A2A message attached empty metadata `{}` to `Part#partMetadata`.

**Solution:**
1. Updated `PartConverter#toGenaiPart` (for `TextPart`) to only call `partBuilder.partMetadata(...)` when `textPart.getMetadata() != null && !textPart.getMetadata().isEmpty()`.
2. Updated `PartConverter#convertFilePartToGenAiPart` (for `FileWithUri` and `FileWithBytes`) to check `metadata != null && !metadata.isEmpty()` before calling `builder.partMetadata(metadata)`.
3. Added unit tests in `PartConverterTest` to verify that `TextPart` and `FilePart` with empty metadata maps do not set `Part.partMetadata`.

### Testing Plan

_Please describe the tests that you ran to verify your changes. This is required
for all PRs that are not small documentation or typo fixes._

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.



### Checklist

- [x] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md) document.
- [x] My pull request contains a single commit.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [x] Any dependent changes have been merged and published in downstream modules.


