### PR TITLE
feat: configure similarity top-K in the VertexAiRagRetrieval tool

### DIFF
--- a/core/src/main/java/com/google/adk/tools/retrieval/VertexAiRagRetrieval.java
+++ b/core/src/main/java/com/google/adk/tools/retrieval/VertexAiRagRetrieval.java
@@ -23,6 +23,7 @@ import com.google.adk.tools.ToolContext;
 import com.google.adk.utils.ModelNameUtils;
 import com.google.cloud.aiplatform.v1.RagContexts;
 import com.google.cloud.aiplatform.v1.RagQuery;
+import com.google.cloud.aiplatform.v1.RagRetrievalConfig;
 import com.google.cloud.aiplatform.v1.RetrieveContextsRequest;
 import com.google.cloud.aiplatform.v1.RetrieveContextsRequest.VertexRagStore.RagResource;
 import com.google.cloud.aiplatform.v1.RetrieveContextsResponse;
@@ -47,7 +48,8 @@ import org.slf4j.LoggerFactory;
  * A retrieval tool that fetches context from Vertex AI RAG.
  *
  * <p>This tool allows to retrieve relevant information based on a query using Vertex AI RAG
- * service. It supports configuration of rag resources and a vector distance threshold.
+ * service. It supports configuration of rag resources, a vector distance threshold, and similarity
+ * top-k.
  */
 public class VertexAiRagRetrieval extends BaseRetrievalTool {
   private static final Logger logger = LoggerFactory.getLogger(VertexAiRagRetrieval.class);
@@ -55,6 +57,7 @@ public class VertexAiRagRetrieval extends BaseRetrievalTool {
   private final String parent;
   private final List<RagResource> ragResources;
   private final Double vectorDistanceThreshold;
+  private final Integer similarityTopK;
   private final VertexRagStore vertexRagStore;
   private final RetrieveContextsRequest.VertexRagStore apiVertexRagStore;
 
@@ -65,11 +68,30 @@ public class VertexAiRagRetrieval extends BaseRetrievalTool {
       String parent,
       @Nullable List<RagResource> ragResources,
       @Nullable Double vectorDistanceThreshold) {
+    this(
+        name,
+        description,
+        vertexRagServiceClient,
+        parent,
+        ragResources,
+        vectorDistanceThreshold,
+        null);
+  }
+
+  public VertexAiRagRetrieval(
+      String name,
+      String description,
+      VertexRagServiceClient vertexRagServiceClient,
+      String parent,
+      @Nullable List<RagResource> ragResources,
+      @Nullable Double vectorDistanceThreshold,
+      @Nullable Integer similarityTopK) {
     super(name, description);
     this.vertexRagServiceClient = vertexRagServiceClient;
     this.parent = parent;
     this.ragResources = ragResources;
     this.vectorDistanceThreshold = vectorDistanceThreshold;
+    this.similarityTopK = similarityTopK;
 
     // For Gemini 2
     VertexRagStore.Builder vertexRagStoreBuilder = VertexRagStore.builder();
@@ -85,6 +107,9 @@ public class VertexAiRagRetrieval extends BaseRetrievalTool {
     }
     if (this.vectorDistanceThreshold != null) {
       vertexRagStoreBuilder.vectorDistanceThreshold(this.vectorDistanceThreshold);
+    }
+    if (this.similarityTopK != null) {
+      vertexRagStoreBuilder.similarityTopK(this.similarityTopK);
     }
     this.vertexRagStore = vertexRagStoreBuilder.build();
 
@@ -135,10 +160,18 @@ public class VertexAiRagRetrieval extends BaseRetrievalTool {
     return Single.fromCallable(
         () -> {
           logger.info("Retrieving context for query: {}", query);
+
+          RagQuery.Builder queryBuilder = RagQuery.newBuilder().setText(query);
+
+          if (similarityTopK != null) {
+            queryBuilder.setRagRetrievalConfig(
+                RagRetrievalConfig.newBuilder().setTopK(similarityTopK).build());
+          }
+
           RetrieveContextsRequest retrieveContextsRequest =
               RetrieveContextsRequest.newBuilder()
                   .setParent(this.parent)
-                  .setQuery(RagQuery.newBuilder().setText(query))
+                  .setQuery(queryBuilder.build())
                   .setVertexRagStore(this.apiVertexRagStore)
                   .build();
           logger.info("Request to VertexRagService: {}", retrieveContextsRequest);

--- a/core/src/test/java/com/google/adk/tools/retrieval/VertexAiRagRetrievalTest.java
+++ b/core/src/test/java/com/google/adk/tools/retrieval/VertexAiRagRetrievalTest.java
@@ -29,6 +29,7 @@ import com.google.adk.sessions.Session;
 import com.google.adk.tools.ToolContext;
 import com.google.cloud.aiplatform.v1.RagContexts;
 import com.google.cloud.aiplatform.v1.RagQuery;
+import com.google.cloud.aiplatform.v1.RagRetrievalConfig;
 import com.google.cloud.aiplatform.v1.RetrieveContextsRequest;
 import com.google.cloud.aiplatform.v1.RetrieveContextsRequest.VertexRagStore.RagResource;
 import com.google.cloud.aiplatform.v1.RetrieveContextsResponse;
@@ -72,6 +73,7 @@ public final class VertexAiRagRetrievalTest {
     ImmutableList<RagResource> ragResources =
         ImmutableList.of(RagResource.newBuilder().setRagCorpus("corpus1").build());
     Double vectorDistanceThreshold = 0.5;
+    Integer similarityTopK = 10;
     VertexAiRagRetrieval tool =
         new VertexAiRagRetrieval(
             "testTool",
@@ -79,13 +81,18 @@ public final class VertexAiRagRetrievalTest {
             vertexRagServiceClient,
             "projects/test-project/locations/us-central1",
             ragResources,
-            vectorDistanceThreshold);
+            vectorDistanceThreshold,
+            similarityTopK);
     String query = "test query";
     ToolContext toolContext = buildToolContext();
     RetrieveContextsRequest expectedRequest =
         RetrieveContextsRequest.newBuilder()
             .setParent("projects/test-project/locations/us-central1")
-            .setQuery(RagQuery.newBuilder().setText(query))
+            .setQuery(
+                RagQuery.newBuilder()
+                    .setText(query)
+                    .setRagRetrievalConfig(
+                        RagRetrievalConfig.newBuilder().setTopK(similarityTopK).build()))
             .setVertexRagStore(
                 com.google.cloud.aiplatform.v1.RetrieveContextsRequest.VertexRagStore.newBuilder()
                     .addAllRagResources(ragResources)
@@ -112,6 +119,7 @@ public final class VertexAiRagRetrievalTest {
     ImmutableList<RagResource> ragResources =
         ImmutableList.of(RagResource.newBuilder().setRagCorpus("corpus1").build());
     Double vectorDistanceThreshold = 0.5;
+    Integer similarityTopK = 10;
     VertexAiRagRetrieval tool =
         new VertexAiRagRetrieval(
             "testTool",
@@ -119,13 +127,18 @@ public final class VertexAiRagRetrievalTest {
             vertexRagServiceClient,
             "projects/test-project/locations/us-central1",
             ragResources,
-            vectorDistanceThreshold);
+            vectorDistanceThreshold,
+            similarityTopK);
     String query = "test query";
     ToolContext toolContext = buildToolContext();
     RetrieveContextsRequest expectedRequest =
         RetrieveContextsRequest.newBuilder()
             .setParent("projects/test-project/locations/us-central1")
-            .setQuery(RagQuery.newBuilder().setText(query))
+            .setQuery(
+                RagQuery.newBuilder()
+                    .setText(query)
+                    .setRagRetrievalConfig(
+                        RagRetrievalConfig.newBuilder().setTopK(similarityTopK).build()))
             .setVertexRagStore(
                 com.google.cloud.aiplatform.v1.RetrieveContextsRequest.VertexRagStore.newBuilder()
                     .addAllRagResources(ragResources)
@@ -154,6 +167,7 @@ public final class VertexAiRagRetrievalTest {
     ImmutableList<RagResource> ragResources =
         ImmutableList.of(RagResource.newBuilder().setRagCorpus("corpus1").build());
     Double vectorDistanceThreshold = 0.5;
+    Integer similarityTopK = 10;
     VertexAiRagRetrieval tool =
         new VertexAiRagRetrieval(
             "testTool",
@@ -161,7 +175,8 @@ public final class VertexAiRagRetrievalTest {
             vertexRagServiceClient,
             "projects/test-project/locations/us-central1",
             ragResources,
-            vectorDistanceThreshold);
+            vectorDistanceThreshold,
+            similarityTopK);
     LlmRequest.Builder llmRequestBuilder = LlmRequest.builder().model("gemini-2-pro");
     ToolContext toolContext = buildToolContext();
 
@@ -181,7 +196,72 @@ public final class VertexAiRagRetrievalTest {
                                           VertexRagStoreRagResource.builder()
                                               .ragCorpus("corpus1")
                                               .build()))
-                                  .vectorDistanceThreshold(0.5)
+                                  .vectorDistanceThreshold(vectorDistanceThreshold)
+                                  .similarityTopK(similarityTopK)
+                                  .build())
+                          .build())
+                  .build());
+    } else {
+      // Assert that the function declaration is added instead
+      assertThat(llmRequestBuilder.build().config().get().tools().get())
+          .containsExactly(
+              Tool.builder()
+                  .functionDeclarations(
+                      ImmutableList.of(
+                          FunctionDeclaration.builder()
+                              .name("testTool")
+                              .description("test description")
+                              .parameters(
+                                  Schema.builder()
+                                      .properties(
+                                          ImmutableMap.of(
+                                              "query",
+                                              Schema.builder()
+                                                  .description("The query to retrieve.")
+                                                  .type("STRING")
+                                                  .build()))
+                                      .type("OBJECT")
+                                      .build())
+                              .build()))
+                  .build());
+    }
+  }
+
+  @Test
+  public void processLlmRequest_gemini2Model_withoutSimilarityTopK_addVertexRagStoreToConfig() {
+    // This test's behavior depends on the GOOGLE_GENAI_USE_VERTEXAI environment variable
+    boolean useVertexAi = Boolean.parseBoolean(System.getenv("GOOGLE_GENAI_USE_VERTEXAI"));
+    ImmutableList<RagResource> ragResources =
+        ImmutableList.of(RagResource.newBuilder().setRagCorpus("corpus1").build());
+    Double vectorDistanceThreshold = 0.5;
+    VertexAiRagRetrieval tool =
+        new VertexAiRagRetrieval(
+            "testTool",
+            "test description",
+            vertexRagServiceClient,
+            "projects/test-project/locations/us-central1",
+            ragResources,
+            vectorDistanceThreshold);
+    LlmRequest.Builder llmRequestBuilder = LlmRequest.builder().model("gemini-2-pro");
+    ToolContext toolContext = buildToolContext();
+
+    tool.processLlmRequest(llmRequestBuilder, toolContext).blockingAwait();
+
+    if (useVertexAi) {
+      // Assert that VertexRagStore is added to the config without similarityTopK
+      assertThat(llmRequestBuilder.build().config().get().tools().get())
+          .containsExactly(
+              Tool.builder()
+                  .retrieval(
+                      Retrieval.builder()
+                          .vertexRagStore(
+                              VertexRagStore.builder()
+                                  .ragResources(
+                                      ImmutableList.of(
+                                          VertexRagStoreRagResource.builder()
+                                              .ragCorpus("corpus1")
+                                              .build()))
+                                  .vectorDistanceThreshold(vectorDistanceThreshold)
                                   .build())
                           .build())
                   .build());
@@ -216,6 +296,7 @@ public final class VertexAiRagRetrievalTest {
     ImmutableList<RagResource> ragResources =
         ImmutableList.of(RagResource.newBuilder().setRagCorpus("corpus1").build());
     Double vectorDistanceThreshold = 0.5;
+    Integer similarityTopK = 10;
     VertexAiRagRetrieval tool =
         new VertexAiRagRetrieval(
             "testTool",
@@ -223,7 +304,8 @@ public final class VertexAiRagRetrievalTest {
             vertexRagServiceClient,
             "projects/test-project/locations/us-central1",
             ragResources,
-            vectorDistanceThreshold);
+            vectorDistanceThreshold,
+            similarityTopK);
     LlmRequest.Builder llmRequestBuilder = LlmRequest.builder().model("other-model");
     ToolContext toolContext = buildToolContext();
     GenerateContentConfig initialConfig = GenerateContentConfig.builder().build();


### PR DESCRIPTION
### Link to Issue or Description of Change

**Problem:**

Add support for the similarity top-K parameter in the `VertexAiRagRetrieval` tool

**Solution:**

New `similarityTopK` constructor parameter in the constructor of the `VertexAiRagRetrieval` class.

The similarity top-K is then added to the LLM request, when the model is a Gemini one and when the `GOOGLE_GENAI_USE_VERTEXAI` env var is enabled. Otherwise, the similarity top-K parameter is transmitted to the `retrieveContexts` method.

### Testing Plan

Updates of the `VertexAiRagRetrievalTest` unit test.

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

```
[INFO] +-- com.google.adk.tools.retrieval.VertexAiRagRetrievalTest
[INFO] | +-- [OK] processLlmRequest_otherModel_doNotAddVertexRagStoreToConfig - 1.298 ss
[INFO] | +-- [OK] processLlmRequest_gemini2Model_addVertexRagStoreToConfig - 0.006 ss

...

[INFO] +-- com.google.adk.tools.retrieval.VertexAiRagRetrievalTest
[INFO] | +-- [OK] processLlmRequest_otherModel_doNotAddVertexRagStoreToConfig - 0.084 ss
[INFO] | +-- [OK] processLlmRequest_gemini2Model_addVertexRagStoreToConfig - 0.001 ss
[INFO] | +-- [OK] runAsync_withResults_returnsContexts - 0.190 ss
[INFO] | +-- [OK] runAsync_noResults_returnsNoResultFoundMessage - 0.003 ss
[INFO] | +-- [OK] processLlmRequest_gemini2Model_withoutSimilarityTopK_addVertexRagStoreToConfig - 0 ss
```

**Manual End-to-End (E2E) Tests:**

- Use the tool new parameter in a production agent.
- Check both code branches based on the `GOOGLE_GENAI_USE_VERTEXAI` env var.
- Count retrieved chunks from the RAG corpus. The number of chunks must match the configured similarity top-K


### Checklist

- [x] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md) document.
- [x] My pull request contains a single commit.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [x] Any dependent changes have been merged and published in downstream modules.

### Additional context

N/A
