### PR TITLE
fix(spring-ai): declare ordering for SpringAIAutoConfiguration so @ConditionalOnBean matches Spring AI model beans

### DIFF
--- a/contrib/spring-ai/pom.xml
+++ b/contrib/spring-ai/pom.xml
@@ -137,6 +137,11 @@
             <artifactId>spring-ai-ollama</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.ai</groupId>
+            <artifactId>spring-ai-starter-model-openai</artifactId>
+            <scope>test</scope>
+        </dependency>
 
         <!-- Testcontainers for local testing -->
         <dependency>

--- a/contrib/spring-ai/src/main/java/com/google/adk/models/springai/autoconfigure/SpringAIAutoConfiguration.java
+++ b/contrib/spring-ai/src/main/java/com/google/adk/models/springai/autoconfigure/SpringAIAutoConfiguration.java
@@ -58,7 +58,28 @@ import org.springframework.context.annotation.Primary;
  * adk.spring-ai.validation.enabled=true
  * </pre>
  */
-@AutoConfiguration
+@AutoConfiguration(
+    afterName = {
+      // --- Spring AI 2.0.1 chat model auto-configurations (verified against published jars) ---
+      "org.springframework.ai.model.anthropic.autoconfigure.AnthropicChatAutoConfiguration",
+      "org.springframework.ai.model.bedrock.converse.autoconfigure.BedrockConverseProxyChatAutoConfiguration",
+      "org.springframework.ai.model.deepseek.autoconfigure.DeepSeekChatAutoConfiguration",
+      "org.springframework.ai.model.google.genai.autoconfigure.chat.GoogleGenAiChatAutoConfiguration",
+      "org.springframework.ai.model.mistralai.autoconfigure.MistralAiChatAutoConfiguration",
+      "org.springframework.ai.model.ollama.autoconfigure.OllamaChatAutoConfiguration",
+      "org.springframework.ai.model.openai.autoconfigure.OpenAiChatAutoConfiguration",
+      // --- embedding model auto-configurations (required for springAIEmbedding,
+      //     which silently fails to register without these) ---
+      "org.springframework.ai.model.bedrock.cohere.autoconfigure.BedrockCohereEmbeddingAutoConfiguration",
+      "org.springframework.ai.model.bedrock.titan.autoconfigure.BedrockTitanEmbeddingAutoConfiguration",
+      "org.springframework.ai.model.google.genai.autoconfigure.embedding.GoogleGenAiTextEmbeddingAutoConfiguration",
+      "org.springframework.ai.model.mistralai.autoconfigure.MistralAiEmbeddingAutoConfiguration",
+      "org.springframework.ai.model.ollama.autoconfigure.OllamaEmbeddingAutoConfiguration",
+      "org.springframework.ai.model.openai.autoconfigure.OpenAiEmbeddingAutoConfiguration",
+      "org.springframework.ai.model.postgresml.autoconfigure.PostgresMlEmbeddingAutoConfiguration",
+      "org.springframework.ai.model.transformers.autoconfigure.TransformersEmbeddingModelAutoConfiguration",
+      "org.springframework.ai.model.vertexai.autoconfigure.embedding.VertexAiTextEmbeddingAutoConfiguration"
+    })
 @ConditionalOnClass({SpringAI.class, ChatModel.class})
 @ConditionalOnProperty(
     prefix = "adk.spring-ai.auto-configuration",

--- a/contrib/spring-ai/src/test/java/com/google/adk/models/springai/autoconfigure/SpringAIAutoConfigurationOrderingTest.java
+++ b/contrib/spring-ai/src/test/java/com/google/adk/models/springai/autoconfigure/SpringAIAutoConfigurationOrderingTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.adk.models.springai.autoconfigure;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.ai.model.openai.autoconfigure.OpenAiChatAutoConfiguration;
+import org.springframework.ai.model.openai.autoconfigure.OpenAiEmbeddingAutoConfiguration;
+import org.springframework.ai.model.tool.autoconfigure.ToolCallingAutoConfiguration;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+/**
+ * Regression tests: SpringAIAutoConfiguration guards its beans with {@code @ConditionalOnBean},
+ * which is order-sensitive. It must therefore declare itself ordered after the Spring AI model
+ * auto-configurations, otherwise the conditions never match and no SpringAI/SpringAIEmbedding bean
+ * is registered.
+ */
+class SpringAIAutoConfigurationOrderingTest {
+
+  // OpenAI auto-configurations fail at context refresh without a non-blank api key.
+  private static final String[] PROPERTIES = {"spring.ai.openai.api-key=dummy"};
+
+  // ToolCallingAutoConfiguration provides the ToolCallingManager that
+  // OpenAiChatAutoConfiguration requires. A real application imports it
+  // automatically; ApplicationContextRunner only processes what is declared.
+  private final ApplicationContextRunner runner =
+      new ApplicationContextRunner()
+          .withPropertyValues(PROPERTIES)
+          .withConfiguration(
+              AutoConfigurations.of(
+                  SpringAIAutoConfiguration.class, // listed first on purpose
+                  ToolCallingAutoConfiguration.class,
+                  OpenAiChatAutoConfiguration.class,
+                  OpenAiEmbeddingAutoConfiguration.class));
+
+  @Test
+  void registersSpringAI_whenProviderAutoConfigurationsAreProcessedFirst() {
+    runner.run(context -> assertThat(context).hasBean("springAIWithBothModels"));
+  }
+
+  @Test
+  void registersSpringAIEmbedding_whenEmbeddingAutoConfigurationIsProcessedFirst() {
+    runner.run(context -> assertThat(context).hasBean("springAIEmbedding"));
+  }
+}


### PR DESCRIPTION
Fixes #1501

## Problem

`SpringAIAutoConfiguration` (contrib/spring-ai) guards all four of its `@Bean` methods with
`@ConditionalOnBean` — three `SpringAI` variants on `ChatModel`/`StreamingChatModel`, and
`springAIEmbedding` on `EmbeddingModel` — but declares no ordering relative to the
auto-configurations that register those beans.

The result of `@ConditionalOnBean` depends on what has been processed so far. With no
declared ordering, evaluation order falls back to the alphabetical class-name sort, and
`com.google.adk...` sorts before `org.springframework.ai...` — so ADK's conditions are
evaluated before any Spring AI model bean definition exists. No `SpringAI` bean is
registered and applications fail to start:

```
Parameter 0 of method scienceTeacher in ...AdkJavaSpringAiDemoApplication required a bean
of type 'com.google.adk.models.springai.SpringAI' that could not be found.
```

`springAIEmbedding` is affected identically — silently: no error, just a missing bean.

## Fix

Declare `afterName` on `@AutoConfiguration`, listing the Spring AI model auto-configurations
that may provide `ChatModel`, `StreamingChatModel`, or `EmbeddingModel` beans
(7 chat + 9 embedding entries in the commit).

Design notes:

1. **Why `afterName` (string) and not `after` (Class):** this module compiles only against
   `spring-ai-model`; provider auto-configuration classes are not on the compile classpath.
   Names that do not exist on the classpath are ignored by the sorter, which makes string
   form the intended mechanism here — the same pattern Spring AI 1.x's own
   `ChatClientAutoConfiguration` used for the identical problem.
2. **How the list was derived and verified** (against the published Spring AI 2.0.1 jars):
   - Read every provider module's
     `META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports`
     (the authoritative registration file — class-path/name-pattern guessing misses
     nested packages such as `google.genai.autoconfigure.chat` or `vertexai.autoconfigure.embedding`).
   - `javap`-verified the bean type of every configuration whose name alone is not
     sufficient: `GoogleGenAiChatModel implements ChatModel`;
     `GoogleGenAiTextEmbeddingModel` / `VertexAiTextEmbeddingModel` extend
     `AbstractEmbeddingModel`.
3. **Deliberately excluded** (each verified, not guessed):
   - `*Connection*AutoConfiguration` (google-genai, vertex-ai) — register connection-details
     beans, not models;
   - `VertexAiMultiModalEmbeddingAutoConfiguration` — registers a `DocumentEmbeddingModel`,
     which does not satisfy `@ConditionalOnBean(EmbeddingModel)`;
   - `ElevenLabsAutoConfiguration` — registers a text-to-speech model, not chat/embedding;
   - `OllamaApiAutoConfiguration` and the image/audio/moderation/OCR configurations —
     unrelated interfaces.
4. **Maintenance:** new Spring AI provider modules need to be appended to this list — the
   same standing cost Spring AI 1.x accepted for this pattern. Modules introduced after
   2.0.1 are ignored harmlessly until added.

## Test

New `SpringAIAutoConfigurationOrderingTest` places `SpringAIAutoConfiguration` first in
`AutoConfigurations.of(...)` alongside the provider configurations and
`ToolCallingAutoConfiguration` (the latter provides the `ToolCallingManager` that
`OpenAiChatAutoConfiguration` requires; a real application imports it automatically, the
context runner must declare it explicitly).

`AutoConfigurations.of` applies the same ordering rules as production auto-configuration
import (`AutoConfigurationSorter#getInPriorityOrder`), so:

- **Before this change** the tests fail: the alphabetical order processes
  `SpringAIAutoConfiguration` before the provider configurations, so `@ConditionalOnBean`
  never matches.
- **After** both tests pass, and runtime behavior flips accordingly — in a demo application,
  singleton pre-instantiation logs change from `springAIEmbedding` being created before
  `openAiChatModel` (alphabetical order, conditions evaluated too early) to OpenAI beans
  being created first followed by `Auto-configuring SpringAI...`.

## Notes

An alternative fix — dropping `@ConditionalOnBean` in favor of `@Bean` method parameter
injection, as Spring AI 2.0's own `ChatClientAutoConfiguration` does — would also remove
the ordering sensitivity, but changes semantics: with no model present, failure moves from
a clear startup report to a less friendly bean-creation error. The `afterName` declaration
is the smaller, behavior-preserving change.

Google CLA signed.