### PR TITLE
fix: support typed responseSchema in ChatCompletionsRequest

### DIFF
--- a/core/src/main/java/com/google/adk/models/chat/ChatCompletionsRequest.java
+++ b/core/src/main/java/com/google/adk/models/chat/ChatCompletionsRequest.java
@@ -575,6 +575,16 @@ public final class ChatCompletionsRequest {
       schema.strict = true;
       format.jsonSchema = schema;
       request.responseFormat = format;
+    } else if (config.responseSchema().isPresent()) {
+      ResponseFormatJsonSchema format = new ResponseFormatJsonSchema();
+      ResponseFormatJsonSchema.JsonSchema schema = new ResponseFormatJsonSchema.JsonSchema();
+      schema.name = "response_schema";
+      schema.schema =
+          objectMapper.convertValue(
+              config.responseSchema().get(), new TypeReference<Map<String, Object>>() {});
+      schema.strict = true;
+      format.jsonSchema = schema;
+      request.responseFormat = format;
     } else if (config.responseMimeType().isPresent()
         && config.responseMimeType().get().equals("application/json")) {
       request.responseFormat = new ResponseFormatJsonObject();

--- a/core/src/test/java/com/google/adk/models/chat/ChatCompletionsRequestTest.java
+++ b/core/src/test/java/com/google/adk/models/chat/ChatCompletionsRequestTest.java
@@ -758,6 +758,73 @@ public final class ChatCompletionsRequestTest {
         .isInstanceOf(ChatCompletionsRequest.ResponseFormatJsonObject.class);
   }
 
+  @Test
+  public void testFromLlmRequest_withTypedResponseSchema() throws Exception {
+    Schema outputSchema =
+        Schema.builder()
+            .type("OBJECT")
+            .properties(
+                ImmutableMap.of(
+                    "rootCause", Schema.builder().type("STRING").build(),
+                    "confidence", Schema.builder().type("NUMBER").build()))
+            .required(ImmutableList.of("rootCause", "confidence"))
+            .build();
+
+    LlmRequest llmRequest =
+        LlmRequest.builder()
+            .model("openai-compatible-model")
+            .outputSchema(outputSchema)
+            .contents(ImmutableList.of())
+            .build();
+
+    ChatCompletionsRequest request = ChatCompletionsRequest.fromLlmRequest(llmRequest, false);
+
+    assertThat(request.responseFormat)
+        .isInstanceOf(ChatCompletionsRequest.ResponseFormatJsonSchema.class);
+    ChatCompletionsRequest.ResponseFormatJsonSchema format =
+        (ChatCompletionsRequest.ResponseFormatJsonSchema) request.responseFormat;
+    assertThat(format.jsonSchema.name).isEqualTo("response_schema");
+    assertThat(format.jsonSchema.strict).isTrue();
+    assertThat(format.jsonSchema.schema).isNotNull();
+    assertThat(format.jsonSchema.schema.get("type")).isEqualTo("object");
+    @SuppressWarnings("unchecked")
+    Map<String, Object> props = (Map<String, Object>) format.jsonSchema.schema.get("properties");
+    @SuppressWarnings("unchecked")
+    Map<String, Object> rootCause = (Map<String, Object>) props.get("rootCause");
+    assertThat(rootCause.get("type")).isEqualTo("string");
+    @SuppressWarnings("unchecked")
+    Map<String, Object> confidence = (Map<String, Object>) props.get("confidence");
+    assertThat(confidence.get("type")).isEqualTo("number");
+    assertThat(format.jsonSchema.schema.get("required"))
+        .isEqualTo(ImmutableList.of("rootCause", "confidence"));
+  }
+
+  @Test
+  public void testFromLlmRequest_withRawResponseJsonSchemaPrecedenceOverTypedSchema()
+      throws Exception {
+    Schema typedSchema = Schema.builder().type("OBJECT").build();
+    ImmutableMap<String, Object> rawSchema = ImmutableMap.of("type", "object", "title", "raw");
+
+    LlmRequest llmRequest =
+        LlmRequest.builder()
+            .model("openai-compatible-model")
+            .config(
+                GenerateContentConfig.builder()
+                    .responseSchema(typedSchema)
+                    .responseJsonSchema(rawSchema)
+                    .build())
+            .contents(ImmutableList.of())
+            .build();
+
+    ChatCompletionsRequest request = ChatCompletionsRequest.fromLlmRequest(llmRequest, false);
+
+    assertThat(request.responseFormat)
+        .isInstanceOf(ChatCompletionsRequest.ResponseFormatJsonSchema.class);
+    ChatCompletionsRequest.ResponseFormatJsonSchema format =
+        (ChatCompletionsRequest.ResponseFormatJsonSchema) request.responseFormat;
+    assertThat(format.jsonSchema.schema).isEqualTo(rawSchema);
+  }
+
   // ----- thought_signature round-trip on the request side ----------------------------------
   //
   // The four chat source files share a single contract for round-tripping Gemini's


### PR DESCRIPTION
**Please ensure you have read the [contribution guide](./CONTRIBUTING.md) before creating a pull request.**

### Link to Issue or Description of Change

**Link to an existing issue (if applicable):**

- Closes: #1444

**Problem:**
When setting an output schema via LlmRequest.Builder.outputSchema(Schema) or LlmAgent.outputSchema(Schema), the schema is stored in GenerateContentConfig.responseSchema with responseMimeType = "application/json". In ChatCompletionsRequest.handleConfigOptions(...), only config.responseJsonSchema() was checked. Because responseJsonSchema is empty when using typed schemas, ChatCompletionsRequest fell back to responseMimeType.equals("application/json") and downgraded the request's response_format to {"type": "json_object"}. As a result, the defined schema was ignored and dropped from the OpenAI-compatible /chat/completions request.

**Solution:**
- Added a check in ChatCompletionsRequest.handleConfigOptions(...) for config.responseSchema().isPresent() when config.responseJsonSchema() is absent.
- Serialized the typed Schema into an OpenAI-compatible ResponseFormatJsonSchema ({"type": "json_schema", "json_schema": {"name": "response_schema", "strict": true, "schema": ...}}) using objectMapper.convertValue(...).
- Retained precedence for explicitly provided raw schemas (config.responseJsonSchema()).

### Testing Plan

_Please describe the tests that you ran to verify your changes. This is required
for all PRs that are not small documentation or typo fixes._

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.


**Manual End-to-End (E2E) Tests:**

Built and verified a reproduction test harness that creates an LlmRequest with an outputSchema(Schema), converts it via ChatCompletionsRequest.fromLlmRequest(request, false), and serializes it with Jackson:
Before Fix: Serialized output emitted {"type": "json_object"} without the schema.
After Fix: Serialized output emits {"type": "json_schema", "json_schema": {...}} preserving all defined fields (rootCause, confidence) and strict: true.

### Checklist

- [x] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md) document.
- [x] My pull request contains a single commit.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [x] Any dependent changes have been merged and published in downstream modules.

