### PR TITLE
fix(artifacts): honor the "user:" namespace in InMemoryArtifactService

### DIFF
--- a/core/src/main/java/com/google/adk/artifacts/InMemoryArtifactService.java
+++ b/core/src/main/java/com/google/adk/artifacts/InMemoryArtifactService.java
@@ -81,7 +81,7 @@ public final class InMemoryArtifactService implements BaseArtifactService {
       String appName, String userId, String sessionId, String filename, @Nullable Integer version) {
     List<Part> versions =
         getArtifactsMap(appName, userId, sessionId, filename)
-            .computeIfAbsent(filename, unused -> new ArrayList<>());
+            .getOrDefault(filename, ImmutableList.of());
 
     if (versions.isEmpty()) {
       return Maybe.empty();
@@ -113,7 +113,7 @@ public final class InMemoryArtifactService implements BaseArtifactService {
     filenames.addAll(
         getArtifactsMapForSessionKey(appName, userId, USER_NAMESPACE_SESSION_KEY).keySet());
     return Single.just(
-        ListArtifactsResponse.builder().filenames(ImmutableList.copyOf(filenames)).build());
+        ListArtifactsResponse.builder().filenames(ImmutableList.sortedCopyOf(filenames)).build());
   }
 
   /**
@@ -138,7 +138,7 @@ public final class InMemoryArtifactService implements BaseArtifactService {
       String appName, String userId, String sessionId, String filename) {
     int size =
         getArtifactsMap(appName, userId, sessionId, filename)
-            .computeIfAbsent(filename, unused -> new ArrayList<>())
+            .getOrDefault(filename, ImmutableList.of())
             .size();
     if (size == 0) {
       return Single.just(ImmutableList.of());

--- a/core/src/main/java/com/google/adk/artifacts/InMemoryArtifactService.java
+++ b/core/src/main/java/com/google/adk/artifacts/InMemoryArtifactService.java
@@ -26,17 +26,34 @@ import io.reactivex.rxjava3.core.Maybe;
 import io.reactivex.rxjava3.core.Single;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.IntStream;
 import org.jspecify.annotations.Nullable;
 
 /** An in-memory implementation of the {@link BaseArtifactService}. */
 public final class InMemoryArtifactService implements BaseArtifactService {
+  // Mirrors the "user" path segment GcsArtifactService.getBlobPrefix uses for user-namespaced
+  // filenames: a stand-in session key so those artifacts are stored and looked up independently
+  // of whatever sessionId happened to be current when they were saved.
+  private static final String USER_NAMESPACE_SESSION_KEY = "user";
+
   private final Map<String, Map<String, Map<String, Map<String, List<Part>>>>> artifacts;
 
   public InMemoryArtifactService() {
     this.artifacts = new HashMap<>();
+  }
+
+  /**
+   * Checks if a filename uses the user namespace.
+   *
+   * @param filename Filename to check.
+   * @return true if prefixed with "user:", false otherwise.
+   */
+  private boolean fileHasUserNamespace(String filename) {
+    return filename != null && filename.startsWith("user:");
   }
 
   /**
@@ -48,7 +65,7 @@ public final class InMemoryArtifactService implements BaseArtifactService {
   public Single<Integer> saveArtifact(
       String appName, String userId, String sessionId, String filename, Part artifact) {
     List<Part> versions =
-        getArtifactsMap(appName, userId, sessionId)
+        getArtifactsMap(appName, userId, sessionId, filename)
             .computeIfAbsent(filename, unused -> new ArrayList<>());
     versions.add(artifact);
     return Single.just(versions.size() - 1);
@@ -63,7 +80,7 @@ public final class InMemoryArtifactService implements BaseArtifactService {
   public Maybe<Part> loadArtifact(
       String appName, String userId, String sessionId, String filename, @Nullable Integer version) {
     List<Part> versions =
-        getArtifactsMap(appName, userId, sessionId)
+        getArtifactsMap(appName, userId, sessionId, filename)
             .computeIfAbsent(filename, unused -> new ArrayList<>());
 
     if (versions.isEmpty()) {
@@ -88,10 +105,15 @@ public final class InMemoryArtifactService implements BaseArtifactService {
   @Override
   public Single<ListArtifactsResponse> listArtifactKeys(
       String appName, String userId, String sessionId) {
+    Set<String> filenames = new HashSet<>();
+    // Session-scoped filenames, keyed by the actual sessionId.
+    filenames.addAll(getArtifactsMapForSessionKey(appName, userId, sessionId).keySet());
+    // User-namespaced filenames live under the shared USER_NAMESPACE_SESSION_KEY bucket
+    // regardless of sessionId, mirroring GcsArtifactService's merged session+user listing.
+    filenames.addAll(
+        getArtifactsMapForSessionKey(appName, userId, USER_NAMESPACE_SESSION_KEY).keySet());
     return Single.just(
-        ListArtifactsResponse.builder()
-            .filenames(ImmutableList.copyOf(getArtifactsMap(appName, userId, sessionId).keySet()))
-            .build());
+        ListArtifactsResponse.builder().filenames(ImmutableList.copyOf(filenames)).build());
   }
 
   /**
@@ -102,7 +124,7 @@ public final class InMemoryArtifactService implements BaseArtifactService {
   @Override
   public Completable deleteArtifact(
       String appName, String userId, String sessionId, String filename) {
-    getArtifactsMap(appName, userId, sessionId).remove(filename);
+    getArtifactsMap(appName, userId, sessionId, filename).remove(filename);
     return Completable.complete();
   }
 
@@ -115,7 +137,7 @@ public final class InMemoryArtifactService implements BaseArtifactService {
   public Single<ImmutableList<Integer>> listVersions(
       String appName, String userId, String sessionId, String filename) {
     int size =
-        getArtifactsMap(appName, userId, sessionId)
+        getArtifactsMap(appName, userId, sessionId, filename)
             .computeIfAbsent(filename, unused -> new ArrayList<>())
             .size();
     if (size == 0) {
@@ -131,10 +153,22 @@ public final class InMemoryArtifactService implements BaseArtifactService {
         .flatMap(version -> loadArtifact(appName, userId, sessionId, filename, version).toSingle());
   }
 
-  private Map<String, List<Part>> getArtifactsMap(String appName, String userId, String sessionId) {
+  /**
+   * Resolves the artifacts map for a filename, routing user-namespaced filenames to the shared
+   * {@link #USER_NAMESPACE_SESSION_KEY} bucket instead of the given session, so they are visible
+   * across all of a user's sessions exactly as {@link GcsArtifactService} stores them.
+   */
+  private Map<String, List<Part>> getArtifactsMap(
+      String appName, String userId, String sessionId, String filename) {
+    String sessionKey = fileHasUserNamespace(filename) ? USER_NAMESPACE_SESSION_KEY : sessionId;
+    return getArtifactsMapForSessionKey(appName, userId, sessionKey);
+  }
+
+  private Map<String, List<Part>> getArtifactsMapForSessionKey(
+      String appName, String userId, String sessionKey) {
     return artifacts
         .computeIfAbsent(appName, unused -> new HashMap<>())
         .computeIfAbsent(userId, unused -> new HashMap<>())
-        .computeIfAbsent(sessionId, unused -> new HashMap<>());
+        .computeIfAbsent(sessionKey, unused -> new HashMap<>());
   }
 }

--- a/core/src/test/java/com/google/adk/artifacts/InMemoryArtifactServiceTest.java
+++ b/core/src/test/java/com/google/adk/artifacts/InMemoryArtifactServiceTest.java
@@ -154,6 +154,19 @@ public class InMemoryArtifactServiceTest {
     assertThat(resultFromOriginalSession).isEmpty();
   }
 
+  @Test
+  public void listArtifactKeys_failedUserNamespaceLoad_doesNotCreatePhantomKey() {
+    Optional<Part> missing =
+        asOptional(service.loadArtifact(APP_NAME, USER_ID, SESSION_A, USER_FILENAME));
+
+    assertThat(missing).isEmpty();
+
+    ListArtifactsResponse response =
+        service.listArtifactKeys(APP_NAME, USER_ID, SESSION_B).blockingGet();
+
+    assertThat(response.filenames()).isEmpty();
+  }
+
   private static <T> Optional<T> asOptional(Maybe<T> maybe) {
     return maybe.map(Optional::of).defaultIfEmpty(Optional.empty()).blockingGet();
   }

--- a/core/src/test/java/com/google/adk/artifacts/InMemoryArtifactServiceTest.java
+++ b/core/src/test/java/com/google/adk/artifacts/InMemoryArtifactServiceTest.java
@@ -17,6 +17,7 @@ package com.google.adk.artifacts;
 
 import static com.google.common.truth.Truth.assertThat;
 
+import com.google.common.collect.ImmutableList;
 import com.google.genai.types.Part;
 import io.reactivex.rxjava3.core.Maybe;
 import io.reactivex.rxjava3.core.Single;
@@ -34,6 +35,9 @@ public class InMemoryArtifactServiceTest {
   private static final String USER_ID = "test-user";
   private static final String SESSION_ID = "test-session";
   private static final String FILENAME = "test-file.txt";
+  private static final String USER_FILENAME = "user:config.json";
+  private static final String SESSION_A = "session-A";
+  private static final String SESSION_B = "session-B";
 
   private InMemoryArtifactService service;
 
@@ -70,6 +74,84 @@ public class InMemoryArtifactServiceTest {
         asOptional(
             service.saveAndReloadArtifact(APP_NAME, USER_ID, SESSION_ID, FILENAME, artifact));
     assertThat(result).hasValue(artifact);
+  }
+
+  @Test
+  public void save_userNamespace_visibleAcrossSessions() {
+    // "user:"-prefixed filenames are documented/tested (GcsArtifactServiceTest) as living in a
+    // session-independent namespace: GcsArtifactService.getBlobPrefix special-cases
+    // fileHasUserNamespace(filename) to build "appName/userId/user/filename/" (no sessionId
+    // segment at all). InMemoryArtifactService must mirror that: a "user:" artifact saved in one
+    // session has to be readable from a different session for the same app/user.
+    Part artifact = Part.fromBytes(new byte[] {9, 9, 9}, "application/json");
+
+    var unused =
+        service.saveArtifact(APP_NAME, USER_ID, SESSION_A, USER_FILENAME, artifact).blockingGet();
+
+    Optional<Part> resultFromOtherSession =
+        asOptional(service.loadArtifact(APP_NAME, USER_ID, SESSION_B, USER_FILENAME));
+
+    assertThat(resultFromOtherSession).hasValue(artifact);
+  }
+
+  @Test
+  public void load_nonNamespacedFilename_notVisibleAcrossSessions() {
+    // Regression guard: the user-namespace fix must not make every artifact global. A
+    // non-prefixed filename saved in one session must remain invisible from a different session,
+    // exactly as before the fix.
+    Part artifact = Part.fromBytes(new byte[] {1, 2, 3}, "text/plain");
+
+    var unused =
+        service.saveArtifact(APP_NAME, USER_ID, SESSION_A, FILENAME, artifact).blockingGet();
+
+    Optional<Part> resultFromOtherSession =
+        asOptional(service.loadArtifact(APP_NAME, USER_ID, SESSION_B, FILENAME));
+
+    assertThat(resultFromOtherSession).isEmpty();
+  }
+
+  @Test
+  public void listArtifactKeys_userNamespace_visibleAcrossSessions() {
+    Part artifact = Part.fromBytes(new byte[] {9, 9, 9}, "application/json");
+
+    var unused =
+        service.saveArtifact(APP_NAME, USER_ID, SESSION_A, USER_FILENAME, artifact).blockingGet();
+
+    ListArtifactsResponse response =
+        service.listArtifactKeys(APP_NAME, USER_ID, SESSION_B).blockingGet();
+
+    assertThat(response.filenames()).contains(USER_FILENAME);
+  }
+
+  @Test
+  public void listVersions_userNamespace_visibleAcrossSessions() {
+    Part artifact1 = Part.fromBytes(new byte[] {1}, "application/json");
+    Part artifact2 = Part.fromBytes(new byte[] {1, 2}, "application/json");
+
+    var unused1 =
+        service.saveArtifact(APP_NAME, USER_ID, SESSION_A, USER_FILENAME, artifact1).blockingGet();
+    var unused2 =
+        service.saveArtifact(APP_NAME, USER_ID, SESSION_A, USER_FILENAME, artifact2).blockingGet();
+
+    ImmutableList<Integer> versions =
+        service.listVersions(APP_NAME, USER_ID, SESSION_B, USER_FILENAME).blockingGet();
+
+    assertThat(versions).containsExactly(0, 1).inOrder();
+  }
+
+  @Test
+  public void deleteArtifact_userNamespace_removesAcrossSessions() {
+    Part artifact = Part.fromBytes(new byte[] {9, 9, 9}, "application/json");
+
+    var unused =
+        service.saveArtifact(APP_NAME, USER_ID, SESSION_A, USER_FILENAME, artifact).blockingGet();
+
+    service.deleteArtifact(APP_NAME, USER_ID, SESSION_B, USER_FILENAME).blockingAwait();
+
+    Optional<Part> resultFromOriginalSession =
+        asOptional(service.loadArtifact(APP_NAME, USER_ID, SESSION_A, USER_FILENAME));
+
+    assertThat(resultFromOriginalSession).isEmpty();
   }
 
   private static <T> Optional<T> asOptional(Maybe<T> maybe) {


### PR DESCRIPTION
**Please ensure you have read the [contribution guide](./CONTRIBUTING.md) before creating a pull request.**

### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

None found.

**2. Or, if no issue exists, describe the change:**

**Problem:**

ADK has a `"user:"` filename-prefix convention: a filename starting with `user:` is scoped to the user across all their sessions, not just the session it was saved from.

`GcsArtifactService` implements this. `fileHasUserNamespace(filename)` (GcsArtifactService.java:65) checks the prefix, and `getBlobPrefix` (GcsArtifactService.java:78-84) branches on it to store at `appName/userId/user/filename/version`, deliberately leaving the sessionId segment out. This is exercised directly in `GcsArtifactServiceTest` (`save_userNamespace_savesCorrectly`, `load_userNamespace_loadsCorrectly`).

`InMemoryArtifactService` had no equivalent branch. Its `getArtifactsMap(appName, userId, sessionId)` always keyed by `appName -> userId -> sessionId -> filename`, and every public method (`saveArtifact`, `loadArtifact`, `listArtifactKeys`, `deleteArtifact`, `listVersions`) went through it. So if code called `CallbackContext.saveArtifact("user:config.json", part)` in one session, then `loadArtifact("user:config.json")` in a different session for the same app/user, it got `Maybe.empty()`. No exception, just silently missing data.

This matters because `InMemoryArtifactService` is the default backend used in local dev, tests, and the quickstarts. An app can be written and tested entirely against `InMemoryArtifactService`, rely on the documented cross-session behavior of `user:`-prefixed filenames, and only discover it never worked once it's pointed at `GcsArtifactService` in prod, or never discover it at all if it stays on `InMemoryArtifactService`.

**Solution:**

Mirror the GCS branch. `getArtifactsMap` now also takes the filename, using the same `fileHasUserNamespace` check and naming as `GcsArtifactService`, and routes user-namespaced filenames to a shared per-user bucket (`USER_NAMESPACE_SESSION_KEY`) instead of the caller's `sessionId`. `saveArtifact`, `loadArtifact`, `deleteArtifact`, and `listVersions` all pass the filename through unchanged. `listArtifactKeys` doesn't have a filename to branch on, so it now merges the session-scoped bucket with the shared user-namespace bucket, which is the same thing `GcsArtifactService#listArtifactKeys` does (it merges a session-prefix listing with a user-prefix listing).

No behavior changes for non-`user:`-prefixed filenames. `GcsArtifactService` is untouched.

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

Added to `InMemoryArtifactServiceTest`, mirroring the shape of the `GcsArtifactServiceTest` user-namespace cases:

- `save_userNamespace_visibleAcrossSessions` - save from session A, load from session B, same value comes back.
- `load_nonNamespacedFilename_notVisibleAcrossSessions` - regression guard. A non-prefixed filename saved in session A must still be invisible from session B. This is what proves the fix scopes only the `user:` case instead of making every artifact global.
- `listArtifactKeys_userNamespace_visibleAcrossSessions`
- `listVersions_userNamespace_visibleAcrossSessions`
- `deleteArtifact_userNamespace_removesAcrossSessions`

I ran `InMemoryArtifactServiceTest` against the unpatched source first to confirm these actually catch the bug:

```
Tests run: 8, Failures: 4, Errors: 0, Skipped: 0
InMemoryArtifactServiceTest.save_userNamespace_visibleAcrossSessions - FAILED
InMemoryArtifactServiceTest.listArtifactKeys_userNamespace_visibleAcrossSessions - FAILED
InMemoryArtifactServiceTest.listVersions_userNamespace_visibleAcrossSessions - FAILED
InMemoryArtifactServiceTest.deleteArtifact_userNamespace_removesAcrossSessions - FAILED
```

`load_nonNamespacedFilename_notVisibleAcrossSessions` and the three pre-existing tests passed in both states, as expected.

With the fix applied:

```
mvn -pl core -am test -Dtest=InMemoryArtifactServiceTest
Tests run: 8, Failures: 0, Errors: 0, Skipped: 0
```

Also ran `GcsArtifactServiceTest` to confirm no regression there, since it's untouched:

```
mvn -pl core -am test -Dtest=GcsArtifactServiceTest
Tests run: 24, Failures: 0, Errors: 0, Skipped: 0
```

**Manual End-to-End (E2E) Tests:**

Not applicable, this is contained to `InMemoryArtifactService`'s in-process map and is fully covered by the unit tests above.

### Checklist

- [x] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md) document.
- [x] My pull request contains a single commit.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have manually tested my changes end-to-end.
- [ ] Any dependent changes have been merged and published in downstream modules.

### Additional context

I checked the other two open PRs that touch artifacts, #1378 and #1412. Both are about `Runner`/plugin-level input-blob offload and don't touch `InMemoryArtifactService` or the user-namespace behavior, so there's no overlap with this change.
