### PR TITLE
fix: honor the user: namespace convention in InMemoryArtifactService

### DIFF
--- a/core/src/main/java/com/google/adk/artifacts/InMemoryArtifactService.java
+++ b/core/src/main/java/com/google/adk/artifacts/InMemoryArtifactService.java
@@ -33,10 +33,34 @@ import org.jspecify.annotations.Nullable;
 
 /** An in-memory implementation of the {@link BaseArtifactService}. */
 public final class InMemoryArtifactService implements BaseArtifactService {
-  private final Map<String, Map<String, Map<String, Map<String, List<Part>>>>> artifacts;
+  private final Map<String, List<Part>> artifacts;
 
   public InMemoryArtifactService() {
     this.artifacts = new HashMap<>();
+  }
+
+  /**
+   * Checks if a filename uses the user namespace.
+   *
+   * @param filename Filename to check.
+   * @return true if prefixed with "user:", false otherwise.
+   */
+  private static boolean fileHasUserNamespace(String filename) {
+    return filename != null && filename.startsWith("user:");
+  }
+
+  /**
+   * Builds the storage key for an artifact.
+   *
+   * <p>A "user:"-prefixed filename is stored under a session-independent, user-scoped key so it is
+   * visible from every session for that user, matching {@link GcsArtifactService} and adk-python's
+   * {@code InMemoryArtifactService}. Any other filename is scoped to the given session, as before.
+   */
+  private static String artifactKey(
+      String appName, String userId, String sessionId, String filename) {
+    return fileHasUserNamespace(filename)
+        ? String.format("%s/%s/user/%s", appName, userId, filename)
+        : String.format("%s/%s/%s/%s", appName, userId, sessionId, filename);
   }
 
   /**
@@ -48,8 +72,8 @@ public final class InMemoryArtifactService implements BaseArtifactService {
   public Single<Integer> saveArtifact(
       String appName, String userId, String sessionId, String filename, Part artifact) {
     List<Part> versions =
-        getArtifactsMap(appName, userId, sessionId)
-            .computeIfAbsent(filename, unused -> new ArrayList<>());
+        artifacts.computeIfAbsent(
+            artifactKey(appName, userId, sessionId, filename), unused -> new ArrayList<>());
     versions.add(artifact);
     return Single.just(versions.size() - 1);
   }
@@ -63,8 +87,7 @@ public final class InMemoryArtifactService implements BaseArtifactService {
   public Maybe<Part> loadArtifact(
       String appName, String userId, String sessionId, String filename, @Nullable Integer version) {
     List<Part> versions =
-        getArtifactsMap(appName, userId, sessionId)
-            .computeIfAbsent(filename, unused -> new ArrayList<>());
+        artifacts.getOrDefault(artifactKey(appName, userId, sessionId, filename), List.of());
 
     if (versions.isEmpty()) {
       return Maybe.empty();
@@ -81,17 +104,25 @@ public final class InMemoryArtifactService implements BaseArtifactService {
   }
 
   /**
-   * Lists filenames of stored artifacts for the session.
+   * Lists filenames of stored artifacts for the session, including every "user:"-namespaced
+   * artifact for the user regardless of which session saved it.
    *
    * @return Single with list of artifact filenames.
    */
   @Override
   public Single<ListArtifactsResponse> listArtifactKeys(
       String appName, String userId, String sessionId) {
-    return Single.just(
-        ListArtifactsResponse.builder()
-            .filenames(ImmutableList.copyOf(getArtifactsMap(appName, userId, sessionId).keySet()))
-            .build());
+    String sessionPrefix = String.format("%s/%s/%s/", appName, userId, sessionId);
+    String userPrefix = String.format("%s/%s/user/", appName, userId);
+    List<String> filenames = new ArrayList<>();
+    for (String key : artifacts.keySet()) {
+      if (key.startsWith(sessionPrefix)) {
+        filenames.add(key.substring(sessionPrefix.length()));
+      } else if (key.startsWith(userPrefix)) {
+        filenames.add(key.substring(userPrefix.length()));
+      }
+    }
+    return Single.just(ListArtifactsResponse.builder().filenames(filenames).build());
   }
 
   /**
@@ -102,7 +133,7 @@ public final class InMemoryArtifactService implements BaseArtifactService {
   @Override
   public Completable deleteArtifact(
       String appName, String userId, String sessionId, String filename) {
-    getArtifactsMap(appName, userId, sessionId).remove(filename);
+    artifacts.remove(artifactKey(appName, userId, sessionId, filename));
     return Completable.complete();
   }
 
@@ -115,9 +146,7 @@ public final class InMemoryArtifactService implements BaseArtifactService {
   public Single<ImmutableList<Integer>> listVersions(
       String appName, String userId, String sessionId, String filename) {
     int size =
-        getArtifactsMap(appName, userId, sessionId)
-            .computeIfAbsent(filename, unused -> new ArrayList<>())
-            .size();
+        artifacts.getOrDefault(artifactKey(appName, userId, sessionId, filename), List.of()).size();
     if (size == 0) {
       return Single.just(ImmutableList.of());
     }
@@ -129,12 +158,5 @@ public final class InMemoryArtifactService implements BaseArtifactService {
       String appName, String userId, String sessionId, String filename, Part artifact) {
     return saveArtifact(appName, userId, sessionId, filename, artifact)
         .flatMap(version -> loadArtifact(appName, userId, sessionId, filename, version).toSingle());
-  }
-
-  private Map<String, List<Part>> getArtifactsMap(String appName, String userId, String sessionId) {
-    return artifacts
-        .computeIfAbsent(appName, unused -> new HashMap<>())
-        .computeIfAbsent(userId, unused -> new HashMap<>())
-        .computeIfAbsent(sessionId, unused -> new HashMap<>());
   }
 }

--- a/core/src/test/java/com/google/adk/artifacts/InMemoryArtifactServiceTest.java
+++ b/core/src/test/java/com/google/adk/artifacts/InMemoryArtifactServiceTest.java
@@ -72,6 +72,53 @@ public class InMemoryArtifactServiceTest {
     assertThat(result).hasValue(artifact);
   }
 
+  @Test
+  public void loadArtifact_userNamespacedFile_visibleFromDifferentSession() {
+    String userFilename = "user:profile.txt";
+    Part artifact = Part.fromBytes(new byte[] {1, 2, 3}, "text/plain");
+    var unused =
+        service.saveArtifact(APP_NAME, USER_ID, "session-a", userFilename, artifact).blockingGet();
+
+    Optional<Part> result =
+        asOptional(service.loadArtifact(APP_NAME, USER_ID, "session-b", userFilename));
+
+    assertThat(result).hasValue(artifact);
+  }
+
+  @Test
+  public void listArtifactKeys_includesUserNamespacedFilesFromOtherSessions() {
+    String userFilename = "user:profile.txt";
+    Part userArtifact = Part.fromBytes(new byte[] {1}, "text/plain");
+    Part sessionArtifact = Part.fromBytes(new byte[] {2}, "text/plain");
+    var unused1 =
+        service
+            .saveArtifact(APP_NAME, USER_ID, "session-a", userFilename, userArtifact)
+            .blockingGet();
+    var unused2 =
+        service
+            .saveArtifact(APP_NAME, USER_ID, "session-b", FILENAME, sessionArtifact)
+            .blockingGet();
+
+    ListArtifactsResponse response =
+        service.listArtifactKeys(APP_NAME, USER_ID, "session-b").blockingGet();
+
+    assertThat(response.filenames()).containsExactly(userFilename, FILENAME);
+  }
+
+  @Test
+  public void deleteArtifact_userNamespacedFile_removesFromEverySession() {
+    String userFilename = "user:profile.txt";
+    Part artifact = Part.fromBytes(new byte[] {1, 2, 3}, "text/plain");
+    var unused =
+        service.saveArtifact(APP_NAME, USER_ID, "session-a", userFilename, artifact).blockingGet();
+
+    service.deleteArtifact(APP_NAME, USER_ID, "session-b", userFilename).blockingAwait();
+
+    Optional<Part> result =
+        asOptional(service.loadArtifact(APP_NAME, USER_ID, "session-a", userFilename));
+    assertThat(result).isEmpty();
+  }
+
   private static <T> Optional<T> asOptional(Maybe<T> maybe) {
     return maybe.map(Optional::of).defaultIfEmpty(Optional.empty()).blockingGet();
   }


### PR DESCRIPTION
### What is the purpose of the change

`InMemoryArtifactService` keys every artifact strictly by `(appName, userId, sessionId, filename)`, so a `user:`-prefixed filename is silently scoped to the session that saved it instead of being visible from every session for that user. Both other implementations of `BaseArtifactService` already special-case this prefix:

- `GcsArtifactService.getBlobPrefix()` stores `user:`-prefixed filenames under `appName/userId/user/filename/...`, independent of `sessionId`.
- adk-python's `InMemoryArtifactService._artifact_path()` does the same (`{app_name}/{user_id}/user/{filename}`), and its `list_artifact_keys` unions the session-scoped and user-namespaced prefixes.

Any app relying on the in-memory service (the default for tests, samples, and quick local runs) for cross-session, per-user artifacts silently loses that data the moment a new session starts, with no error — the call just succeeds against the wrong (empty) scope.

Fixes #1460.

### Brief change log

- `InMemoryArtifactService.java`: replace the 4-level nested `Map<String, Map<String, Map<String, Map<String, List<Part>>>>>` (keyed unconditionally by session) with a flat `Map<String, List<Part>>` keyed by a computed path string, mirroring `GcsArtifactService`'s blob-prefix scheme. A `user:`-prefixed filename now maps to `appName/userId/user/filename`, independent of `sessionId`; every other filename keeps the existing `appName/userId/sessionId/filename` scoping. `listArtifactKeys` now unions the session-scoped and user-namespaced prefixes, the same way `GcsArtifactService.listArtifactKeys` unions its two GCS prefixes.
- `InMemoryArtifactServiceTest.java`: three regression tests — a `user:`-namespaced artifact is visible from a different session, appears in `listArtifactKeys` for a different session, and is removed everywhere by `deleteArtifact`.

### Tests

- Added the three regression tests above; confirmed they fail against the pre-fix code (`git stash` the source change, keep the tests) and pass with the fix.
- `mvn -pl core -am test`: 1779 tests, only 1 pre-existing failure (`LocalSkillSourceTest.testListResources`, a Windows path-separator (`\` vs `/`) issue unrelated to this change — reproduces identically on `main` without this diff).

### Are these changes tested?

Yes, see above.

### Are there any user-facing changes?

Yes: `InMemoryArtifactService` now honors the `user:` filename namespace convention documented and implemented by `GcsArtifactService` and adk-python. Existing session-scoped artifacts (any filename not starting with `user:`) are unaffected.

### Was this PR generated with the help of a generative AI tool?

Yes.

Generated-by: AI coding assistant
