### PR TITLE
fix(sessions): validate HTTP status before parsing Vertex AI session responses

### DIFF
--- a/core/src/main/java/com/google/adk/sessions/HttpApiResponse.java
+++ b/core/src/main/java/com/google/adk/sessions/HttpApiResponse.java
@@ -35,6 +35,11 @@ public final class HttpApiResponse extends ApiResponse {
     return response.body();
   }
 
+  @Override
+  public int getStatusCode() {
+    return response.code();
+  }
+
   /** Closes the Http response. */
   @Override
   public void close() {

--- a/core/src/main/java/com/google/adk/sessions/VertexAiApiException.java
+++ b/core/src/main/java/com/google/adk/sessions/VertexAiApiException.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.adk.sessions;
+
+/**
+ * Signals a non-2xx, non-404 HTTP status from the Vertex AI Session API. Extends {@link
+ * SessionException} so existing {@code catch (SessionException)} call sites still work.
+ */
+public final class VertexAiApiException extends SessionException {
+  private final int statusCode;
+
+  VertexAiApiException(int statusCode, String responseBody) {
+    super(
+        "Vertex AI Session API request failed with HTTP status "
+            + statusCode
+            + (responseBody == null || responseBody.isEmpty() ? "" : ": " + responseBody));
+    this.statusCode = statusCode;
+  }
+
+  /** Returns the HTTP status code returned by the API. */
+  public int statusCode() {
+    return statusCode;
+  }
+}

--- a/core/src/main/java/com/google/adk/sessions/VertexAiClient.java
+++ b/core/src/main/java/com/google/adk/sessions/VertexAiClient.java
@@ -206,16 +206,29 @@ final class VertexAiClient {
    */
   @Nullable
   private static Maybe<JsonNode> getJsonResponse(ApiResponse apiResponse) {
+    if (apiResponse == null) {
+      return Maybe.empty();
+    }
     try {
-      if (apiResponse == null || apiResponse.getResponseBody() == null) {
+      int statusCode = apiResponse.getStatusCode();
+      String responseString;
+      try {
+        ResponseBody responseBody = apiResponse.getResponseBody();
+        responseString = responseBody == null ? "" : responseBody.string();
+      } catch (IOException e) {
+        return Maybe.error(new UncheckedIOException(e));
+      }
+
+      if (statusCode == 404) {
+        return Maybe.empty();
+      }
+      if (statusCode < 200 || statusCode >= 300) {
+        return Maybe.error(new VertexAiApiException(statusCode, responseString));
+      }
+      if (responseString.isEmpty()) {
         return Maybe.empty();
       }
       try {
-        ResponseBody responseBody = apiResponse.getResponseBody();
-        String responseString = responseBody.string(); // Read body here
-        if (responseString.isEmpty()) {
-          return Maybe.empty();
-        }
         return Maybe.just(objectMapper.readTree(responseString));
       } catch (IOException e) {
         return Maybe.error(new UncheckedIOException(e));

--- a/core/src/test/java/com/google/adk/sessions/ApiResponseTest.java
+++ b/core/src/test/java/com/google/adk/sessions/ApiResponseTest.java
@@ -16,18 +16,30 @@
 
 package com.google.adk.sessions;
 
+import static org.junit.Assert.assertThrows;
+
 import okhttp3.ResponseBody;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 
-/** The API response contains a response to a call to the GenAI APIs. */
-public abstract class ApiResponse implements AutoCloseable {
-  /** Gets the HttpEntity. */
-  public abstract ResponseBody getResponseBody();
+@RunWith(JUnit4.class)
+public final class ApiResponseTest {
 
-  /** Gets the HTTP status code of the response. */
-  public int getStatusCode() {
-    throw new UnsupportedOperationException("getStatusCode() is not implemented.");
+  private static final class SubclassWithoutStatusCodeOverride extends ApiResponse {
+    @Override
+    public ResponseBody getResponseBody() {
+      return null;
+    }
+
+    @Override
+    public void close() {}
   }
 
-  @Override
-  public abstract void close();
+  @Test
+  public void getStatusCode_notOverridden_throwsUnsupportedOperationException() {
+    ApiResponse response = new SubclassWithoutStatusCodeOverride();
+
+    assertThrows(UnsupportedOperationException.class, response::getStatusCode);
+  }
 }

--- a/core/src/test/java/com/google/adk/sessions/MockApiAnswer.java
+++ b/core/src/test/java/com/google/adk/sessions/MockApiAnswer.java
@@ -99,10 +99,19 @@ class MockApiAnswer implements Answer<ApiResponse> {
   }
 
   private static ApiResponse responseWithBody(String body) {
+    return responseWithStatus(200, body);
+  }
+
+  static ApiResponse responseWithStatus(int statusCode, String body) {
     return new ApiResponse() {
       @Override
       public ResponseBody getResponseBody() {
-        return ResponseBody.create(JSON_MEDIA_TYPE, body);
+        return body == null ? null : ResponseBody.create(JSON_MEDIA_TYPE, body);
+      }
+
+      @Override
+      public int getStatusCode() {
+        return statusCode;
       }
 
       @Override
@@ -144,7 +153,7 @@ class MockApiAnswer implements Answer<ApiResponse> {
     if (sessionData != null) {
       return responseWithBody(sessionData);
     } else {
-      throw new RuntimeException("Session not found: " + sessionId);
+      return responseWithStatus(404, "");
     }
   }
 

--- a/core/src/test/java/com/google/adk/sessions/VertexAiSessionServiceTest.java
+++ b/core/src/test/java/com/google/adk/sessions/VertexAiSessionServiceTest.java
@@ -241,15 +241,10 @@ public class VertexAiSessionServiceTest {
   }
 
   @Test
-  public void getEmptySession_success() {
-    RuntimeException exception =
-        assertThrows(
-            RuntimeException.class,
-            () ->
-                vertexAiSessionService
-                    .getSession("123", "user", "0", Optional.empty())
-                    .blockingGet());
-    assertThat(exception).hasMessageThat().contains("Session not found: 0");
+  public void getEmptySession_returnsNull() {
+    Session session =
+        vertexAiSessionService.getSession("123", "user", "0", Optional.empty()).blockingGet();
+    assertThat(session).isNull();
   }
 
   @Test
@@ -258,14 +253,41 @@ public class VertexAiSessionServiceTest {
         vertexAiSessionService.getSession("123", "user", "1", Optional.empty()).blockingGet();
     assertThat(session.toJson()).isEqualTo(getMockSession().toJson());
     vertexAiSessionService.deleteSession("123", "user", "1").blockingAwait();
-    RuntimeException exception =
+    Session sessionAfterDelete =
+        vertexAiSessionService.getSession("123", "user", "1", Optional.empty()).blockingGet();
+    assertThat(sessionAfterDelete).isNull();
+  }
+
+  @Test
+  public void getSession_permissionDenied_propagatesAsError() {
+    when(mockApiClient.request(eq("GET"), eq("reasoningEngines/123/sessions/1"), eq("")))
+        .thenReturn(
+            MockApiAnswer.responseWithStatus(
+                403, "{\"userId\": \"user\", \"error\": \"permission denied\"}"));
+
+    VertexAiApiException exception =
         assertThrows(
-            RuntimeException.class,
+            VertexAiApiException.class,
             () ->
                 vertexAiSessionService
                     .getSession("123", "user", "1", Optional.empty())
                     .blockingGet());
-    assertThat(exception).hasMessageThat().contains("Session not found: 1");
+    assertThat(exception.statusCode()).isEqualTo(403);
+  }
+
+  @Test
+  public void getSession_serverError_propagatesAsError() {
+    when(mockApiClient.request(eq("GET"), eq("reasoningEngines/123/sessions/1"), eq("")))
+        .thenReturn(MockApiAnswer.responseWithStatus(500, "{\"error\": \"internal\"}"));
+
+    VertexAiApiException exception =
+        assertThrows(
+            VertexAiApiException.class,
+            () ->
+                vertexAiSessionService
+                    .getSession("123", "user", "1", Optional.empty())
+                    .blockingGet());
+    assertThat(exception.statusCode()).isEqualTo(500);
   }
 
   @Test


### PR DESCRIPTION
### Link to Issue or Description of Change

**1. Link to an existing issue (if applicable):**

- Closes: #1466

**2. Or, if no issue exists, describe the change:**

**Problem:**
`VertexAiClient.getJsonResponse` never checks the HTTP status of the Vertex AI Session API response. It only checks whether the body is empty. So a non-2xx response with a body (403, 429, 500, etc.) gets parsed exactly like a successful one, and `VertexAiSessionService.getSession` builds a phantom `Session` — with the requested id, empty state, and a null `lastUpdateTime` (serialized as `0.0` by `Session.toJson()`) — instead of surfacing the failure. This is indistinguishable from a real session that happens to have no events, and callers using a get-or-create pattern can silently start a new session mid-conversation on a transient error.

**Solution:**
Added `getStatusCode()` to `ApiResponse`/`HttpApiResponse`, and updated `getJsonResponse` to branch on status before touching the body:
- `404` → treated as a genuine miss, returns empty.
- Any other non-2xx → returns a new `VertexAiApiException(statusCode, body)` instead of parsing.
- `2xx` with an empty body → empty (unchanged).
- `2xx` with a body → parsed and returned (unchanged).

### Testing Plan

**Unit Tests:**

- [x] I have added or updated unit tests for my change.
- [x] All unit tests pass locally.

Summary: `VertexAiSessionServiceTest` — 32 tests, 0 failures. Added `getSession_permissionDenied_propagatesAsError` (403) and `getSession_serverError_propagatesAsError` (500), both asserting a `VertexAiApiException` is thrown instead of a phantom session. Renamed `getEmptySession_success` to `getEmptySession_returnsNull` and updated `getAndDeleteSession_success` to assert a real 404 now correctly returns `null` from `getSession()` rather than throwing a mock-only exception. Also ran the full module test suite (`mvn -pl core -am test`): 1791 tests, 0 failures.

**Manual End-to-End (E2E) Tests:**

Not applicable — this is a transport-layer fix inside `VertexAiSessionService`/`VertexAiClient` with no UI surface, exercised entirely through the unit tests above.

### Checklist

- [x] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md) document.
- [x] My pull request contains a single commit.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have manually tested my changes end-to-end.
- [ ] Any dependent changes have been merged and published in downstream modules.

### Additional context

None.