### PR TITLE
fix(memory): guard parts without text in searchMemory

### DIFF
--- a/core/src/main/java/com/google/adk/memory/InMemoryMemoryService.java
+++ b/core/src/main/java/com/google/adk/memory/InMemoryMemoryService.java
@@ -20,7 +20,6 @@ import static com.google.common.collect.ImmutableList.toImmutableList;
 
 import com.google.adk.events.Event;
 import com.google.adk.sessions.Session;
-import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.genai.types.Part;
@@ -105,8 +104,9 @@ public final class InMemoryMemoryService implements BaseMemoryService {
 
               Set<String> wordsInEvent = new HashSet<>();
               for (Part part : event.content().get().parts().get()) {
-                if (!Strings.isNullOrEmpty(part.text().get())) {
-                  Matcher matcher = WORD_PATTERN.matcher(part.text().get());
+                String text = part.text().orElse("");
+                if (!text.isEmpty()) {
+                  Matcher matcher = WORD_PATTERN.matcher(text);
                   while (matcher.find()) {
                     wordsInEvent.add(matcher.group().toLowerCase(Locale.ROOT));
                   }

--- a/core/src/test/java/com/google/adk/memory/InMemoryMemoryServiceTest.java
+++ b/core/src/test/java/com/google/adk/memory/InMemoryMemoryServiceTest.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.adk.memory;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.adk.events.Event;
+import com.google.adk.sessions.Session;
+import com.google.common.collect.ImmutableList;
+import com.google.genai.types.Content;
+import com.google.genai.types.FileData;
+import com.google.genai.types.FunctionCall;
+import com.google.genai.types.FunctionResponse;
+import com.google.genai.types.Part;
+import java.util.Map;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Tests for {@link InMemoryMemoryService}. */
+@RunWith(JUnit4.class)
+public final class InMemoryMemoryServiceTest {
+
+  private static final String APP_NAME = "app";
+  private static final String USER_ID = "user";
+
+  private static Event event(Part... parts) {
+    return Event.builder().author("agent").content(Content.fromParts(parts)).build();
+  }
+
+  private static Session sessionWith(Event... events) {
+    return Session.builder("session")
+        .appName(APP_NAME)
+        .userId(USER_ID)
+        .events(ImmutableList.copyOf(events))
+        .build();
+  }
+
+  @Test
+  public void searchMemory_functionCallPart_skipsPartInsteadOfThrowing() {
+    Part functionCall =
+        Part.builder().functionCall(FunctionCall.builder().name("loadMemory").build()).build();
+    InMemoryMemoryService service = new InMemoryMemoryService();
+    service
+        .addSessionToMemory(
+            sessionWith(event(Part.fromText("weather in Seoul")), event(functionCall)))
+        .blockingAwait();
+
+    SearchMemoryResponse response =
+        service.searchMemory(APP_NAME, USER_ID, "weather").blockingGet();
+
+    assertThat(response.memories()).hasSize(1);
+  }
+
+  @Test
+  public void searchMemory_functionResponsePart_skipsPartInsteadOfThrowing() {
+    Part functionResponse =
+        Part.builder()
+            .functionResponse(
+                FunctionResponse.builder()
+                    .name("loadMemory")
+                    .response(Map.of("result", "ok"))
+                    .build())
+            .build();
+    InMemoryMemoryService service = new InMemoryMemoryService();
+    service.addSessionToMemory(sessionWith(event(functionResponse))).blockingAwait();
+
+    SearchMemoryResponse response =
+        service.searchMemory(APP_NAME, USER_ID, "weather").blockingGet();
+
+    assertThat(response.memories()).isEmpty();
+  }
+
+  @Test
+  public void searchMemory_inlineDataPart_skipsPartInsteadOfThrowing() {
+    Part inlineData = Part.fromBytes(new byte[] {1, 2, 3}, "image/png");
+    InMemoryMemoryService service = new InMemoryMemoryService();
+    service
+        .addSessionToMemory(
+            sessionWith(event(Part.fromText("weather in Seoul")), event(inlineData)))
+        .blockingAwait();
+
+    SearchMemoryResponse response =
+        service.searchMemory(APP_NAME, USER_ID, "weather").blockingGet();
+
+    assertThat(response.memories()).hasSize(1);
+  }
+
+  @Test
+  public void searchMemory_fileDataPart_skipsPartInsteadOfThrowing() {
+    Part fileData =
+        Part.builder()
+            .fileData(
+                FileData.builder()
+                    .mimeType("application/pdf")
+                    .fileUri("gs://bucket/file.pdf")
+                    .build())
+            .build();
+    InMemoryMemoryService service = new InMemoryMemoryService();
+    service
+        .addSessionToMemory(sessionWith(event(Part.fromText("weather in Seoul")), event(fileData)))
+        .blockingAwait();
+
+    SearchMemoryResponse response =
+        service.searchMemory(APP_NAME, USER_ID, "weather").blockingGet();
+
+    assertThat(response.memories()).hasSize(1);
+  }
+
+  @Test
+  public void searchMemory_textAndFunctionCallInOneEvent_stillMatchesOnTheText() {
+    Part functionCall =
+        Part.builder().functionCall(FunctionCall.builder().name("loadMemory").build()).build();
+    InMemoryMemoryService service = new InMemoryMemoryService();
+    service
+        .addSessionToMemory(sessionWith(event(Part.fromText("weather in Seoul"), functionCall)))
+        .blockingAwait();
+
+    SearchMemoryResponse response =
+        service.searchMemory(APP_NAME, USER_ID, "weather").blockingGet();
+
+    assertThat(response.memories()).hasSize(1);
+    assertThat(response.memories().get(0).content())
+        .isEqualTo(Content.fromParts(Part.fromText("weather in Seoul"), functionCall));
+  }
+}


### PR DESCRIPTION
### Link to Issue or Description of Change

- Closes: #1464

**Problem:**

`InMemoryMemoryService.searchMemory` calls `part.text().get()` before checking that the `Optional` holds a value. `Part.text()` is empty for `functionCall`, `functionResponse`, `inlineData` and `fileData` parts, so the call throws `NoSuchElementException` and the whole search fails.

`addSessionToMemory` stores those events — it only drops events whose `parts` list is empty. `searchMemory` scans every session stored under the same app and user, so one tool call in any one session breaks every later search for that app and user, whatever the query. Reachable from an agent through `LoadMemoryTool` → `ToolContext.searchMemory`.

**Solution:**

Read the text through `orElse("")` and keep the existing empty-text check, so a part without text is skipped exactly like a part whose text is blank.

```java
String text = part.text().orElse("");
if (!text.isEmpty()) {
  Matcher matcher = WORD_PATTERN.matcher(text);
```

Every other `part.text()` read in `core` already guards with `isPresent()`, `filter` or `orElse` — `LlmEventSummarizer` uses `part.text().filter(not(String::isEmpty))` for the same job. This was the one that did not. It also matches adk-python, which filters the same loop on `if part.text`, and adk-go, which skips with `if part.Text == ""`.

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

`InMemoryMemoryService` had no test class. Added five cases, one per part type without text plus a mixed event:

- `searchMemory_functionCallPart_skipsPartInsteadOfThrowing`
- `searchMemory_functionResponsePart_skipsPartInsteadOfThrowing`
- `searchMemory_inlineDataPart_skipsPartInsteadOfThrowing`
- `searchMemory_fileDataPart_skipsPartInsteadOfThrowing`
- `searchMemory_textAndFunctionCallInOneEvent_stillMatchesOnTheText`

All five fail on `main` with the new test class alone:

```
$ ./mvnw -pl core test -Dtest=InMemoryMemoryServiceTest -DfailIfNoTests=false
[ERROR] Tests run: 5, Failures: 0, Errors: 5, Skipped: 0
java.util.NoSuchElementException: No value present
	at java.base/java.util.Optional.get(Optional.java:143)
	at com.google.adk.memory.InMemoryMemoryService.lambda$searchMemory$5(InMemoryMemoryService.java:108)
	at io.reactivex.rxjava3.core.Single.blockingGet(Single.java:3644)
```

With the fix:

```
$ ./mvnw -pl core test -Dtest=InMemoryMemoryServiceTest -DfailIfNoTests=false
[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```

Full `core` suite on this branch, rebased onto `main`:

```
$ ./mvnw -f core/pom.xml test
[WARNING] Tests run: 1794, Failures: 0, Errors: 0, Skipped: 24
[INFO] BUILD SUCCESS
```

**Manual End-to-End (E2E) Tests:**

Ran a driver locally (not part of this PR) modelled on `AgentWithMemoryTest`, but with the agent calling a tool in the first turn: `InMemoryRunner` + `LlmAgent` with a `getWeather` `FunctionTool` and `LoadMemoryTool`, driven by `TestLlm` so the run is deterministic and needs no model credentials. Turn one asks about the weather and the agent uses the tool; the session is saved with `addSessionToMemory`; turn two makes the agent call `load_memory`.

`AgentWithMemoryTest` passes today only because its first turn is text-only. Adding a tool call to that first turn is enough to break it.

On `main`:

```
turn 1 stored 4 events:
  user           text
  weather_agent  functionCall
  weather_agent  functionResponse
  weather_agent  text

[ERROR] MemoryE2eDriverTest.agentUsesToolThenSearchesMemory » NoSuchElement No value present
```

With the fix:

```
turn 1 stored 4 events:
  user           text
  weather_agent  functionCall
  weather_agent  functionResponse
  weather_agent  text

load_memory returned: FunctionResponse{name=loadMemory,
  response={memories=[{content={parts=[{text=what is the weather in Seoul}],
  role=user}, author=user}]}}
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0
```

Any app that saves a tool-using session with `addSessionToMemory` and later lets the agent call `load_memory` hits this today.

This fixes the crash only. `InMemoryMemoryService` has drifted from adk-python in other ways since — result ranking, Unicode-aware word extraction, thread safety — and none of that is in scope here.

### Checklist

- [x] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md) document.
- [x] My pull request contains a single commit.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have manually tested my changes end-to-end.
- [x] Any dependent changes have been merged and published in downstream modules.

### Additional context

Same class of bug as #1279 and #1280. Follows the "Alignment with adk-python" section of CONTRIBUTING.md.

