### PR TITLE
Align Jackson annotations with 2.22

### DIFF
--- a/a2a/pom.xml
+++ b/a2a/pom.xml
@@ -19,6 +19,7 @@
     <a2a.sdk.version>0.3.2.Final</a2a.sdk.version>
     <google.adk.version>${project.version}</google.adk.version>
     <guava.version>33.0.0-jre</guava.version>
+    <jackson.annotations.version>2.22</jackson.annotations.version>
     <jackson.version>2.22.0</jackson.version>
     <jspecify.version>1.0.0</jspecify.version>
     <slf4j.version>2.0.17</slf4j.version>
@@ -44,7 +45,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-annotations</artifactId>
-      <version>${jackson.version}</version>
+      <version>${jackson.annotations.version}</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>


### PR DESCRIPTION
## Summary

Completes the Jackson 2.22 upgrade in [Dependabot PR #1299](https://github.com/google/adk-java/pull/1299).

Jackson Annotations uses the release version `2.22`, while Jackson Databind and Jackson Core use `2.22.0`. Sharing the existing `${jackson.version}` property therefore makes Maven request the unpublished artifact `jackson-annotations:2.22.0`.

## Change

- add a dedicated `jackson.annotations.version` property set to `2.22`
- keep the other Jackson modules on `2.22.0`
- make no Java source or runtime behavior changes

## Verification

- reproduced the exact bot-head failure on `9b7ab1000ba91421b1bbce5bb4790328154b2e87`: Maven could not resolve `com.fasterxml.jackson.core:jackson-annotations:2.22.0`
- `./mvnw -B -ntp -pl a2a test` on Java 21: 93 tests passed
- `./mvnw -B -ntp test` on Java 21: all 21 reactor modules passed; the core suite ran 1,449 tests with 24 skips
- `./mvnw -Prelease clean package` on Java 21: all 21 reactor modules passed
- JAIPilot Remote, Java 17: `./mvnw -B -ntp -pl a2a -am test` passed; core and A2A modules succeeded, including all 93 A2A tests
- the configured formatter processed the A2A sources with zero rewrites; `git diff --check` passed

The repair is a single signed-off commit and changes only `a2a/pom.xml` (two insertions, one deletion).

Built and verified with [JAIPilot](https://github.com/JAIPilot/jaipilot):
- Skills: `jaipilot-maintainer-intent`, `jaipilot-fast-execution`, `jaipilot-review-diff`, and `jaipilot-remote-java`
- Execution profile: `gpt-5.6-sol · xhigh · fast`
