### PR TITLE
fix(chat): expose non-success HTTP status via typed exception

### DIFF
--- a/core/src/main/java/com/google/adk/models/chat/ChatCompletionsClient.java
+++ b/core/src/main/java/com/google/adk/models/chat/ChatCompletionsClient.java
@@ -35,6 +35,11 @@ public interface ChatCompletionsClient {
    * messages. This encapsulates building the payload, sending the request to the completions
    * endpoint, and initiating the handling of complete calls.
    *
+   * <p>On a non-2xx HTTP response the returned {@link io.reactivex.rxjava3.core.Flowable} emits a
+   * {@link ChatCompletionsHttpException}; callers can inspect {@link
+   * ChatCompletionsHttpException#statusCode()} without parsing the message text. On a
+   * connection-level failure a plain {@link java.io.IOException} is emitted instead.
+   *
    * @param llmRequest The request containing the model, configuration, and sequence of messages.
    * @param stream Whether to request a streaming response.
    * @return A {@link Flowable} emitting the discrete (or combined) {@link LlmResponse} objects.

--- a/core/src/main/java/com/google/adk/models/chat/ChatCompletionsHttpClient.java
+++ b/core/src/main/java/com/google/adk/models/chat/ChatCompletionsHttpClient.java
@@ -249,11 +249,8 @@ public final class ChatCompletionsHttpClient implements ChatCompletionsClient {
                     if (!response.isSuccessful()) {
                       String bodyStr = body != null ? body.string() : "";
                       emitter.tryOnError(
-                          new IOException(
-                              "HTTP request failed with status: "
-                                  + response
-                                  + " - body: "
-                                  + bodyStr));
+                          new ChatCompletionsHttpException(
+                              response.code(), response.toString(), bodyStr));
                       return;
                     }
                     if (body == null) {
@@ -349,8 +346,7 @@ public final class ChatCompletionsHttpClient implements ChatCompletionsClient {
         if (!response.isSuccessful()) {
           String bodyStr = body != null ? body.string() : "";
           emitter.tryOnError(
-              new IOException(
-                  "HTTP request failed with status: " + response + " - body: " + bodyStr));
+              new ChatCompletionsHttpException(response.code(), response.toString(), bodyStr));
           return;
         }
         if (body == null) {

--- a/core/src/main/java/com/google/adk/models/chat/ChatCompletionsHttpException.java
+++ b/core/src/main/java/com/google/adk/models/chat/ChatCompletionsHttpException.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.adk.models.chat;
+
+import java.io.IOException;
+
+/**
+ * Thrown by {@link ChatCompletionsHttpClient} when the server returns a non-successful HTTP status
+ * code. Extends {@link IOException} so existing {@code catch (IOException)} call sites continue to
+ * work without modification. Callers that need to branch on the HTTP status (e.g. to apply bounded
+ * retry/backoff on 429) can catch this subtype and call {@link #statusCode()} directly, without
+ * parsing {@link Throwable#getMessage()}.
+ */
+public final class ChatCompletionsHttpException extends IOException {
+  private final int statusCode;
+  private final String responseBody;
+
+  public ChatCompletionsHttpException(int statusCode, String message, String responseBody) {
+    super("HTTP request failed with status: " + message + " - body: " + responseBody);
+    this.statusCode = statusCode;
+    this.responseBody = responseBody;
+  }
+
+  public int statusCode() {
+    return statusCode;
+  }
+
+  public String responseBody() {
+    return responseBody;
+  }
+}

--- a/core/src/test/java/com/google/adk/models/chat/ChatCompletionsHttpClientTest.java
+++ b/core/src/test/java/com/google/adk/models/chat/ChatCompletionsHttpClientTest.java
@@ -36,11 +36,14 @@ import com.google.genai.types.FinishReason;
 import com.google.genai.types.FunctionCall;
 import com.google.genai.types.HttpOptions;
 import com.google.genai.types.Part;
+import io.reactivex.rxjava3.core.Flowable;
 import io.reactivex.rxjava3.subscribers.TestSubscriber;
 import java.io.IOException;
 import java.lang.reflect.Field;
 import java.time.Duration;
 import java.util.Base64;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicReference;
 import okhttp3.Call;
 import okhttp3.Callback;
 import okhttp3.MediaType;
@@ -124,6 +127,26 @@ public final class ChatCompletionsHttpClientTest {
         .model("gpt-4")
         .contents(ImmutableList.of(Content.builder().parts(Part.fromText("hello")).build()))
         .build();
+  }
+
+  private Throwable captureError(
+      Flowable<LlmResponse> flowable,
+      ArgumentCaptor<Callback> callbackCaptor,
+      Response mockResponse)
+      throws InterruptedException, IOException {
+    AtomicReference<Throwable> errorRef = new AtomicReference<>();
+    CountDownLatch latch = new CountDownLatch(1);
+    var unused =
+        flowable.subscribe(
+            resp -> {},
+            err -> {
+              errorRef.set(err);
+              latch.countDown();
+            },
+            latch::countDown);
+    callbackCaptor.getValue().onResponse(mockCall, mockResponse);
+    latch.await(AWAIT_TIMEOUT.toMillis(), MILLISECONDS);
+    return errorRef.get();
   }
 
   @Test
@@ -351,16 +374,14 @@ public final class ChatCompletionsHttpClientTest {
     ArgumentCaptor<Callback> callbackCaptor = ArgumentCaptor.forClass(Callback.class);
     doNothing().when(mockCall).enqueue(callbackCaptor.capture());
 
-    TestSubscriber<LlmResponse> testSubscriber = client.complete(minimalRequest(), false).test();
+    Throwable error =
+        captureError(client.complete(minimalRequest(), false), callbackCaptor, mockResponse);
 
-    callbackCaptor.getValue().onResponse(mockCall, mockResponse);
-    testSubscriber.await(AWAIT_TIMEOUT.toMillis(), MILLISECONDS);
-
-    testSubscriber.assertError(
-        e ->
-            e instanceof IOException
-                && e.getMessage().contains("HTTP request failed with status:")
-                && e.getMessage().contains("server exploded"));
+    assertThat(error).isInstanceOf(ChatCompletionsHttpException.class);
+    ChatCompletionsHttpException exception = (ChatCompletionsHttpException) error;
+    assertThat(exception.getMessage()).contains("HTTP request failed with status:");
+    assertThat(exception.getMessage()).contains("server exploded");
+    assertThat(exception.responseBody()).contains("server exploded");
   }
 
   /**
@@ -391,6 +412,101 @@ public final class ChatCompletionsHttpClientTest {
 
     testSubscriber.assertNoValues();
     testSubscriber.assertError(Throwable.class);
+  }
+
+  @Test
+  public void complete_nonStreaming_429_emitsTypedExceptionWithStatusCode() throws Exception {
+    Response mockResponse =
+        createMockResponse("{\"error\":\"rate limited\"}", JSON, 429, "Too Many Requests");
+
+    ArgumentCaptor<Callback> callbackCaptor = ArgumentCaptor.forClass(Callback.class);
+    doNothing().when(mockCall).enqueue(callbackCaptor.capture());
+
+    Throwable error =
+        captureError(client.complete(minimalRequest(), false), callbackCaptor, mockResponse);
+
+    assertThat(error).isInstanceOf(ChatCompletionsHttpException.class);
+    ChatCompletionsHttpException exception = (ChatCompletionsHttpException) error;
+    assertThat(exception.statusCode()).isEqualTo(429);
+    assertThat(exception.responseBody()).contains("rate limited");
+  }
+
+  @Test
+  public void complete_nonStreaming_401_emitsSameTypeWithDistinctStatusCode() throws Exception {
+    Response mockResponse =
+        createMockResponse("{\"error\":\"unauthorized\"}", JSON, 401, "Unauthorized");
+
+    ArgumentCaptor<Callback> callbackCaptor = ArgumentCaptor.forClass(Callback.class);
+    doNothing().when(mockCall).enqueue(callbackCaptor.capture());
+
+    Throwable error =
+        captureError(client.complete(minimalRequest(), false), callbackCaptor, mockResponse);
+
+    assertThat(error).isInstanceOf(ChatCompletionsHttpException.class);
+    ChatCompletionsHttpException exception = (ChatCompletionsHttpException) error;
+    assertThat(exception.statusCode()).isEqualTo(401);
+  }
+
+  @Test
+  public void complete_streaming_429_emitsTypedExceptionWithStatusCode() throws Exception {
+    Response mockResponse =
+        createMockResponse("{\"error\":\"rate limited\"}", JSON, 429, "Too Many Requests");
+
+    ArgumentCaptor<Callback> callbackCaptor = ArgumentCaptor.forClass(Callback.class);
+    doNothing().when(mockCall).enqueue(callbackCaptor.capture());
+
+    Throwable error =
+        captureError(client.complete(minimalRequest(), true), callbackCaptor, mockResponse);
+
+    assertThat(error).isInstanceOf(ChatCompletionsHttpException.class);
+    assertThat(((ChatCompletionsHttpException) error).statusCode()).isEqualTo(429);
+  }
+
+  @Test
+  public void complete_nonStreaming_connectionFailure_remainsPlainIOException() throws Exception {
+    ArgumentCaptor<Callback> callbackCaptor = ArgumentCaptor.forClass(Callback.class);
+    doNothing().when(mockCall).enqueue(callbackCaptor.capture());
+
+    AtomicReference<Throwable> errorRef = new AtomicReference<>();
+    CountDownLatch latch = new CountDownLatch(1);
+    var unused =
+        client
+            .complete(minimalRequest(), false)
+            .subscribe(
+                resp -> {},
+                err -> {
+                  errorRef.set(err);
+                  latch.countDown();
+                },
+                latch::countDown);
+
+    callbackCaptor.getValue().onFailure(mockCall, new IOException("Connection reset"));
+    latch.await(AWAIT_TIMEOUT.toMillis(), MILLISECONDS);
+
+    Throwable error = errorRef.get();
+    assertThat(error).isInstanceOf(IOException.class);
+    assertThat(error).isNotInstanceOf(ChatCompletionsHttpException.class);
+  }
+
+  @Test
+  public void complete_nonStreaming_bodyContainingCodeText_doesNotAffectExposedStatus()
+      throws Exception {
+    Response mockResponse =
+        createMockResponse(
+            "{\"error\":{\"code\":429,\"message\":\"unrelated\"}}",
+            JSON,
+            500,
+            "Internal Server Error");
+
+    ArgumentCaptor<Callback> callbackCaptor = ArgumentCaptor.forClass(Callback.class);
+    doNothing().when(mockCall).enqueue(callbackCaptor.capture());
+
+    Throwable error =
+        captureError(client.complete(minimalRequest(), false), callbackCaptor, mockResponse);
+
+    ChatCompletionsHttpException exception = (ChatCompletionsHttpException) error;
+    assertThat(exception.statusCode()).isEqualTo(500);
+    assertThat(exception.responseBody()).contains("\"code\":429");
   }
 
   /**


### PR DESCRIPTION
### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**
- Closes: #1451

**2. Or, if no issue exists, describe the change:**

**Problem:**
`ChatCompletionsHttpClient` wraps every non-successful HTTP response (both streaming and non-streaming) in a plain `IOException` whose message embeds OkHttp's `Response#toString()` and the raw body. Callers can't inspect the HTTP status programmatically and must regex-parse `getMessage()`, which breaks if OkHttp's format changes.

**Solution:**
Added `ChatCompletionsHttpException` (extends `IOException`, so existing `catch (IOException)` code is unaffected) exposing `statusCode()` and `responseBody()`. Both the streaming and non-streaming callback paths now surface this typed exception for non-2xx HTTP responses. Connection-level failures (no HTTP response at all) still surface as plain `IOException`, since there's no status code to report.

### Testing Plan

**Unit Tests:**
- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

Added 6 tests to `ChatCompletionsHttpClientTest`: 429/401 non-streaming typed status, streaming parity, connection failures remain plain `IOException`, response body text containing `"code":429` doesn't spoof the real status, and existing message/body content is preserved on the typed exception.

Full `core` module suite result (`./mvnw -pl core -am test`):
Tests run: 1781, Failures: 0, Errors: 0, Skipped: 24 — BUILD SUCCESS

**Manual End-to-End (E2E) Tests:**
Reproduced the original bug with a real local HTTP server (`com.sun.net.httpserver.HttpServer`) returning 429, confirmed before the fix the client only exposed `java.io.IOException` with the status buried in the message text. After the fix, the same request throws `ChatCompletionsHttpException` with `statusCode() == 429` directly accessible, no message parsing required.

### Checklist
- [x] I have read the [[CONTRIBUTING.md](https://claude.ai/chat/CONTRIBUTING.md)](./CONTRIBUTING.md) document.
- [x] My pull request contains a single commit.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [x] Any dependent changes have been merged and published in downstream modules.

### Additional context
This request does not implement retry/backoff logic; it only preserves the HTTP status as machine-readable metadata so callers can implement their own retry policy against `statusCode()` instead of parsing `Response.toString()`.