### PR TITLE
fix(web): make root->dev-ui redirect reverse-proxy-prefix-aware

### DIFF
--- a/dev/src/main/java/com/google/adk/web/AdkWebServer.java
+++ b/dev/src/main/java/com/google/adk/web/AdkWebServer.java
@@ -143,12 +143,15 @@ public class AdkWebServer implements WebMvcConfigurer {
   }
 
   /**
-   * Configures simple automated controllers: - Redirects the root path "/" to "/dev-ui". - Forwards
-   * requests to "/dev-ui" to "/dev-ui/index.html" so the ResourceHandler serves it.
+   * Configures simple automated controllers: - Redirects the root path "/" to "dev-ui" (context-
+   * relative, not "/dev-ui", so it stays reverse-proxy-prefix-aware when this app runs behind a
+   * proxy that strips a path prefix and forwards it via server.forward-headers-strategy /
+   * X-Forwarded-Prefix). - Forwards requests to "/dev-ui" to "/dev-ui/index.html" so the
+   * ResourceHandler serves it.
    */
   @Override
   public void addViewControllers(ViewControllerRegistry registry) {
-    registry.addRedirectViewController("/", "/dev-ui");
+    registry.addRedirectViewController("/", "dev-ui");
     registry.addViewController("/dev-ui").setViewName("forward:/index.html");
     registry.addViewController("/dev-ui/").setViewName("forward:/index.html");
   }

--- a/dev/src/test/java/com/google/adk/web/AdkWebServerReverseProxyTest.java
+++ b/dev/src/test/java/com/google/adk/web/AdkWebServerReverseProxyTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.adk.web;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrl;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrlPattern;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.test.web.servlet.MockMvc;
+
+/**
+ * Verifies that the root ("/") -> "dev-ui" redirect (see {@link AdkWebServer#addViewControllers})
+ * is reverse-proxy-prefix-aware once Spring's ForwardedHeaderFilter is enabled via {@code
+ * server.forward-headers-strategy=framework}.
+ *
+ * <p>This is a regression test for the redirect target being context-relative ("dev-ui") rather
+ * than root-relative ("/dev-ui"): only a context-relative sendRedirect() target is passed through
+ * {@link org.springframework.util.StringUtils#applyRelativePath}, which is what makes {@code
+ * ForwardedHeaderFilter} splice an {@code X-Forwarded-Prefix} header's value back into the redirect
+ * Location. A root-relative target bypasses that codepath entirely and would leave this test's
+ * "with X-Forwarded-Prefix" case failing.
+ *
+ * <p>Uses a dedicated test class (rather than adding to {@link AdkWebServerUITest}) because {@code
+ * server.forward-headers-strategy} is a server-wide property, kept separate here so enabling it
+ * doesn't affect the default context {@link AdkWebServerUITest} runs against.
+ */
+@SpringBootTest(properties = "server.forward-headers-strategy=framework")
+@AutoConfigureMockMvc
+public class AdkWebServerReverseProxyTest {
+
+  @Autowired private MockMvc mockMvc;
+
+  /**
+   * With no Forwarded/X-Forwarded-* headers on the request, Spring's ForwardedHeaderFilter doesn't
+   * wrap the response at all (verified by running this test), so behavior matches the property
+   * being off entirely: the redirect is the raw, unresolved "dev-ui" string.
+   */
+  @Test
+  public void rootRedirect_withoutForwardedHeaders_isUnchanged() throws Exception {
+    mockMvc
+        .perform(get("/"))
+        .andExpect(status().is3xxRedirection())
+        .andExpect(redirectedUrl("dev-ui"));
+  }
+
+  @Test
+  public void rootRedirect_withForwardedPrefixHeader_restoresPathPrefix() throws Exception {
+    mockMvc
+        .perform(get("/").header("X-Forwarded-Prefix", "/my-app-prefix"))
+        .andExpect(status().is3xxRedirection())
+        .andExpect(redirectedUrlPattern("http://*/my-app-prefix/dev-ui"));
+  }
+}

--- a/dev/src/test/java/com/google/adk/web/AdkWebServerUITest.java
+++ b/dev/src/test/java/com/google/adk/web/AdkWebServerUITest.java
@@ -45,7 +45,7 @@ public class AdkWebServerUITest {
     mockMvc
         .perform(get("/"))
         .andExpect(status().is3xxRedirection())
-        .andExpect(redirectedUrl("/dev-ui"));
+        .andExpect(redirectedUrl("dev-ui"));
   }
 
   @ParameterizedTest


### PR DESCRIPTION
Fixes #1457

## Summary

`AdkWebServer.addViewControllers()` redirects `"/"` to the root-relative path `"/dev-ui"`. Root-relative `sendRedirect()` targets are left untouched by Spring's own reverse-proxy support (`ForwardedHeaderFilter` only applies `X-Forwarded-Prefix` to context-relative targets, via `StringUtils.applyRelativePath`, which it skips whenever the target already starts with `/`). So when this app is deployed behind a path-stripping reverse proxy, the browser follows an unprefixed `Location` header the proxy has no route for, and the dev UI 404s.

This PR makes the redirect context-relative (`"dev-ui"`) instead, so `server.forward-headers-strategy=framework` + an `X-Forwarded-Prefix` header from the proxy can correctly restore the prefix.

## Behavior for the non-proxied/local case

No change: `RedirectView`'s `contextRelative` handling only prepends the context path when the target starts with `/` (so a context-relative target is passed through as-is), and the servlet container's own relative-URL resolution for `sendRedirect` still resolves `"dev-ui"` against the current request path `"/"` to `"/dev-ui"`.

## Test plan

Added `AdkWebServerReverseProxyTest`, covering both cases with `server.forward-headers-strategy=framework` enabled:
- Without any forwarded headers: redirect is unchanged (`"dev-ui"`) — confirmed `ForwardedHeaderFilter` doesn't wrap the response at all when the request carries no `Forwarded`/`X-Forwarded-*` headers, so this matches the property being off entirely.
- With `X-Forwarded-Prefix: /my-app-prefix`: redirect becomes `http://.../my-app-prefix/dev-ui`, confirming the fix.

Also updated `AdkWebServerUITest.rootShouldRedirectToDevUi` to expect the new context-relative value (`MockHttpServletResponse.sendRedirect` stores the location verbatim with no resolution, so this assertion needed to change from `"/dev-ui"` to `"dev-ui"`).

Verified locally end-to-end (JDK 17, as required by this repo):
```
mvn -pl dev -am test
```
→ `BUILD SUCCESS`, 1776 core tests + all `dev` module tests (including the new and updated ones) pass, 0 failures.

`mvn compile` was also run to confirm `google-java-format` is happy with the new file (auto-formatted cleanly, no manual formatting issues found).