### PR TITLE
fix(runner): default InMemoryRunner appName to match Python SDK

### DIFF
--- a/contrib/spring-ai/src/test/java/com/google/adk/models/springai/SpringAIIntegrationTest.java
+++ b/contrib/spring-ai/src/test/java/com/google/adk/models/springai/SpringAIIntegrationTest.java
@@ -75,7 +75,7 @@ class SpringAIIntegrationTest {
     // when
     Runner runner = new InMemoryRunner(agent);
     Session session =
-        runner.sessionService().createSession(agent.name(), "test-user").blockingGet();
+        runner.sessionService().createSession(runner.appName(), "test-user").blockingGet();
 
     Content userMessage =
         Content.builder().role("user").parts(List.of(Part.fromText("What is a qubit?"))).build();
@@ -152,7 +152,7 @@ class SpringAIIntegrationTest {
     // when
     Runner runner = new InMemoryRunner(agent);
     Session session =
-        runner.sessionService().createSession(agent.name(), "test-user").blockingGet();
+        runner.sessionService().createSession(runner.appName(), "test-user").blockingGet();
 
     Content userMessage =
         Content.builder()
@@ -221,7 +221,7 @@ class SpringAIIntegrationTest {
     // when
     Runner runner = new InMemoryRunner(agent);
     Session session =
-        runner.sessionService().createSession(agent.name(), "test-user").blockingGet();
+        runner.sessionService().createSession(runner.appName(), "test-user").blockingGet();
 
     Content userMessage =
         Content.builder()

--- a/contrib/spring-ai/src/test/java/com/google/adk/models/springai/TestUtils.java
+++ b/contrib/spring-ai/src/test/java/com/google/adk/models/springai/TestUtils.java
@@ -32,7 +32,8 @@ public class TestUtils {
     ArrayList<Event> allEvents = new ArrayList<>();
 
     Runner runner = new InMemoryRunner(agent, agent.name());
-    Session session = runner.sessionService().createSession(agent.name(), "user132").blockingGet();
+    Session session =
+        runner.sessionService().createSession(runner.appName(), "user132").blockingGet();
 
     for (Object message : messages) {
       Content messageContent = null;
@@ -68,7 +69,7 @@ public class TestUtils {
 
     Runner runner = new InMemoryRunner(agent);
     Session session =
-        runner.sessionService().createSession(agent.name(), "test-user").blockingGet();
+        runner.sessionService().createSession(runner.appName(), "test-user").blockingGet();
 
     List<Event> events = new ArrayList<>();
 
@@ -93,7 +94,7 @@ public class TestUtils {
 
     Runner runner = new InMemoryRunner(agent);
     Session session =
-        runner.sessionService().createSession(agent.name(), "test-user").blockingGet();
+        runner.sessionService().createSession(runner.appName(), "test-user").blockingGet();
 
     List<Event> events = new ArrayList<>();
 

--- a/core/src/main/java/com/google/adk/runner/InMemoryRunner.java
+++ b/core/src/main/java/com/google/adk/runner/InMemoryRunner.java
@@ -26,11 +26,10 @@ import java.util.List;
 
 /** The class for the in-memory GenAi runner, using in-memory artifact and session services. */
 public class InMemoryRunner extends Runner {
+  private static final String DEFAULT_APP_NAME = "InMemoryRunner";
 
   public InMemoryRunner(BaseAgent agent) {
-    // TODO: Change the default appName to InMemoryRunner to align with adk python.
-    // Check the dev UI in case we break something there.
-    this(agent, /* appName= */ agent.name(), ImmutableList.of());
+    this(agent, DEFAULT_APP_NAME, ImmutableList.of());
   }
 
   public InMemoryRunner(BaseAgent agent, String appName) {

--- a/core/src/test/java/com/google/adk/agents/AgentWithMemoryTest.java
+++ b/core/src/test/java/com/google/adk/agents/AgentWithMemoryTest.java
@@ -87,7 +87,8 @@ public final class AgentWithMemoryTest {
             .build();
 
     InMemoryRunner runner = new InMemoryRunner(agent);
-    String sessionId = runner.sessionService().createSession(agentName, userId).blockingGet().id();
+    String sessionId =
+        runner.sessionService().createSession(runner.appName(), userId).blockingGet().id();
 
     Content firstMessage = Content.fromParts(Part.fromText("My name is James"));
 
@@ -101,7 +102,7 @@ public final class AgentWithMemoryTest {
     Session updatedSession =
         runner
             .sessionService()
-            .getSession("test_agent", userId, sessionId, Optional.empty())
+            .getSession(runner.appName(), userId, sessionId, Optional.empty())
             .blockingGet();
 
     // Save the updated session to memory so we can bring it up on the next request.

--- a/core/src/test/java/com/google/adk/runner/InMemoryRunnerTest.java
+++ b/core/src/test/java/com/google/adk/runner/InMemoryRunnerTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.adk.runner;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.adk.agents.LlmAgent;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public final class InMemoryRunnerTest {
+
+  @Test
+  public void defaultAppName_isInMemoryRunner() {
+    LlmAgent agent = LlmAgent.builder().name("my_agent").model("gemini-2.0-flash").build();
+    InMemoryRunner runner = new InMemoryRunner(agent);
+    assertThat(runner.appName()).isEqualTo("InMemoryRunner");
+  }
+
+  @Test
+  public void explicitAppName_isPreserved() {
+    LlmAgent agent = LlmAgent.builder().name("my_agent").model("gemini-2.0-flash").build();
+    InMemoryRunner runner = new InMemoryRunner(agent, "custom-app");
+    assertThat(runner.appName()).isEqualTo("custom-app");
+  }
+}


### PR DESCRIPTION
Fixes #1486 

## Summary
- Default `InMemoryRunner(BaseAgent)` appName to `"InMemoryRunner"` instead of `agent.name()`, matching [adk-python](https://github.com/google/adk-python/blob/main/src/google/adk/runners.py).
- Add `InMemoryRunnerTest` and update `AgentWithMemoryTest` to use `runner.appName()`.

## Breaking change (minor)
Callers that relied on implicit `agent.name()` as appName should use `new InMemoryRunner(agent, agent.name())` explicitly.

## Test plan
- [x] `./mvnw -pl core -am test` — BUILD SUCCESS