### PR TITLE
Preserve complete successful MCP tool results

### DIFF
--- a/core/src/main/java/com/google/adk/tools/mcp/AbstractMcpTool.java
+++ b/core/src/main/java/com/google/adk/tools/mcp/AbstractMcpTool.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.adk.tools.BaseTool;
 import com.google.adk.tools.mcp.McpToolException.McpToolDeclarationException;
 import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.genai.types.FunctionDeclaration;
 import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
@@ -31,6 +32,7 @@ import io.modelcontextprotocol.spec.McpSchema.TextContent;
 import io.modelcontextprotocol.spec.McpSchema.Tool;
 import io.modelcontextprotocol.spec.McpSchema.ToolAnnotations;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -145,11 +147,14 @@ public abstract class AbstractMcpTool<T> extends BaseTool {
     }
 
     if (textOutputs.isEmpty()) {
-      return ImmutableMap.of(
-          "error",
-          "Tool '" + mcpToolName + "' returned content that is not TextContent.",
-          "content_details",
-          contents.toString());
+      Map<String, Object> result = new HashMap<>();
+      result.put("text_output", ImmutableList.of());
+      result.put("content", contents);
+      result.put("isError", Boolean.FALSE);
+      if (callResult.structuredContent() != null) {
+        result.put("structuredContent", callResult.structuredContent());
+      }
+      return result;
     }
 
     List<Map<String, Object>> resultMaps = new ArrayList<>();
@@ -161,6 +166,13 @@ public abstract class AbstractMcpTool<T> extends BaseTool {
         resultMaps.add(ImmutableMap.of("text", textOutput));
       }
     }
-    return ImmutableMap.of("text_output", resultMaps);
+    Map<String, Object> result = new HashMap<>();
+    result.put("text_output", resultMaps);
+    result.put("content", contents);
+    result.put("isError", Boolean.FALSE);
+    if (callResult.structuredContent() != null) {
+      result.put("structuredContent", callResult.structuredContent());
+    }
+    return result;
   }
 }

--- a/core/src/test/java/com/google/adk/tools/mcp/AbstractMcpToolTest.java
+++ b/core/src/test/java/com/google/adk/tools/mcp/AbstractMcpToolTest.java
@@ -25,6 +25,7 @@ import com.google.common.collect.ImmutableList;
 import io.modelcontextprotocol.client.McpSyncClient;
 import io.modelcontextprotocol.spec.McpSchema;
 import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
+import io.modelcontextprotocol.spec.McpSchema.ImageContent;
 import io.modelcontextprotocol.spec.McpSchema.TextContent;
 import java.util.List;
 import java.util.Map;
@@ -59,6 +60,43 @@ public final class AbstractMcpToolTest {
 
     Map<?, ?> contentItem = (Map<?, ?>) content.get(0);
     assertThat(contentItem).containsEntry("text", "success");
+  }
+
+  @Test
+  public void testWrapCallResult_preservesCompleteSuccessfulResult() {
+    Map<String, Object> structuredContent = Map.of("count", 2);
+    CallToolResult result =
+        CallToolResult.builder()
+            .content(
+                ImmutableList.of(
+                    new TextContent("first"),
+                    new ImageContent("aW1hZ2U=", "image/png")))
+            .structuredContent(structuredContent)
+            .isError(false)
+            .build();
+
+    Map<String, Object> map = AbstractMcpTool.wrapCallResult(objectMapper, "my_tool", result);
+
+    assertThat(map).containsEntry("isError", false);
+    assertThat(map).containsEntry("structuredContent", structuredContent);
+    assertThat((List<?>) map.get("content")).hasSize(2);
+    assertThat(map).containsKey("text_output");
+  }
+
+  @Test
+  public void testWrapCallResult_preservesSuccessfulNonTextResult() {
+    CallToolResult result =
+        CallToolResult.builder()
+            .content(ImmutableList.of(new ImageContent("aW1hZ2U=", "image/png")))
+            .isError(false)
+            .build();
+
+    Map<String, Object> map = AbstractMcpTool.wrapCallResult(objectMapper, "my_tool", result);
+
+    assertThat(map).containsEntry("isError", false);
+    assertThat((List<?>) map.get("content")).hasSize(1);
+    assertThat((List<?>) map.get("text_output")).isEmpty();
+    assertThat(map).doesNotContainKey("error");
   }
 
   @Test


### PR DESCRIPTION
## Summary / Problem

Fixes #1443. Successful MCP tool calls currently reduce the result to `text_output`, silently dropping structured content, non-text content, and the explicit error state.

## Changes

- Preserve the original ordered `content` list, `structuredContent`, and `isError` on successful results.
- Keep the existing `text_output` field unchanged for backward compatibility.
- Preserve successful results that contain only non-text content instead of converting them to an error.
- Add focused regression tests for mixed and non-text MCP results.

## Tests

- `git diff --check` — passed.
- `docker run --rm -v "$PWD:/workspace" -w /workspace maven:3.9.11-eclipse-temurin-17 mvn -B -pl core -Dtest=AbstractMcpToolTest -DfailIfNoTests=true test` — not completed: the container reached Maven Central, but dependency downloads did not finish within the local execution window.

## Compatibility / Known limitations

The existing `text_output` response shape remains available. The additional fields are additive. Local Maven compilation and tests remain to be confirmed by CI because dependency resolution did not finish locally, even in the project-compatible Maven 3.9/Java 17 container.

Issue: https://github.com/google/adk-java/issues/1443
