### PR TITLE
fix(spring-ai): order SpringAI auto-configuration after Spring AI mod…

### DIFF
--- a/contrib/spring-ai/pom.xml
+++ b/contrib/spring-ai/pom.xml
@@ -124,6 +124,16 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.ai</groupId>
+            <artifactId>spring-ai-autoconfigure-model-openai</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.ai</groupId>
+            <artifactId>spring-ai-autoconfigure-model-tool</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.ai</groupId>
             <artifactId>spring-ai-anthropic</artifactId>
             <scope>test</scope>
         </dependency>

--- a/contrib/spring-ai/src/main/java/com/google/adk/models/springai/autoconfigure/SpringAIAutoConfiguration.java
+++ b/contrib/spring-ai/src/main/java/com/google/adk/models/springai/autoconfigure/SpringAIAutoConfiguration.java
@@ -58,7 +58,27 @@ import org.springframework.context.annotation.Primary;
  * adk.spring-ai.validation.enabled=true
  * </pre>
  */
-@AutoConfiguration
+@AutoConfiguration(
+    afterName = {
+      "org.springframework.ai.model.anthropic.autoconfigure.AnthropicChatAutoConfiguration",
+      "org.springframework.ai.model.bedrock.converse.autoconfigure.BedrockConverseProxyChatAutoConfiguration",
+      "org.springframework.ai.model.deepseek.autoconfigure.DeepSeekChatAutoConfiguration",
+      "org.springframework.ai.model.google.genai.autoconfigure.chat.GoogleGenAiChatAutoConfiguration",
+      "org.springframework.ai.model.mistralai.autoconfigure.MistralAiChatAutoConfiguration",
+      "org.springframework.ai.model.ollama.autoconfigure.OllamaChatAutoConfiguration",
+      "org.springframework.ai.model.openai.autoconfigure.OpenAiChatAutoConfiguration",
+      "org.springframework.ai.model.bedrock.cohere.autoconfigure.BedrockCohereEmbeddingAutoConfiguration",
+      "org.springframework.ai.model.bedrock.titan.autoconfigure.BedrockTitanEmbeddingAutoConfiguration",
+      "org.springframework.ai.model.google.genai.autoconfigure.embedding.GoogleGenAiTextEmbeddingAutoConfiguration",
+      "org.springframework.ai.model.mistralai.autoconfigure.MistralAiEmbeddingAutoConfiguration",
+      "org.springframework.ai.model.ollama.autoconfigure.OllamaEmbeddingAutoConfiguration",
+      "org.springframework.ai.model.openai.autoconfigure.OpenAiEmbeddingAutoConfiguration",
+      "org.springframework.ai.model.postgresml.autoconfigure.PostgresMlEmbeddingAutoConfiguration",
+      "org.springframework.ai.model.transformers.autoconfigure.TransformersEmbeddingModelAutoConfiguration",
+      "org.springframework.ai.model.vertexai.autoconfigure.embedding.VertexAiEmbeddingConnectionAutoConfiguration",
+      "org.springframework.ai.model.vertexai.autoconfigure.embedding.VertexAiTextEmbeddingAutoConfiguration",
+      "org.springframework.ai.model.vertexai.autoconfigure.embedding.VertexAiMultiModalEmbeddingAutoConfiguration",
+    })
 @ConditionalOnClass({SpringAI.class, ChatModel.class})
 @ConditionalOnProperty(
     prefix = "adk.spring-ai.auto-configuration",

--- a/contrib/spring-ai/src/test/java/com/google/adk/models/springai/autoconfigure/SpringAIAutoConfigurationOrderingTest.java
+++ b/contrib/spring-ai/src/test/java/com/google/adk/models/springai/autoconfigure/SpringAIAutoConfigurationOrderingTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.adk.models.springai.autoconfigure;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.adk.models.springai.SpringAI;
+import com.google.adk.models.springai.SpringAIEmbedding;
+import org.junit.jupiter.api.Test;
+import org.springframework.ai.model.openai.autoconfigure.OpenAiChatAutoConfiguration;
+import org.springframework.ai.model.openai.autoconfigure.OpenAiEmbeddingAutoConfiguration;
+import org.springframework.ai.model.tool.autoconfigure.ToolCallingAutoConfiguration;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+/**
+ * Verifies that {@link SpringAIAutoConfiguration} is ordered after the Spring AI model
+ * auto-configurations.
+ *
+ * <p>{@link org.springframework.boot.autoconfigure.condition.ConditionalOnBean} conditions are
+ * evaluated when the configuration is processed, so {@code @ConditionalOnBean(ChatModel)} on this
+ * auto-configuration only sees the model beans if the provider auto-configurations ran first. In a
+ * real application the configurations are otherwise sorted alphabetically, which puts {@code
+ * com.google.adk...} before {@code org.springframework.ai...} and makes every SpringAI bean
+ * silently disappear (see issue #1501).
+ */
+class SpringAIAutoConfigurationOrderingTest {
+
+  private final ApplicationContextRunner contextRunner =
+      new ApplicationContextRunner()
+          .withConfiguration(
+              AutoConfigurations.of(
+                  SpringAIAutoConfiguration.class,
+                  OpenAiChatAutoConfiguration.class,
+                  OpenAiEmbeddingAutoConfiguration.class,
+                  ToolCallingAutoConfiguration.class));
+
+  @Test
+  void springAIBeansAreCreatedWhenModelsComeFromSpringAIModelAutoConfigurations() {
+    contextRunner
+        .withPropertyValues(
+            "spring.ai.openai.api-key=dummy-key", "adk.spring-ai.validation.enabled=false")
+        .run(
+            context -> {
+              assertThat(context).hasSingleBean(SpringAI.class);
+              assertThat(context).hasSingleBean(SpringAIEmbedding.class);
+            });
+  }
+
+  @Test
+  void disabledAutoConfigurationStillBacksOff() {
+    contextRunner
+        .withPropertyValues(
+            "spring.ai.openai.api-key=dummy-key", "adk.spring-ai.auto-configuration.enabled=false")
+        .run(
+            context -> {
+              assertThat(context).doesNotHaveBean(SpringAI.class);
+              assertThat(context).doesNotHaveBean(SpringAIEmbedding.class);
+              assertThat(context).hasSingleBean(org.springframework.ai.chat.model.ChatModel.class);
+            });
+  }
+}


### PR DESCRIPTION
Closes #1501

## Root cause

`SpringAIAutoConfiguration` guards its `@Bean` methods with `@ConditionalOnBean(ChatModel/StreamingChatModel/EmbeddingModel)`, but declared no ordering relative to the Spring AI model auto-configurations that register those beans. `@ConditionalOnBean` is evaluated when the configuration is processed, and in a real application the auto-configurations are otherwise sorted alphabetically, which puts `com.google.adk.models.springai.autoconfigure.SpringAIAutoConfiguration` before `org.springframework.ai.model.*.autoconfigure.*AutoConfiguration` — every condition misses, and all `SpringAI`/`SpringAIEmbedding` beans are silently skipped (the `springAIEmbedding` failure being fully silent, as noted in the issue).

Since this module intentionally compiles only against `spring-ai-model` (no provider modules on the compile classpath), the class-based `after` attribute is not usable; the string-based `afterName` attribute exists exactly for this case, and unknown class names are ignored, so versions that lack a listed configuration are unaffected. This mirrors the approach Spring AI 1.x's own `ChatClientAutoConfiguration` used for the identical `@ConditionalOnBean(ChatModel)` situation.

The list covers the chat/embedding auto-configurations that exist in Spring AI 2.0.x, verified against each module's `META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports` at v2.0.1:

- chat: anthropic, bedrock converse, deepseek, google genai, mistralai, ollama, openai
- embedding: bedrock cohere/titan, google genai, mistralai, ollama, openai, postgresml, transformers, vertex ai

## Testing

New `SpringAIAutoConfigurationOrderingTest` builds an `ApplicationContextRunner` with `AutoConfigurations.of(SpringAIAutoConfiguration.class, OpenAiChatAutoConfiguration.class, OpenAiEmbeddingAutoConfiguration.class, ToolCallingAutoConfiguration.class)`. `AutoConfigurations` applies the same `AutoConfigurationSorter` as a real application, so:

- without the ordering declaration the test fails (the `com.google.adk...` configuration is processed before `org.springframework.ai...` and no `SpringAI` bean exists),
- with the ordering it passes and both `SpringAI` and `SpringAIEmbedding` beans are created.

`spring-ai-autoconfigure-model-openai` and `spring-ai-autoconfigure-model-tool` are added as test-scoped dependencies to make the real provider configurations available to the runner.

Module test run: 2/2 passing; the ordering test was also verified to fail when the `afterName` declaration is reverted (test-first verification).